### PR TITLE
Endpoint PATCH /itachallenge/api/v1/challenge/resource/{idResource} Feature#381

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -8,6 +8,7 @@ import com.itachallenge.challenge.dto.SolutionDto;
 import com.itachallenge.challenge.dto.LanguageDto;
 import com.itachallenge.challenge.dto.zmq.ChallengeRequestDto;
 import com.itachallenge.challenge.dto.zmq.StatisticsResponseDto;
+import com.itachallenge.challenge.exception.ChallengeNotFoundException;
 import com.itachallenge.challenge.mqclient.ZMQClient;
 import com.itachallenge.challenge.service.IChallengeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -147,7 +149,10 @@ public class ChallengeController {
     )
     public Mono<ResponseEntity<Map<String, String>>> patchResourcesById(@PathVariable String idResource) {
         return challengeService.removeResourcesByUuid(idResource)
-                .map(response -> ResponseEntity.ok(Collections.singletonMap("response", response)));
+                .map(response -> ResponseEntity.ok(Collections.singletonMap("response", response)))
+                .onErrorResume(ChallengeNotFoundException.class, e -> {
+                    return Mono.just(ResponseEntity.status(HttpStatus.NOT_FOUND).body(Collections.singletonMap("error", e.getMessage())));
+                });
     }
 
     @GetMapping("/challenges")

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -129,8 +129,9 @@ public class ChallengeController {
                     @ApiResponse(responseCode = "404", description = "The Resource with given Id was not found.", content = {@Content(schema = @Schema())})
             }
     )
-    public Mono<GenericResultDto<String>> removeResourcesById(@PathVariable String idResource) {
-        return challengeService.removeResourcesByUuid(idResource);
+    public Mono<ResponseEntity<Map<String, String>>> removeResourcesById(@PathVariable String idResource) {
+        return challengeService.removeResourcesByUuid(idResource)
+                .map(response -> ResponseEntity.ok(Collections.singletonMap("response", response)));
     }
 
     //@PreAuthorize("hasRole('SUPERUSER'))TODO Securizar en Apisix
@@ -145,7 +146,7 @@ public class ChallengeController {
             }
     )
     public Mono<ResponseEntity<Map<String, String>>> patchResourcesById(@PathVariable String idResource) {
-        return challengeService.patchResourcesByUuid(idResource)
+        return challengeService.removeResourcesByUuid(idResource)
                 .map(response -> ResponseEntity.ok(Collections.singletonMap("response", response)));
     }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -19,15 +19,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -133,6 +131,22 @@ public class ChallengeController {
     )
     public Mono<GenericResultDto<String>> removeResourcesById(@PathVariable String idResource) {
         return challengeService.removeResourcesByUuid(idResource);
+    }
+
+    //@PreAuthorize("hasRole('SUPERUSER'))TODO Securizar en Apisix
+    @PatchMapping("/resources/{idResource}")
+    @Operation(
+            operationId = "Remove resource from all Challenges from Resource Id.",
+            summary = "Remove resource from all Challenges from Resource Id.",
+            description = "Sending the ID Resource through the URI to patch the challenges.",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = GenericResultDto.class), mediaType = "application/json")}),
+                    @ApiResponse(responseCode = "404", description = "The Resource with given Id was not found.", content = {@Content(schema = @Schema())})
+            }
+    )
+    public Mono<ResponseEntity<Map<String, String>>> patchResourcesById(@PathVariable String idResource) {
+        return challengeService.patchResourcesByUuid(idResource)
+                .map(response -> ResponseEntity.ok(Collections.singletonMap("response", response)));
     }
 
     @GetMapping("/challenges")

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImp.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImp.java
@@ -63,7 +63,7 @@ public class ChallengeServiceImp implements IChallengeService {
                 );
     }
 
