### PR TITLE
Creación de endpoint GET /itachallenge/api/v1/user/bookmarks/{idChallenge} Feature#386

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.itachallenge.user.controller;
 
 import com.itachallenge.user.annotations.GenericUUIDValid;
+import com.itachallenge.user.document.UserSolutionDocument;
 import com.itachallenge.user.dtos.*;
 import com.itachallenge.user.repository.IUserSolutionRepository;
 import com.itachallenge.user.service.IUserSolutionService;
@@ -16,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import javax.validation.Valid;
@@ -113,5 +115,4 @@ public class UserController {
                         Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build())
                 );
     }
-
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -95,4 +95,23 @@ public class UserController {
                 );
     }
 
+    @GetMapping(value = "/bookmarks/{idChallenge}")
+    @Operation(
+            summary = "Get the count of bookmarks for a specific challenge.",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = Long.class), mediaType = "application/json")}),
+                    @ApiResponse(responseCode = "404", description = "Challenge not found", content = {@Content(schema = @Schema())}),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error", content = {@Content(schema = @Schema())})
+            }
+    )
+    public Mono<ResponseEntity<Long>> getBookmarkCountByIdChallenge(
+            @PathVariable("idChallenge") @GenericUUIDValid(message = "Invalid UUID for challenge") String idChallenge) {
+        return userScoreService.getBookmarkCountByIdChallenge(UUID.fromString(idChallenge))
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.notFound().build())
+                .onErrorResume(throwable ->
+                        Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build())
+                );
+    }
+
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/User.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/User.java
@@ -1,0 +1,40 @@
+package com.itachallenge.user.document;
+
+import jakarta.validation.constraints.Email;
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.MongoId;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document(collection = "users")
+public class User {
+
+    @MongoId
+    @Field(name = "uuid")
+    private UUID uuid;
+    @Field(name = "name")
+    private String name;
+
+    @Field(name = "surname")
+    private String surname;
+
+    @Field(name = "nickname")
+    private String nickname;
+
+    @Email
+    @Field(name = "email")
+    private String email;
+
+    @Field(name = "password")
+    private String password;
+
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/repository/IUserSolutionRepository.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/repository/IUserSolutionRepository.java
@@ -21,6 +21,4 @@ public interface IUserSolutionRepository extends ReactiveMongoRepository<UserSol
     Flux<UserSolutionDocument> findByStatus(String status);
     Mono<Boolean> existsByUuid(UUID uuid);
     Mono<Long> countBookmarkedTrueByChallengeId(UUID challengeId);
-
-
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/repository/IUserSolutionRepository.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/repository/IUserSolutionRepository.java
@@ -20,6 +20,7 @@ public interface IUserSolutionRepository extends ReactiveMongoRepository<UserSol
     Flux<UserSolutionDocument> findByScore(int score);
     Flux<UserSolutionDocument> findByStatus(String status);
     Mono<Boolean> existsByUuid(UUID uuid);
+    Mono<Long> countBookmarkedTrueByChallengeId(UUID challengeId);
 
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/IUserSolutionService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/IUserSolutionService.java
@@ -15,5 +15,6 @@ public interface IUserSolutionService {
 
     Mono<SolutionUserDto<UserScoreDto>> getChallengeById(String id, String idChallenge, String idLanguage);
     Mono<UserSolutionScoreDto> addSolution(String id, String idChallenge, String idLanguage, String solution);
+    Mono<Long> getBookmarkCountByIdChallenge(UUID idChallenge);
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/IUserSolutionService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/IUserSolutionService.java
@@ -7,6 +7,7 @@ import com.itachallenge.user.dtos.UserScoreDto;
 import com.itachallenge.user.dtos.UserSolutionScoreDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
@@ -16,5 +17,4 @@ public interface IUserSolutionService {
     Mono<SolutionUserDto<UserScoreDto>> getChallengeById(String id, String idChallenge, String idLanguage);
     Mono<UserSolutionScoreDto> addSolution(String id, String idChallenge, String idLanguage, String solution);
     Mono<Long> getBookmarkCountByIdChallenge(UUID idChallenge);
-
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImp.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImp.java
@@ -96,5 +96,10 @@ public class UserSolutionServiceImp implements IUserSolutionService {
                 });
     }
 
+    @Override
+    public Mono<Long> getBookmarkCountByIdChallenge(UUID idChallenge) {
+        return this.userSolutionRepository.countBookmarkedTrueByChallengeId(idChallenge);
+    }
+
 }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImp.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImp.java
