### PR TITLE
Feature#543

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/config/FilterConfig.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/config/FilterConfig.java
@@ -1,0 +1,18 @@
+package com.itachallenge.user.config;
+
+import com.itachallenge.user.filter.ContentLengthFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<ContentLengthFilter> contentLength(TomcatConfig tomcatConfig) {
+        FilterRegistrationBean<ContentLengthFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new ContentLengthFilter(tomcatConfig));
+        registrationBean.addUrlPatterns("/itachallenge/api/v1/user/solution/*");
+        return registrationBean;
+    }
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/config/ServerConfig.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/config/ServerConfig.java
@@ -1,0 +1,27 @@
+package com.itachallenge.user.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ServerConfig {
+
+    @Value("${server.tomcat.max-http-form-post-size}")
+    private int maxHttpFormPostSize;
+
+    @Bean
+    public WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> webServerFactoryCustomizer() {
+        return factory -> {
+            if (factory instanceof TomcatServletWebServerFactory) {
+                ((TomcatServletWebServerFactory) factory).addConnectorCustomizers(connector -> {
+                    connector.setMaxPostSize(maxHttpFormPostSize);
+                    connector.setMaxSavePostSize(maxHttpFormPostSize);
+                });
+            }
+        };
+    }
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/config/TomcatConfig.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/config/TomcatConfig.java
@@ -1,0 +1,15 @@
+package com.itachallenge.user.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "server.tomcat")
+public class TomcatConfig {
+
+    private int maxHttpFormPostSize;
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/GlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.util.stream.Collectors;
 
@@ -47,6 +48,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ChallengeNotFoundException.class)
     public ResponseEntity<ErrorResponseDto> handleChallengeNotFoundException(ChallengeNotFoundException e) {
         return ResponseEntity.status(HttpStatus.OK).body(new ErrorResponseDto(e.getMessage()));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<String> handleMaxSizeException(MaxUploadSizeExceededException exc) {
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body("Payload too large!");
     }
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/filter/ContentLengthFilter.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/filter/ContentLengthFilter.java
@@ -1,0 +1,33 @@
+package com.itachallenge.user.filter;
+
+import com.itachallenge.user.config.TomcatConfig;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class ContentLengthFilter implements Filter {
+
+    private final TomcatConfig tomcatConfig;
+
+    @Autowired
+    public ContentLengthFilter(TomcatConfig tomcatConfig) {
+        this.tomcatConfig = tomcatConfig;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (request instanceof HttpServletRequest) {
+            int contentLength = request.getContentLength();
+            if (contentLength > tomcatConfig.getMaxHttpFormPostSize()) {
+                throw new ServletException("Request body is too large!");
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+}

--- a/itachallenge-user/src/main/resources/application.yml
+++ b/itachallenge-user/src/main/resources/application.yml
@@ -11,6 +11,10 @@ spring:
     mongodb:
       uri: mongodb://admin_user:yxRG4sYBDjPFzbh5@localhost:27017/users?authSource=admin
       uuid-representation: standard
+  servlet:
+    multipart:
+      max-file-size: 2MB
+      max-request-size: 2MB
 
 springdoc:
   swagger-ui:
@@ -22,6 +26,8 @@ springdoc:
 
 server:
   port: 8764
+  tomcat:
+    max-http-form-post-size: 2MB
 
 management:
   endpoints:

--- a/itachallenge-user/src/main/resources/application.yml
+++ b/itachallenge-user/src/main/resources/application.yml
@@ -27,7 +27,7 @@ springdoc:
 server:
   port: 8764
   tomcat:
-    max-http-form-post-size: 2MB
+    max-http-form-post-size: 2097152
 
 management:
   endpoints:


### PR DESCRIPTION
Created TomacatConfig, ServerConfig, FilterConfig y ContentLenghtFilter

All of them uses Application.yml -> server.tomcat.max-http-form-post-size to regularize the max volume a User can send in a put/post form