-    public Mono<GenericResultDto<String>> removeResourcesByUuid(String id) {
+    public Mono<String> removeResourcesByUuid(String id) {
         return validateUUID(id)
                 .flatMap(resourceId -> {
                     Flux<ChallengeDocument> challengeFlux = challengeRepository.findAllByResourcesContaining(resourceId);
@@ -77,9 +77,7 @@ public class ChallengeServiceImp implements IChallengeService {
                             .hasElements()
                             .flatMap(result -> {
                                 if (Boolean.TRUE.equals(result)) {
-                                    GenericResultDto<String> resultDto = new GenericResultDto<>();
-                                    resultDto.setInfo(0, 1, 1, new String[]{"resource deleted correctly"});
-                                    return Mono.just(resultDto);
+                                    return Mono.just("resource deleted correctly");
                                 } else {
                                     return Mono.error(new ChallengeNotFoundException("Resource with id " + resourceId + " not found"));
                                 }
@@ -88,11 +86,6 @@ public class ChallengeServiceImp implements IChallengeService {
                             .doOnError(error -> log.error("Error occurred while retrieving resource: {}", error.getMessage()));
                 });
     }
-
-    public Mono<String> patchResourcesByUuid(String id) {
-        return null;
-    }
-
 
     public Mono<GenericResultDto<ChallengeDto>> getChallengesByLanguageAndDifficulty(String idLanguage, String difficulty) {
         // TODO: Get challenges by language and difficulty

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImp.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImp.java
@@ -89,6 +89,10 @@ public class ChallengeServiceImp implements IChallengeService {
                 });
     }
 
+    public Mono<String> patchResourcesByUuid(String id) {
+        return null;
+    }
+
 
     public Mono<GenericResultDto<ChallengeDto>> getChallengesByLanguageAndDifficulty(String idLanguage, String difficulty) {
         // TODO: Get challenges by language and difficulty

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -10,8 +10,7 @@ import reactor.core.publisher.Mono;
 public interface IChallengeService {
 
     Mono<ChallengeDto> getChallengeById(String id);
-    Mono<GenericResultDto<String>> removeResourcesByUuid(String id);
-    Mono<String> patchResourcesByUuid(String id);
+    Mono<String> removeResourcesByUuid(String id);
     Mono<GenericResultDto<LanguageDto>> getAllLanguages();
     Mono<GenericResultDto<SolutionDto>> getSolutions(String idChallenge, String idLanguage);
     Mono<SolutionDto> addSolution(SolutionDto solutionDto);

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -11,6 +11,7 @@ public interface IChallengeService {
 
     Mono<ChallengeDto> getChallengeById(String id);
     Mono<GenericResultDto<String>> removeResourcesByUuid(String id);
+    Mono<String> patchResourcesByUuid(String id);
     Mono<GenericResultDto<LanguageDto>> getAllLanguages();
     Mono<GenericResultDto<SolutionDto>> getSolutions(String idChallenge, String idLanguage);
     Mono<SolutionDto> addSolution(SolutionDto solutionDto);

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
@@ -192,12 +192,10 @@ class ChallengeIntegrationTest {
                 .uri("/itachallenge/api/v1/challenge/resources/{idResource}", UUID_VALID)
                 .exchange()
                 .expectStatus().isOk()
-                .expectBody(GenericResultDto.class)
-                .value(dto -> {
-                    assert dto != null;
-                    assert dto.getCount() == 1;
-                    assert dto.getResults() != null;
-                    assert dto.getResults().length == 1;
+                .expectBody(Map.class)
+                .value(responseMap -> {
+                    String response = (String) responseMap.get("response");
+                    assert response.equals("Resource removed successfully");
                 });
     }
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImpTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImpTest.java
@@ -130,13 +130,12 @@ class ChallengeServiceImpTest {
         when(challengeRepository.save(any(ChallengeDocument.class))).thenReturn(Mono.just(challengeDocument));
 
         // Act
-        Mono<GenericResultDto<String>> result = challengeService.removeResourcesByUuid(resourceId.toString());
+        Mono<String> result = challengeService.removeResourcesByUuid(resourceId.toString());
 
         // Assert
         StepVerifier.create(result)
-                .expectNextMatches(dto -> dto.getCount() == 1 && dto.getResults()[0].equals("resource deleted correctly"))
-                .expectComplete()
-                .verify();
+                .expectNext("Resource removed successfully")
+                .verifyComplete();
 
         verify(challengeRepository).findAllByResourcesContaining(resourceId);
         verify(challengeRepository).save(any(ChallengeDocument.class));
@@ -150,7 +149,7 @@ class ChallengeServiceImpTest {
         when(challengeRepository.findAllByResourcesContaining(resourceId)).thenReturn(Flux.empty());
 
         // Act
-        Mono<GenericResultDto<String>> result = challengeService.removeResourcesByUuid(resourceId.toString());
+        Mono<String> result = challengeService.removeResourcesByUuid(resourceId.toString());
 
         // Assert
         StepVerifier.create(result)


### PR DESCRIPTION
- Added patch endpoint to remove one resource from all challenges and testing.

- Refactored old Delete endpoint so it doesn't return a GenericDto as well as testing. DRY usage because the two controller methods use the same service method.