### PR TITLE
Feature#565

### DIFF
--- a/itachallenge-auth/Dockerfile
+++ b/itachallenge-auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.1
+FROM bellsoft/liberica-openjdk-alpine:21
 #RUN apk add -U consul
 ADD ["build/libs/itachallenge-auth.jar", "/opt/itachallenge-auth/"]
 ENTRYPOINT ["java", "-jar", "/opt/itachallenge-auth/itachallenge-auth.jar"]

--- a/itachallenge-challenge/Dockerfile
+++ b/itachallenge-challenge/Dockerfile
@@ -1,4 +1,4 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.1
+FROM bellsoft/liberica-openjdk-alpine:21
 #RUN apk add -U consul
 ADD ["build/libs/itachallenge-challenge.jar", "/opt/itachallenge-challenge/"]
 ENTRYPOINT ["java", "-jar", "/opt/itachallenge-challenge/itachallenge-challenge.jar"]

--- a/itachallenge-document/Dockerfile
+++ b/itachallenge-document/Dockerfile
@@ -1,4 +1,4 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.1
+FROM bellsoft/liberica-openjdk-alpine:21
 #RUN apk add -U consul
 ADD ["build/libs/itachallenge-document.jar", "/opt/itachallenge-document/"]
 ENTRYPOINT ["java", "-jar", "/opt/itachallenge-document/itachallenge-document.jar"]

--- a/itachallenge-mock/Dockerfile
+++ b/itachallenge-mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.1
+FROM bellsoft/liberica-openjdk-alpine:21
 #ADD ["build/libs/itachallenge-mock-1.0.1-RELEASE.jar", "/opt/itachallenge-mock/"]  #sólo para construcción manual
 ADD ["itachallenge-mock-1.0.5-RELEASE.jar", "/opt/itachallenge-mock/"]
 ENTRYPOINT ["java", "-jar", "/opt/itachallenge-mock/itachallenge-mock-1.0.5-RELEASE.jar"]

--- a/itachallenge-mock/Dockerfile
+++ b/itachallenge-mock/Dockerfile
@@ -1,5 +1,9 @@
 FROM bellsoft/liberica-openjdk-alpine:21
-#ADD ["build/libs/itachallenge-mock-1.0.1-RELEASE.jar", "/opt/itachallenge-mock/"]  #sólo para construcción manual
+#sólo para construcción manual
+#------------------------------------------------------------------------------
+#ADD ["build/libs/itachallenge-mock.jar", "/opt/itachallenge-mock/"]
+#ENTRYPOINT ["java", "-jar", "/opt/itachallenge-mock/itachallenge-mock.jar"]
+#------------------------------------------------------------------------------
 ADD ["itachallenge-mock-1.0.5-RELEASE.jar", "/opt/itachallenge-mock/"]
 ENTRYPOINT ["java", "-jar", "/opt/itachallenge-mock/itachallenge-mock-1.0.5-RELEASE.jar"]
 EXPOSE 7779

--- a/itachallenge-score/Dockerfile
+++ b/itachallenge-score/Dockerfile
@@ -1,4 +1,4 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.1
+FROM bellsoft/liberica-openjdk-alpine:21
 #RUN apk add -U consul
 ADD ["build/libs/itachallenge-score.jar", "/opt/itachallenge-score/"]
 ENTRYPOINT ["java", "-jar", "/opt/itachallenge-score/itachallenge-score.jar"]

--- a/itachallenge-user/Dockerfile
+++ b/itachallenge-user/Dockerfile
@@ -1,4 +1,4 @@
-FROM bellsoft/liberica-openjdk-alpine:17.0.1
+FROM bellsoft/liberica-openjdk-alpine:21
 #RUN apk add -U consul
 ADD ["build/libs/itachallenge-user.jar", "/opt/itachallenge-user/"]
 ENTRYPOINT ["java", "-jar", "/opt/itachallenge-user/itachallenge-user.jar"]


### PR DESCRIPTION
- Upgraded the Docker base image from bellsoft/liberica-openjdk-alpine:17.0.1 to bellsoft/liberica-openjdk-alpine:21 for all microservices.
- Enhanced instructions for manually building the mock microservice image (dockerfile).

![Greenshot 2024-07-23 08 07 00](https://github.com/user-attachments/assets/07674b5c-371d-4ed8-beab-137afa5a4931)
![Greenshot 2024-07-23 08 26 40](https://github.com/user-attachments/assets/946d674c-5b80-49d4-bd04-a42d1b684dc7)
![Greenshot 2024-07-22 12 16 35](https://github.com/user-attachments/assets/0ad7ed94-717a-407e-bd9b-897ecf365e6b)
