### PR TITLE
Cambio de nombre de atributo id_example y example_text

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ExampleDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ExampleDocument.java
@@ -14,8 +14,8 @@ public class ExampleDocument {
 
     @Id
     @Field(name="id_example")
-    private UUID idExample;
+    private UUID id_example;
 
     @Field(name="example_text")
-    private Map<Locale, String> exampleText;
+    private Map<Locale, String> example_text;
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ExampleTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ExampleTest.java
@@ -12,20 +12,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ExampleTest {
 
     @Test
-    void getIdExample() {
-    UUID idExample = UUID.randomUUID();
-    ExampleDocument example = new ExampleDocument(idExample, null);
-    assertEquals(idExample, example.getIdExample());
+    void getId_example() {
+    UUID id_example = UUID.randomUUID();
+    ExampleDocument example = new ExampleDocument(id_example, null);
+    assertEquals(id_example, example.getId_example());
 }
 
     @Test
-    void getExampleText() {
+    void getExample_text() {
         Map<Locale, String> exampleMap = new HashMap<>();
             exampleMap.put(Locale.forLanguageTag("ES"), "Ejemplo de prueba");
             exampleMap.put(Locale.forLanguageTag("CA"), "Exemple de prova");
             exampleMap.put(Locale.ENGLISH, "Example Text");
         ExampleDocument example = new ExampleDocument(null, exampleMap);
-        assertEquals(exampleMap, example.getExampleText());
+        assertEquals(exampleMap, example.getExample_text());
     }
 }
 

--- a/itachallenge-challenge/src/test/resources/json/ChallengeSerialized.json
+++ b/itachallenge-challenge/src/test/resources/json/ChallengeSerialized.json
@@ -15,16 +15,16 @@
     },
     "examples" : [
       {
-        "idExample" : "2dab6eaa-fdf4-4a93-8088-810a956e2bf8",
-        "exampleText" : {
+        "id_example": "2dab6eaa-fdf4-4a93-8088-810a956e2bf8",
+        "example_text": {
           "es" : "Texto de ejemplo",
           "en" : "Example text",
           "ca" : "Texte d'exemple"
         }
       },
       {
-        "idExample" : "6c02025e-b06f-420a-bafb-28c737b18473",
-        "exampleText" : {
+        "id_example": "6c02025e-b06f-420a-bafb-28c737b18473",
+        "example_text": {
           "es" : "Ejemplo random",
           "en" : "Random example",
           "ca" : "Exemple random"


### PR DESCRIPTION
Cambio de nombre de atributo id_example y example_text en la clase ExampleDocument, actualización de nombre en atributos y metodos en ExampleTest, y refactorizacion de los nombres también en ChallengeSerialized.json.