@@ -98,8 +98,7 @@ public class UserSolutionServiceImp implements IUserSolutionService {
 
     @Override
     public Mono<Long> getBookmarkCountByIdChallenge(UUID idChallenge) {
-        return this.userSolutionRepository.countBookmarkedTrueByChallengeId(idChallenge);
+        return userSolutionRepository.countBookmarkedTrueByChallengeId(idChallenge);
     }
-
 }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -193,25 +193,19 @@ class UserControllerTest {
 
     @Test
     void testGetBookmarkCountByIdChallenge() {
-        //region VARIABLES
         final UUID VALID_MONGO_UUID = UUID.fromString("5c1a97e5-1cca-4144-9981-2de1fb73b178");
         String URI_TEST = "/bookmarks/{idChallenge}";
         Long testCount = 42L;
-        //endregion VARIABLES
 
-        //region MOCK SETUP
         when(userScoreService.getBookmarkCountByIdChallenge(VALID_MONGO_UUID))
                 .thenReturn(Mono.just(testCount));
-        //endregion MOCK SETUP
 
-        //region TEST
         webTestClient.get()
                 .uri(CONTROLLER_URL + URI_TEST, VALID_MONGO_UUID)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(Long.class)
                 .consumeWith(response -> assertEquals(testCount, response.getResponseBody()));
-        //endregion TEST
     }
 
     //endregion TEST METHODS: ChallengeStatics

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -191,6 +191,29 @@ class UserControllerTest {
 
     }
 
+    @Test
+    void testGetBookmarkCountByIdChallenge() {
+        //region VARIABLES
+        final UUID VALID_MONGO_UUID = UUID.fromString("5c1a97e5-1cca-4144-9981-2de1fb73b178");
+        String URI_TEST = "/bookmarks/{idChallenge}";
+        Long testCount = 42L;
+        //endregion VARIABLES
+
+        //region MOCK SETUP
+        when(userScoreService.getBookmarkCountByIdChallenge(VALID_MONGO_UUID))
+                .thenReturn(Mono.just(testCount));
+        //endregion MOCK SETUP
+
+        //region TEST
+        webTestClient.get()
+                .uri(CONTROLLER_URL + URI_TEST, VALID_MONGO_UUID)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(Long.class)
+                .consumeWith(response -> assertEquals(testCount, response.getResponseBody()));
+        //endregion TEST
+    }
+
     //endregion TEST METHODS: ChallengeStatics
 
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/repository/UserSolutionRepositoryTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/repository/UserSolutionRepositoryTest.java
@@ -230,4 +230,14 @@ public class UserSolutionRepositoryTest {
 
         assertNull(solution);
     }
+
+    @DisplayName("Count number of BookmarkedTrue by idChallenge")
+    @Test
+    void testCountBookmarkedTrueByChallengeId(){
+        Mono<Long> numberOfBookmarks = userSolutionRepository.countBookmarkedTrueByChallengeId(testChallengeUuid);
+        long expectedValue = 1L;
+        StepVerifier.create(numberOfBookmarks)
+                .expectNextCount(expectedValue)
+                .verifyComplete();
+    }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionScoreTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionScoreTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.user.service;
 import com.itachallenge.user.document.UserSolutionDocument;
 import com.itachallenge.user.dtos.UserSolutionScoreDto;
 import com.itachallenge.user.repository.IUserSolutionRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -58,6 +59,30 @@ class UserSolutionScoreTest {
                                 && userSolutionScoreDto.getSolutionText().equals(solutionText)
                                 && userSolutionScoreDto.getScore() == 13)
                 .verifyComplete();
+    }
+
+    @DisplayName("Should return number of BookmarkedTrue by idChallenge")
+    @Test
+    void testGetBookmarkCountByIdChallenge(){
+        UUID idChallenge = UUID.fromString("550e8400-e29b-41d4-a716-446655440002");
+        long expectedValue = 2L;
+
+        UserSolutionDocument userSolutionDocument = new UserSolutionDocument();
+        UserSolutionDocument userSolutionDocument2 = new UserSolutionDocument();
+        userSolutionDocument.setChallengeId(idChallenge);
+        userSolutionDocument2.setChallengeId(idChallenge);
+        userSolutionDocument.setBookmarked(true);
+        userSolutionDocument2.setBookmarked(true);
+
+        when(userSolutionRepository.countBookmarkedTrueByChallengeId(idChallenge))
+                .thenReturn(Mono.just(2L));
+
+        Mono<Long> resultMono = userSolutionService.getBookmarkCountByIdChallenge(idChallenge);
+
+        StepVerifier.create(resultMono)
+                .expectNext(expectedValue)
+                .verifyComplete();
+
     }
 }
 


### PR DESCRIPTION
Added GET /itachallenge/api/v1/user/bookmarks/{idChallenge} endpoint, where number of users having bookmarked a certain Challenge is returned.

- Added countBookmarkedTrueByChallengeId in Repository Layer.
- Added getBookmarkCountByIdChallenge in Service.
- Added getBookmarkCountByIdChallenge in Controller.
- All Tests for said methods pass.

(User.java file marked as edited in changed files. Haven't touched any line of code. The reason Sonar fails)