### PR TITLE
Feauture#513

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -186,11 +186,11 @@ public class ChallengeController {
                     @ApiResponse(responseCode = "200", description = "Level not found.", content = {@Content(schema = @Schema())})
             })
 
-    public Flux<GenericResultDto<ChallengeDto>> getChallengesByLanguageOrDifficulty(
+    public Mono<GenericResultDto<ChallengeDto>> getChallengesByLanguageOrDifficulty(
             @RequestParam Optional<String> idLanguage,
             @RequestParam Optional<String> level,
             @RequestParam(defaultValue = DEFAULT_OFFSET) int offset,
-            @RequestParam(defaultValue = DEFAULT_LIMIT) int limit) {
+            @RequestParam(defaultValue = "-1") int limit) {
         return challengeService.getChallengesByLanguageOrDifficulty(idLanguage, level, offset, limit);
     }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -16,7 +16,7 @@ public interface IChallengeService {
     Mono<GenericResultDto<SolutionDto>> getSolutions(String idChallenge, String idLanguage);
     Mono<SolutionDto> addSolution(SolutionDto solutionDto);
     Flux<ChallengeDto> getAllChallenges(int offset, int limit);
-    Flux<GenericResultDto<ChallengeDto>> getChallengesByLanguageOrDifficulty(Optional<String> idLanguage, Optional<String> level, int offset, int limit);
+    Mono<GenericResultDto<ChallengeDto>> getChallengesByLanguageOrDifficulty(Optional<String> idLanguage, Optional<String> level, int offset, int limit);
     Mono<GenericResultDto<ChallengeDto>> getRelatedChallenges(String id, int offset, int limit);
     Mono<Map<String, Object>> getTestingParamsByChallengeIdAndLanguageId(String idChallenge, String idLanguage);
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -233,11 +233,11 @@ class ChallengeControllerTest {
     }
 
     @Test
-    void getChallengesByLanguageAndDifficultyTest() {
+    void getChallengesByLanguageOrDifficultyTest() {
         String idLanguage = "660e1b18-0c0a-4262-a28a-85de9df6ac5f";
         String level = "EASY";
         int offset = 0;
-        int limit = 1;
+        int limit = -1;
         ChallengeDto challengeDto1 = new ChallengeDto();
         challengeDto1.setLevel(level);
 
@@ -246,7 +246,7 @@ class ChallengeControllerTest {
         GenericResultDto<ChallengeDto> genericResultDto = new GenericResultDto<>();
         genericResultDto.setResults(challengeDtos.toArray(new ChallengeDto[0]));
 
-        Flux<GenericResultDto<ChallengeDto>> expectedResult = Flux.just(genericResultDto);
+        Mono<GenericResultDto<ChallengeDto>> expectedResult = Mono.just(genericResultDto);
 
         // Mock del servicio con los parámetros correctos
         when(challengeService.getChallengesByLanguageOrDifficulty(Optional.of(idLanguage), Optional.of(level), offset, limit))
@@ -264,10 +264,10 @@ class ChallengeControllerTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk()
-                .expectBody(new ParameterizedTypeReference<List<GenericResultDto<ChallengeDto>>>() {})
+                .expectBody(new ParameterizedTypeReference<GenericResultDto<ChallengeDto>>() {})
                 .value(result -> {
                     assertNotNull(result);
-                    assertEquals(level, result.get(0).getResults()[0].getLevel());
+                    assertEquals(level, result.getResults()[0].getLevel());
                 });
     }
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImpTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImpTest.java
@@ -651,7 +651,7 @@ class ChallengeServiceImpTest {
         when(challengeConverter.convertDocumentToDto(challengeDocument, ChallengeDto.class)).thenReturn(challengeDto);
 
         // Act
-        Flux<GenericResultDto<ChallengeDto>> result = challengeService.getChallengesByLanguageOrDifficulty(Optional.of(idLanguage), Optional.of(level), offset, limit);
+        Mono<GenericResultDto<ChallengeDto>> result = challengeService.getChallengesByLanguageOrDifficulty(Optional.of(idLanguage), Optional.of(level), offset, limit);
 
         // Assert
         StepVerifier.create(result)
@@ -673,7 +673,7 @@ class ChallengeServiceImpTest {
         when(challengeConverter.convertDocumentToDto(any(), any())).thenReturn(challengeDto);
 
         // Act
-        Flux<GenericResultDto<ChallengeDto>> result = challengeService.getChallengesByLanguageOrDifficulty(Optional.of(languageId), Optional.empty(), 0, 1);
+        Mono<GenericResultDto<ChallengeDto>> result = challengeService.getChallengesByLanguageOrDifficulty(Optional.of(languageId), Optional.empty(), 0, 1);
 
         // Assert
         StepVerifier.create(result)
@@ -697,7 +697,7 @@ class ChallengeServiceImpTest {
         when(challengeConverter.convertDocumentToDto(any(), any())).thenReturn(ChallengeDto.builder().build());
 
         // Act
-        Flux<GenericResultDto<ChallengeDto>> result = challengeService.getChallengesByLanguageOrDifficulty(Optional.empty(), Optional.of(difficulty), 0, 1);
+        Mono<GenericResultDto<ChallengeDto>> result = challengeService.getChallengesByLanguageOrDifficulty(Optional.empty(), Optional.of(difficulty), 0, 1);
 
         // Assert
         StepVerifier.create(result)


### PR DESCRIPTION
- [ ] Encapsulación de GenericResultDto correcto.

```json
{
    "offset": 0,
    "limit": -1,
    "count": 22,
    "results": [
                  {   // aquí un array de resultados
```

- [ ] Campo limit en la paginación: si no se le pasan parámetros devuelve -1, de lo contrario devuelve el número de elementos pedidos. 

@MarcSantasusana resolves #510 
Closes #397 