### PR TITLE
Eliminar paginación de GET /itachallenge/api/v1/challenge/challenges/{idChallenge} feature#395

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -94,7 +94,7 @@ public class ChallengeController {
                     @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found.", content = {@Content(schema = @Schema())})
             }
     )
-    public Mono<GenericResultDto<ChallengeDto>> getOneChallenge(@PathVariable("challengeId") String id) {
+    public Mono<ChallengeDto> getOneChallenge(@PathVariable("challengeId") String id) {
         return challengeService.getChallengeById(id);
     }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 public interface IChallengeService {
 
-    Mono<GenericResultDto<ChallengeDto>> getChallengeById(String id);
+    Mono<ChallengeDto> getChallengeById(String id);
     Mono<GenericResultDto<String>> removeResourcesByUuid(String id);
     Mono<GenericResultDto<LanguageDto>> getAllLanguages();
     Mono<GenericResultDto<SolutionDto>> getSolutions(String idChallenge, String idLanguage);

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -58,23 +58,21 @@ class ChallengeControllerTest {
     @Test
     void getOneChallenge_ValidId_ChallengeReturned() {
         // Arrange
-        String challengeId = "valid-challenge-id";
-        GenericResultDto<ChallengeDto> expectedResult = new GenericResultDto<>();
-        expectedResult.setInfo(0, 1, 1, new ChallengeDto[]{new ChallengeDto()});
+        UUID challengeId = UUID.randomUUID();
+        ChallengeDto expectedResult = new ChallengeDto();
+        expectedResult.setChallengeId(challengeId);
 
-        when(challengeService.getChallengeById(challengeId)).thenReturn(Mono.just(expectedResult));
+        when(challengeService.getChallengeById(challengeId.toString())).thenReturn(Mono.just(expectedResult));
 
         // Act & Assert
         webTestClient.get()
                 .uri("/itachallenge/api/v1/challenge/challenges/{challengeId}", challengeId)
                 .exchange()
                 .expectStatus().isOk()
-                .expectBody(GenericResultDto.class)
+                .expectBody(ChallengeDto.class)
                 .value(dto -> {
                     assert dto != null;
-                    assert dto.getCount() == 1;
-                    assert dto.getResults() != null;
-                    assert dto.getResults().length == 1;
+                    assert dto.getChallengeId().equals(challengeId);
                 });
     }
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImpTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImpTest.java
@@ -60,7 +60,7 @@ class ChallengeServiceImpTest {
         MockitoAnnotations.openMocks(this);
     }
 
-    @Test
+    /*@Test
     void getChallengeById_ValidId_ChallengeFound() {
         // Arrange
         UUID challengeId = UUID.randomUUID();
@@ -73,7 +73,7 @@ class ChallengeServiceImpTest {
         when(challengeConverter.convertDocumentFluxToDtoFlux(any(), any())).thenReturn(Flux.just(challengeDto));
 
         // Act
-        Mono<GenericResultDto<ChallengeDto>> result = challengeService.getChallengeById(challengeId.toString());
+        Mono<ChallengeDto> result = challengeService.getChallengeById(challengeId.toString());
 
         // Assert
         StepVerifier.create(result)
@@ -83,6 +83,33 @@ class ChallengeServiceImpTest {
 
         verify(challengeRepository).findByUuid(challengeId);
         verify(challengeConverter).convertDocumentFluxToDtoFlux(any(), any());
+    }*/
+
+    @Test
+    void getChallengeById_ValidId_ChallengeFound() {
+        // Arrange
+        UUID challengeId = UUID.randomUUID();
+        ChallengeDocument challengeDocument = new ChallengeDocument();
+        ChallengeDto challengeDto = new ChallengeDto();
+        challengeDto.setChallengeId(challengeId);
+        challengeDto.setLevel("EASY");
+
+        when(challengeRepository.findByUuid(challengeId)).thenReturn(Mono.just(challengeDocument));
+        when(challengeConverter.convertDocumentToDto(any(), any())).thenReturn(challengeDto);
+
+        // Act
+        Mono<ChallengeDto> result = challengeService.getChallengeById(challengeId.toString());
+
+        // Assert
+        StepVerifier.create(result)
+                .expectNextMatches(dto -> dto.getChallengeId().equals(challengeId) &&
+                        dto.getLevel().equals(challengeDto.getLevel())
+                )
+                .expectComplete()
+                .verify();
+
+        verify(challengeRepository).findByUuid(challengeId);
+        verify(challengeConverter).convertDocumentToDto(any(), any());
     }
 
     @Test
@@ -91,7 +118,7 @@ class ChallengeServiceImpTest {
         String invalidId = "invalid-id";
 
         // Act
-        Mono<GenericResultDto<ChallengeDto>> result = challengeService.getChallengeById(invalidId);
+        Mono<ChallengeDto> result = challengeService.getChallengeById(invalidId);
 
         // Assert
         StepVerifier.create(result)
@@ -110,7 +137,7 @@ class ChallengeServiceImpTest {
         when(challengeRepository.findByUuid(challengeId)).thenReturn(Mono.empty());
 
         // Act
-        Mono<GenericResultDto<ChallengeDto>> result = challengeService.getChallengeById(challengeId.toString());
+        Mono<ChallengeDto> result = challengeService.getChallengeById(challengeId.toString());
 
         // Assert
         StepVerifier.create(result)

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImpTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImpTest.java
@@ -60,31 +60,6 @@ class ChallengeServiceImpTest {
         MockitoAnnotations.openMocks(this);
     }
 
-    /*@Test
-    void getChallengeById_ValidId_ChallengeFound() {
-        // Arrange
-        UUID challengeId = UUID.randomUUID();
-        ChallengeDocument challengeDocument = new ChallengeDocument();
-        ChallengeDto challengeDto = new ChallengeDto();
-        GenericResultDto<ChallengeDto> expectedDto = new GenericResultDto<>();
-        expectedDto.setInfo(0, 1, 1, new ChallengeDto[]{challengeDto});
-
-        when(challengeRepository.findByUuid(challengeId)).thenReturn(Mono.just(challengeDocument));
-        when(challengeConverter.convertDocumentFluxToDtoFlux(any(), any())).thenReturn(Flux.just(challengeDto));
-
-        // Act
-        Mono<ChallengeDto> result = challengeService.getChallengeById(challengeId.toString());
-
-        // Assert
-        StepVerifier.create(result)
-                .expectNextMatches(dto -> dto.getCount() == 1 && Arrays.equals(dto.getResults(), expectedDto.getResults()))
-                .expectComplete()
-                .verify();
-
-        verify(challengeRepository).findByUuid(challengeId);
-        verify(challengeConverter).convertDocumentFluxToDtoFlux(any(), any());
-    }*/
-
     @Test
     void getChallengeById_ValidId_ChallengeFound() {
         // Arrange


### PR DESCRIPTION
Deleted pagination functionality from /itachallenge/api/v1/challenge/challenges/{idChallenge} endpoint. 
Now returns Mono<ChallengeDto> instead of Mono<GenericResultDto<ChallengeDto>>.

- Refactored ChallengeServiceImp.getChallengeById and ChallengeController.getOneChallenge.
- Refactored Tests.

Note: Error 500 when should be Bad request. (Chris is on it).