### PR TITLE
Feature/774 validate GitHub access token in backend

### DIFF
--- a/docker/apisix_conf/apisix_standalone_dev.yaml
+++ b/docker/apisix_conf/apisix_standalone_dev.yaml
@@ -19,7 +19,7 @@ routes:
   -
     uri: /itachallenge/api/v1/auth/**
     methods:
-      - GET
+      - GET, POST
     upstream_id: 3
   -
     uri: /api-docs**

--- a/itachallenge-auth/Dockerfile
+++ b/itachallenge-auth/Dockerfile
@@ -1,5 +1,12 @@
 FROM bellsoft/liberica-openjdk-alpine:21
 #RUN apk add -U consul
 ADD ["build/libs/itachallenge-auth.jar", "/opt/itachallenge-auth/"]
+
+ARG GITHUB_CLIENT_ID
+ARG GITHUB_CLIENT_SECRET
+
+ENV GITHUB_CLIENT_ID=$GITHUB_CLIENT_ID
+ENV GITHUB_CLIENT_SECRET=$GITHUB_CLIENT_SECRET
+
 ENTRYPOINT ["java", "-jar", "/opt/itachallenge-auth/itachallenge-auth.jar"]
 EXPOSE 7777

--- a/itachallenge-auth/build_Docker.sh
+++ b/itachallenge-auth/build_Docker.sh
@@ -3,6 +3,8 @@
 #       export ENV=dev
 #       export REGISTRY_NAME=itacademybcn/itachallenges
 #       export MICROSERVICE_VERSION=x.x.x
+#       export GITHUB_CLIENT_ID={GITHUB_CLIENT_ID}
+#       export GITHUB_CLIENT_SECRET={GITHUB_CLIENT_SECRET}
 #       ./itachallenge-auth/build_Docker.sh
 #
 #  At the server, execute:
@@ -13,6 +15,8 @@
 echo " ENV="${ENV}
 echo " REGISTRY_NAME="${REGISTRY_NAME}
 echo " MICROSERVICE_VERSION="${MICROSERVICE_VERSION}
+echo " GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID}
+echo " GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET}
 
 
 now="$(date +'%d-%m-%Y %H:%M:%S:%3N')"
@@ -21,7 +25,10 @@ base_dir=`pwd`
 ./gradlew :itachallenge-auth:clean && ./gradlew :itachallenge-auth:build
 
 cd itachallenge-auth
-docker build -t=${REGISTRY_NAME}:itachallenge-auth-${MICROSERVICE_VERSION} .
+docker build --build-arg GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID} \
+             --build-arg GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET} \
+             -t=${REGISTRY_NAME}:itachallenge-auth-${MICROSERVICE_VERSION} .
+
 
 #upload image to DockerHub
 if [ ${ENV} = "dev" ] || [ ${ENV} = "pre" ];

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -61,16 +61,6 @@ public class AuthController {
                 });
     }
 
-
-    // Old login method with SSO
-//    @PostMapping("/validate")
-//    public Mono<ResponseEntity<String>> validateToken(@RequestBody String token) {
-//        return authService.validateWithSSO(token)
-//                .map(isValid -> isValid ?
-//                        new ResponseEntity<>("Token is valid", HttpStatus.OK) :
-//                        new ResponseEntity<>("Token is not valid", HttpStatus.UNAUTHORIZED));
-//    }
-
     @GetMapping("/version")
     public Mono<ResponseEntity<Map<String, String>>> getVersion() {
         Map<String, String> response = new HashMap<>();

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -47,12 +47,28 @@ public class AuthController {
     public Mono<ResponseEntity<Map<String, Object>>> authenticateWithGithub(@RequestBody Map<String, String> codeRequest) {
         return authService.exchangeCodeForToken(codeRequest.get("code"))
                 .flatMap(authService::validateTokenWithGithub)
-                .map(response -> {
-                    HttpStatus status = (boolean) response.get(KEY_IS_VALID) ? HttpStatus.OK : HttpStatus.UNAUTHORIZED;
-                    return ResponseEntity.status(status).body(response);
+                .flatMap(response -> {
+                    if (!(boolean) response.get(KEY_IS_VALID)) {
+                        return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response));
+                    }
+                    String githubUsername = (String) response.get(KEY_USERNAME);
+                    return authService.validateUserExists(githubUsername)
+                            .flatMap(userExists -> {
+                                if (!userExists) {
+                                    log.warn("User {} does not exist in database", githubUsername);
+
+                                    Map<String, Object> errorResponse = new HashMap<>();
+                                    errorResponse.put(KEY_IS_VALID, false);
+                                    errorResponse.put("message", "User does not exist in the database");
+
+                                    return Mono.just(ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse));
+                                }
+                                return Mono.just(ResponseEntity.ok(response));
+                            });
                 })
                 .onErrorResume(ex -> {
                     log.error("GitHub authentication error: {}", ex.getMessage());
+
                     Map<String, Object> errorResponse = new HashMap<>();
                     errorResponse.put(KEY_IS_VALID, false);
                     errorResponse.put(KEY_USERNAME, null);
@@ -67,6 +83,11 @@ public class AuthController {
         response.put("application_name", appName);
         response.put("version", version);
         return Mono.just(ResponseEntity.ok(response));
+    }
+
+    @GetMapping("/call-user-test")
+    public Mono<String> callUserTest() {
+        return authService.callUserTest();
     }
 
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -45,30 +45,20 @@ public class AuthController {
 
     @PostMapping("/github/authenticate")
     public Mono<ResponseEntity<Map<String, Object>>> authenticateWithGithub(@RequestBody Map<String, String> codeRequest) {
-        String code = codeRequest.get("code");
-
-        return authService.exchangeCodeForToken(code)
-                .flatMap(accessToken -> authService.validateTokenWithGithub(accessToken))
-                .map(result -> {
-                    boolean isValid = (boolean) result.get(KEY_IS_VALID);
-                    String username = (String) result.get(KEY_USERNAME);
-
-                    Map<String, Object> response = new HashMap<>();
-                    response.put(KEY_IS_VALID, isValid);
-                    response.put(KEY_USERNAME, username);
-
-                    return isValid ?
-                            new ResponseEntity<>(response, HttpStatus.OK) :
-                            new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+        return authService.exchangeCodeForToken(codeRequest.get("code"))
+                .flatMap(authService::validateTokenWithGithub)
+                .map(response -> {
+                    HttpStatus status = (boolean) response.get(KEY_IS_VALID) ? HttpStatus.OK : HttpStatus.UNAUTHORIZED;
+                    return ResponseEntity.status(status).body(response);
                 })
                 .onErrorResume(ex -> {
-                    log.error("Error during GitHub authentication: {}", ex.getMessage());
-                    Map<String, Object> errorResponse = new HashMap<>();
-                    errorResponse.put(KEY_IS_VALID, false);
-                    errorResponse.put(KEY_USERNAME, null);
-                    return Mono.just(new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR));
+                    log.error("GitHub authentication error: {}", ex.getMessage());
+                    Map<String, Object> errorResponse = Map.of(KEY_IS_VALID, false, KEY_USERNAME, null);
+                    return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                            .body(errorResponse));
                 });
     }
+
 
     // Old login method with SSO
     @PostMapping("/validate")

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -22,6 +22,8 @@ import java.util.Map;
 public class AuthController {
 
     private static final Logger log = LoggerFactory.getLogger(AuthController.class);
+    private static final String KEY_IS_VALID = "isValid";
+    private static final String KEY_USERNAME = "username";
 
     @Autowired
     public IAuthService authService;
@@ -40,6 +42,35 @@ public class AuthController {
         return "Hello from ITA ChallengeAuth!!!";
     }
 
+
+    @PostMapping("/github/authenticate")
+    public Mono<ResponseEntity<Map<String, Object>>> authenticateWithGithub(@RequestBody Map<String, String> codeRequest) {
+        String code = codeRequest.get("code");
+
+        return authService.exchangeCodeForToken(code)
+                .flatMap(accessToken -> authService.validateTokenWithGithub(accessToken))
+                .map(result -> {
+                    boolean isValid = (boolean) result.get(KEY_IS_VALID);
+                    String username = (String) result.get(KEY_USERNAME);
+
+                    Map<String, Object> response = new HashMap<>();
+                    response.put(KEY_IS_VALID, isValid);
+                    response.put(KEY_USERNAME, username);
+
+                    return isValid ?
+                            new ResponseEntity<>(response, HttpStatus.OK) :
+                            new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+                })
+                .onErrorResume(ex -> {
+                    log.error("Error during GitHub authentication: {}", ex.getMessage());
+                    Map<String, Object> errorResponse = new HashMap<>();
+                    errorResponse.put(KEY_IS_VALID, false);
+                    errorResponse.put(KEY_USERNAME, null);
+                    return Mono.just(new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR));
+                });
+    }
+
+    // Old login method with SSO
     @PostMapping("/validate")
     public Mono<ResponseEntity<String>> validateToken(@RequestBody String token) {
         return authService.validateWithSSO(token)

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -63,13 +63,13 @@ public class AuthController {
 
 
     // Old login method with SSO
-    @PostMapping("/validate")
-    public Mono<ResponseEntity<String>> validateToken(@RequestBody String token) {
-        return authService.validateWithSSO(token)
-                .map(isValid -> isValid ?
-                        new ResponseEntity<>("Token is valid", HttpStatus.OK) :
-                        new ResponseEntity<>("Token is not valid", HttpStatus.UNAUTHORIZED));
-    }
+//    @PostMapping("/validate")
+//    public Mono<ResponseEntity<String>> validateToken(@RequestBody String token) {
+//        return authService.validateWithSSO(token)
+//                .map(isValid -> isValid ?
+//                        new ResponseEntity<>("Token is valid", HttpStatus.OK) :
+//                        new ResponseEntity<>("Token is not valid", HttpStatus.UNAUTHORIZED));
+//    }
 
     @GetMapping("/version")
     public Mono<ResponseEntity<Map<String, String>>> getVersion() {

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -53,9 +53,11 @@ public class AuthController {
                 })
                 .onErrorResume(ex -> {
                     log.error("GitHub authentication error: {}", ex.getMessage());
-                    Map<String, Object> errorResponse = Map.of(KEY_IS_VALID, false, KEY_USERNAME, null);
-                    return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                            .body(errorResponse));
+                    Map<String, Object> errorResponse = new HashMap<>();
+                    errorResponse.put(KEY_IS_VALID, false);
+                    errorResponse.put(KEY_USERNAME, null);
+
+                    return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse));
                 });
     }
 

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
@@ -43,17 +43,22 @@ public class AuthService implements IAuthService {
     @Value("${spring.security.oauth2.client.registration.github.client-secret}")
     private final String clientSecret;
 
+    @Value("${user.service.url}")
+    private final String userServiceUrl;
+
     @Autowired
     public AuthService(WebClient.Builder webClientBuilder,
                        @Value("${spring.security.oauth2.client.provider.github.token-uri}") String githubTokenUri,
                        @Value("${spring.security.oauth2.client.provider.github.user-info-uri}") String githubUserInfoUri,
                        @Value("${spring.security.oauth2.client.registration.github.client-id}") String clientId,
-                       @Value("${spring.security.oauth2.client.registration.github.client-secret}") String clientSecret) {
+                       @Value("${spring.security.oauth2.client.registration.github.client-secret}") String clientSecret,
+                       @Value("${user.service.url}") String userServiceUrl) {
         this.webClientBuilder = webClientBuilder;
         this.githubTokenUri = githubTokenUri;
         this.githubUserInfoUri = githubUserInfoUri;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
+        this.userServiceUrl = userServiceUrl;
     }
 
     public Mono<String> exchangeCodeForToken(String code) {
@@ -114,6 +119,7 @@ public class AuthService implements IAuthService {
                 .retrieve()
                 .bodyToMono(String.class)
                 .flatMap(response -> processGithubResponse(response, token))
+
                 .onErrorResume(WebClientResponseException.class, this::handleGithubApiError)
                 .onErrorResume(this::handleUnexpectedError);
     }
@@ -161,6 +167,42 @@ public class AuthService implements IAuthService {
         errorResult.put(KEY_IS_VALID, false);
         errorResult.put(KEY_USERNAME, null);
         return errorResult;
+    }
+
+    public Mono<Boolean> validateUserExists(String githubUsername) {
+        String url = userServiceUrl + "/itachallenge/api/v1/user/validate-mentor-exists?githubUsername=" + githubUsername;
+        log.debug("Request URL: {}", url);
+
+        return webClientBuilder.build()
+                .get()
+                .uri(url)
+                .retrieve()
+                .toEntity(Boolean.class)
+                .map(responseEntity -> {
+                    if (responseEntity.getStatusCode().is2xxSuccessful() && Boolean.TRUE.equals(responseEntity.getBody())) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                })
+                .onErrorResume(ex -> {
+                    log.debug("Request URL: {}", url);
+                    log.debug("Validating user: {}", githubUsername);
+                    log.warn("Error validating user: {}", ex.getMessage());
+                    return Mono.just(false);
+                });
+    }
+
+    public Mono<String> callUserTest() {
+        return webClientBuilder.build()
+                .get()
+                .uri(userServiceUrl + "/itachallenge/api/v1/user/test")
+                .retrieve()
+                .bodyToMono(String.class)
+                .onErrorResume(ex -> {
+                    log.error("Error calling User microservice: {}", ex.getMessage());
+                    return Mono.just("Error calling User microservice");
+                });
     }
 
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
@@ -164,46 +164,46 @@ public class AuthService implements IAuthService {
     }
 
     // Old validation method
-    @Value("${uri_validate_token}")
-    private String validationUrl;
-    public Mono<Boolean> validateWithSSO(String token) {
-
-        WebClient webClient = webClientBuilder.build();
-        return webClient
-                .post()
-                .uri(validationUrl)
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(token)
-                .retrieve()
-                .bodyToMono(String.class)
-                .flatMap(response -> {
-                    try {
-                        ObjectMapper objectMapper = new ObjectMapper();
-                        JsonNode jsonNode = objectMapper.readTree(response);
-                        if (jsonNode.has("id")) {
-                            log.info("Token is valid");
-                            return Mono.just(true);
-                        } else if (jsonNode.has("message")) {
-                            String message = jsonNode.get("message").asText();
-                            log.warn("Token is not valid: {}", message);
-                            return Mono.just(false);
-                        } else {
-                            log.error("Unexpected JSON response format: {}", response);
-                            return Mono.error(new IllegalStateException("Unexpected JSON response format"));
-                        }
-                    } catch (JsonProcessingException e) {
-                        log.error("Error processing JSON response", e);
-                        return Mono.error(e);
-                    }
-                })
-                .onErrorResume(WebClientResponseException.class, responseException -> {
-                    log.error("Error from SSO server [{}]: {}", validationUrl, responseException.getStatusCode());
-                    return Mono.just(false);
-                })
-                .onErrorResume(ex -> {
-                    log.error("Unexpected error [{}]: {}", validationUrl, ex.getMessage());
-                    return Mono.just(false);
-                });
-    }
+//    @Value("${uri_validate_token}")
+//    private String validationUrl;
+//    public Mono<Boolean> validateWithSSO(String token) {
+//
+//        WebClient webClient = webClientBuilder.build();
+//        return webClient
+//                .post()
+//                .uri(validationUrl)
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .bodyValue(token)
+//                .retrieve()
+//                .bodyToMono(String.class)
+//                .flatMap(response -> {
+//                    try {
+//                        ObjectMapper objectMapper = new ObjectMapper();
+//                        JsonNode jsonNode = objectMapper.readTree(response);
+//                        if (jsonNode.has("id")) {
+//                            log.info("Token is valid");
+//                            return Mono.just(true);
+//                        } else if (jsonNode.has("message")) {
+//                            String message = jsonNode.get("message").asText();
+//                            log.warn("Token is not valid: {}", message);
+//                            return Mono.just(false);
+//                        } else {
+//                            log.error("Unexpected JSON response format: {}", response);
+//                            return Mono.error(new IllegalStateException("Unexpected JSON response format"));
+//                        }
+//                    } catch (JsonProcessingException e) {
+//                        log.error("Error processing JSON response", e);
+//                        return Mono.error(e);
+//                    }
+//                })
+//                .onErrorResume(WebClientResponseException.class, responseException -> {
+//                    log.error("Error from SSO server [{}]: {}", validationUrl, responseException.getStatusCode());
+//                    return Mono.just(false);
+//                })
+//                .onErrorResume(ex -> {
+//                    log.error("Unexpected error [{}]: {}", validationUrl, ex.getMessage());
+//                    return Mono.just(false);
+//                });
+//    }
 
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
@@ -186,8 +186,6 @@ public class AuthService implements IAuthService {
                     }
                 })
                 .onErrorResume(ex -> {
-                    log.debug("Request URL: {}", url);
-                    log.debug("Validating user: {}", githubUsername);
                     log.warn("Error validating user: {}", ex.getMessage());
                     return Mono.just(false);
                 });

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
@@ -13,17 +13,145 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Service
 public class AuthService implements IAuthService {
 
-
-
     private static final Logger log = LoggerFactory.getLogger(AuthService.class);
     private final WebClient.Builder webClientBuilder;
+
+    private static final String KEY_IS_VALID = "isValid";
+    private static final String KEY_USERNAME = "username";
+    private static final String KEY_TOKEN = "token";
+    private static final String CLIENT_ID_KEY = "client_id";
+    private static final String CLIENT_SECRET_KEY = "client_secret";
+    private static final String CODE_KEY = "code";
+    private static final String ACCESS_TOKEN_KEY = "access_token";
+    private static final String GITHUB_LOGIN_KEY = "login";
+
+    @Value("${spring.security.oauth2.client.provider.github.user-info-uri}")
+    private String githubUserInfoUri;
+
+    @Value("${spring.security.oauth2.client.provider.github.token-uri}")
+    private String githubTokenUri;
+
+    @Value("${spring.security.oauth2.client.registration.github.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.github.client-secret}")
+    private String clientSecret;
+
     @Autowired
     public AuthService(WebClient.Builder webClientBuilder) {
         this.webClientBuilder = webClientBuilder;
     }
+
+    public Mono<String> exchangeCodeForToken(String code) {
+        WebClient webClient = webClientBuilder.build();
+
+        return webClient
+                .post()
+                .uri(githubTokenUri)
+                .header("Accept", "application/json")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(createRequestBody(clientId, clientSecret, code))
+                .retrieve()
+                .bodyToMono(String.class)
+                .flatMap(this::processTokenResponse)
+                .onErrorResume(this::handleTokenError);
+    }
+
+    private Map<String, String> createRequestBody(String clientId, String clientSecret, String code) {
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put(CLIENT_ID_KEY, clientId);
+        requestBody.put(CLIENT_SECRET_KEY, clientSecret);
+        requestBody.put(CODE_KEY, code);
+        return requestBody;
+    }
+
+    private Mono<String> processTokenResponse(String response) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(response);
+
+            if (jsonNode.has(ACCESS_TOKEN_KEY)) {
+                String accessToken = jsonNode.get(ACCESS_TOKEN_KEY).asText();
+                log.info("Access token obtained successfully");
+                return Mono.just(accessToken);
+            } else {
+                log.error("GitHub OAuth error: {}", response);
+                return Mono.error(new IllegalStateException("Failed to obtain access token"));
+            }
+        } catch (JsonProcessingException e) {
+            log.error("Error processing GitHub OAuth response", e);
+            return Mono.error(e);
+        }
+    }
+
+    private Mono<String> handleTokenError(Throwable ex) {
+        log.error("Error exchanging code for token: {}", ex.getMessage());
+        return Mono.error(ex);
+    }
+
+    @Override
+    public Mono<Map<String, Object>> validateTokenWithGithub(String token) {
+        WebClient webClient = webClientBuilder.build();
+
+        return webClient
+                .get()
+                .uri(githubUserInfoUri)
+                .header("Authorization", "token " + token)
+                .retrieve()
+                .bodyToMono(String.class)
+                .flatMap(response -> {
+                    try {
+                        ObjectMapper objectMapper = new ObjectMapper();
+                        JsonNode jsonNode = objectMapper.readTree(response);
+
+                        if (jsonNode.has("login")) {
+                            String githubUsername = jsonNode.get("login").asText();
+                            log.info("GitHub username extracted: {}", githubUsername);
+
+                            Map<String, Object> result = new HashMap<>();
+                            result.put(KEY_IS_VALID, true);
+                            result.put(KEY_USERNAME, githubUsername);
+                            result.put("token", token);
+
+                            return Mono.just(result);
+
+                        } else {
+                            log.error("GitHub response does not contain a username: {}", response);
+                            Map<String, Object> errorResult = new HashMap<>();
+                            errorResult.put(KEY_IS_VALID, false);
+                            errorResult.put(KEY_USERNAME, null);
+                            return Mono.just(errorResult);
+                        }
+                    } catch (JsonProcessingException e) {
+                        log.error("Error processing GitHub response", e);
+                        return Mono.error(e);
+                    }
+                })
+                .onErrorResume(WebClientResponseException.class, ex -> {
+                    log.error("GitHub API error: {}", ex.getStatusCode());
+                    Map<String, Object> errorResult = new HashMap<>();
+                    errorResult.put(KEY_IS_VALID, false);
+                    errorResult.put(KEY_USERNAME, null);
+                    return Mono.just(errorResult);
+                })
+                .onErrorResume(ex -> {
+                    log.error("Unexpected error: {}", ex.getMessage());
+                    Map<String, Object> errorResult = new HashMap<>();
+                    errorResult.put(KEY_IS_VALID, false);
+                    errorResult.put(KEY_USERNAME, null);
+                    return Mono.just(errorResult);
+                });
+    }
+
+
+
+    // Old validation method
     @Value("${uri_validate_token}")
     private String validationUrl;
     public Mono<Boolean> validateWithSSO(String token) {
@@ -65,4 +193,5 @@ public class AuthService implements IAuthService {
                     return Mono.just(false);
                 });
     }
+
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
@@ -32,20 +32,28 @@ public class AuthService implements IAuthService {
     private static final String GITHUB_LOGIN_KEY = "login";
 
     @Value("${spring.security.oauth2.client.provider.github.user-info-uri}")
-    private String githubUserInfoUri;
+    private final String githubUserInfoUri;
 
     @Value("${spring.security.oauth2.client.provider.github.token-uri}")
-    private String githubTokenUri;
+    private final String githubTokenUri;
 
     @Value("${spring.security.oauth2.client.registration.github.client-id}")
-    private String clientId;
+    private final String clientId;
 
     @Value("${spring.security.oauth2.client.registration.github.client-secret}")
-    private String clientSecret;
+    private final String clientSecret;
 
     @Autowired
-    public AuthService(WebClient.Builder webClientBuilder) {
+    public AuthService(WebClient.Builder webClientBuilder,
+                       @Value("${spring.security.oauth2.client.provider.github.token-uri}") String githubTokenUri,
+                       @Value("${spring.security.oauth2.client.provider.github.user-info-uri}") String githubUserInfoUri,
+                       @Value("${spring.security.oauth2.client.registration.github.client-id}") String clientId,
+                       @Value("${spring.security.oauth2.client.registration.github.client-secret}") String clientSecret) {
         this.webClientBuilder = webClientBuilder;
+        this.githubTokenUri = githubTokenUri;
+        this.githubUserInfoUri = githubUserInfoUri;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
     }
 
     public Mono<String> exchangeCodeForToken(String code) {
@@ -105,51 +113,55 @@ public class AuthService implements IAuthService {
                 .header("Authorization", "token " + token)
                 .retrieve()
                 .bodyToMono(String.class)
-                .flatMap(response -> {
-                    try {
-                        ObjectMapper objectMapper = new ObjectMapper();
-                        JsonNode jsonNode = objectMapper.readTree(response);
-
-                        if (jsonNode.has("login")) {
-                            String githubUsername = jsonNode.get("login").asText();
-                            log.info("GitHub username extracted: {}", githubUsername);
-
-                            Map<String, Object> result = new HashMap<>();
-                            result.put(KEY_IS_VALID, true);
-                            result.put(KEY_USERNAME, githubUsername);
-                            result.put("token", token);
-
-                            return Mono.just(result);
-
-                        } else {
-                            log.error("GitHub response does not contain a username: {}", response);
-                            Map<String, Object> errorResult = new HashMap<>();
-                            errorResult.put(KEY_IS_VALID, false);
-                            errorResult.put(KEY_USERNAME, null);
-                            return Mono.just(errorResult);
-                        }
-                    } catch (JsonProcessingException e) {
-                        log.error("Error processing GitHub response", e);
-                        return Mono.error(e);
-                    }
-                })
-                .onErrorResume(WebClientResponseException.class, ex -> {
-                    log.error("GitHub API error: {}", ex.getStatusCode());
-                    Map<String, Object> errorResult = new HashMap<>();
-                    errorResult.put(KEY_IS_VALID, false);
-                    errorResult.put(KEY_USERNAME, null);
-                    return Mono.just(errorResult);
-                })
-                .onErrorResume(ex -> {
-                    log.error("Unexpected error: {}", ex.getMessage());
-                    Map<String, Object> errorResult = new HashMap<>();
-                    errorResult.put(KEY_IS_VALID, false);
-                    errorResult.put(KEY_USERNAME, null);
-                    return Mono.just(errorResult);
-                });
+                .flatMap(response -> processGithubResponse(response, token))
+                .onErrorResume(WebClientResponseException.class, this::handleGithubApiError)
+                .onErrorResume(this::handleUnexpectedError);
     }
 
+    private Mono<Map<String, Object>> processGithubResponse(String response, String token) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(response);
 
+            if (jsonNode.has(GITHUB_LOGIN_KEY)) {
+                String githubUsername = jsonNode.get(GITHUB_LOGIN_KEY).asText();
+                log.info("GitHub username extracted: {}", githubUsername);
+
+                return Mono.just(createSuccessResult(githubUsername, token));
+            } else {
+                log.error("GitHub response does not contain a username: {}", response);
+                return Mono.just(createErrorResult());
+            }
+        } catch (JsonProcessingException e) {
+            log.error("Error processing GitHub response", e);
+            return Mono.error(e);
+        }
+    }
+
+    private Mono<Map<String, Object>> handleGithubApiError(WebClientResponseException ex) {
+        log.error("GitHub API error: {}", ex.getStatusCode());
+        return Mono.just(createErrorResult());
+    }
+
+    private Mono<Map<String, Object>> handleUnexpectedError(Throwable ex) {
+        log.error("Unexpected error: {}", ex.getMessage());
+        return Mono.just(createErrorResult());
+    }
+
+    private Map<String, Object> createSuccessResult(String username, String token) {
+        Map<String, Object> result = new HashMap<>();
+        result.put(KEY_IS_VALID, true);
+        result.put(KEY_USERNAME, username);
+        result.put(KEY_TOKEN, token);
+        return result;
+    }
+
+    private Map<String, Object> createErrorResult() {
+        Map<String, Object> errorResult = new HashMap<>();
+        errorResult.put(KEY_IS_VALID, false);
+        errorResult.put(KEY_USERNAME, null);
+        return errorResult;
+    }
 
     // Old validation method
     @Value("${uri_validate_token}")

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
@@ -163,47 +163,4 @@ public class AuthService implements IAuthService {
         return errorResult;
     }
 
-    // Old validation method
-//    @Value("${uri_validate_token}")
-//    private String validationUrl;
-//    public Mono<Boolean> validateWithSSO(String token) {
-//
-//        WebClient webClient = webClientBuilder.build();
-//        return webClient
-//                .post()
-//                .uri(validationUrl)
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .bodyValue(token)
-//                .retrieve()
-//                .bodyToMono(String.class)
-//                .flatMap(response -> {
-//                    try {
-//                        ObjectMapper objectMapper = new ObjectMapper();
-//                        JsonNode jsonNode = objectMapper.readTree(response);
-//                        if (jsonNode.has("id")) {
-//                            log.info("Token is valid");
-//                            return Mono.just(true);
-//                        } else if (jsonNode.has("message")) {
-//                            String message = jsonNode.get("message").asText();
-//                            log.warn("Token is not valid: {}", message);
-//                            return Mono.just(false);
-//                        } else {
-//                            log.error("Unexpected JSON response format: {}", response);
-//                            return Mono.error(new IllegalStateException("Unexpected JSON response format"));
-//                        }
-//                    } catch (JsonProcessingException e) {
-//                        log.error("Error processing JSON response", e);
-//                        return Mono.error(e);
-//                    }
-//                })
-//                .onErrorResume(WebClientResponseException.class, responseException -> {
-//                    log.error("Error from SSO server [{}]: {}", validationUrl, responseException.getStatusCode());
-//                    return Mono.just(false);
-//                })
-//                .onErrorResume(ex -> {
-//                    log.error("Unexpected error [{}]: {}", validationUrl, ex.getMessage());
-//                    return Mono.just(false);
-//                });
-//    }
-
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IAuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IAuthService.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 public interface IAuthService {
 
-    Mono<Boolean> validateWithSSO(String token);
+//    Mono<Boolean> validateWithSSO(String token);
     Mono<Map<String, Object>> validateTokenWithGithub(String token);
     Mono<String> exchangeCodeForToken(String code);
 

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IAuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IAuthService.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 public interface IAuthService {
 
-//    Mono<Boolean> validateWithSSO(String token);
     Mono<Map<String, Object>> validateTokenWithGithub(String token);
     Mono<String> exchangeCodeForToken(String code);
 

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IAuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IAuthService.java
@@ -2,8 +2,12 @@ package com.itachallenge.auth.service;
 
 import reactor.core.publisher.Mono;
 
+import java.util.Map;
+
 public interface IAuthService {
 
     Mono<Boolean> validateWithSSO(String token);
+    Mono<Map<String, Object>> validateTokenWithGithub(String token);
+    Mono<String> exchangeCodeForToken(String code);
 
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IAuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IAuthService.java
@@ -8,5 +8,6 @@ public interface IAuthService {
 
     Mono<Map<String, Object>> validateTokenWithGithub(String token);
     Mono<String> exchangeCodeForToken(String code);
-
+    Mono<String> callUserTest();
+    Mono<Boolean> validateUserExists(String githubUsername);
 }

--- a/itachallenge-auth/src/main/resources/application.yml
+++ b/itachallenge-auth/src/main/resources/application.yml
@@ -42,6 +42,10 @@ management:
 
 uri_validate_token : https://dev.sso.itawiki.eurecatacademy.org/api/v1/tokens/validate
 
+user:
+  service:
+    url: http://172.17.0.2:8764 # LOCAL IP
+    # SHOULD BE http://apisix-gateway:9080 IN PRODUCTION
 
 logging:
   level:

--- a/itachallenge-auth/src/main/resources/application.yml
+++ b/itachallenge-auth/src/main/resources/application.yml
@@ -7,6 +7,19 @@ spring:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
   jmx:
     enabled: true
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}
+        provider:
+          github:
+            authorization-uri: https://github.com/login/oauth/authorize
+            token-uri: https://github.com/login/oauth/access_token
+            user-info-uri: https://api.github.com/user
+            user-name-attribute: login
 
 springdoc:
   swagger-ui:

--- a/itachallenge-auth/src/main/resources/application.yml
+++ b/itachallenge-auth/src/main/resources/application.yml
@@ -44,8 +44,8 @@ uri_validate_token : https://dev.sso.itawiki.eurecatacademy.org/api/v1/tokens/va
 
 user:
   service:
-    url: http://172.17.0.2:8764 # LOCAL IP
-    # SHOULD BE http://apisix-gateway:9080 IN PRODUCTION
+    url: http://apisix-gateway:9080 # IN PRODUCTION
+    # http://172.17.0.2:8764 LOCAL IP
 
 logging:
   level:

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -126,41 +126,41 @@ class AuthControllerTest {
     }
 
     // Old tests
-    @Test
-    void validateTokenOK() {
-        String validToken = "validToken";
-        when(authService.validateWithSSO(validToken)).thenReturn(Mono.just(true));
-
-        // Act & Assert
-        StepVerifier.create(authController.validateToken(validToken))
-                .expectNextMatches(responseEntity ->
-                        responseEntity.getStatusCode() == HttpStatus.OK &&
-                                responseEntity.getBody().equals("Token is valid"))
-                .verifyComplete();
-    }
-
-
-    @Test
-    void validateTokenNotOK() {
-        String invalidToken = "invalidToken";
-        when(authService.validateWithSSO(invalidToken)).thenReturn(Mono.just(false));
-
-        StepVerifier.create((authController.validateToken(invalidToken)))
-                .expectNextMatches(responseEntity -> responseEntity.getStatusCode() == HttpStatus.UNAUTHORIZED &&
-                        responseEntity.getBody().equals("Token is not valid"))
-                .verifyComplete();
-    }
-
-    @Test
-    void getVersionTest() {
-        String expectedVersion = env.getProperty("spring.application.version");
-
-        webTestClient.get()
-                .uri("/itachallenge/api/v1/auth/version")
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody()
-                .jsonPath("$.application_name").isEqualTo("itachallenge-auth")
-                .jsonPath("$.version").isEqualTo("1.0.0-RELEASE");
-    }
+//    @Test
+//    void validateTokenOK() {
+//        String validToken = "validToken";
+//        when(authService.validateWithSSO(validToken)).thenReturn(Mono.just(true));
+//
+//        // Act & Assert
+//        StepVerifier.create(authController.validateToken(validToken))
+//                .expectNextMatches(responseEntity ->
+//                        responseEntity.getStatusCode() == HttpStatus.OK &&
+//                                responseEntity.getBody().equals("Token is valid"))
+//                .verifyComplete();
+//    }
+//
+//
+//    @Test
+//    void validateTokenNotOK() {
+//        String invalidToken = "invalidToken";
+//        when(authService.validateWithSSO(invalidToken)).thenReturn(Mono.just(false));
+//
+//        StepVerifier.create((authController.validateToken(invalidToken)))
+//                .expectNextMatches(responseEntity -> responseEntity.getStatusCode() == HttpStatus.UNAUTHORIZED &&
+//                        responseEntity.getBody().equals("Token is not valid"))
+//                .verifyComplete();
+//    }
+//
+//    @Test
+//    void getVersionTest() {
+//        String expectedVersion = env.getProperty("spring.application.version");
+//
+//        webTestClient.get()
+//                .uri("/itachallenge/api/v1/auth/version")
+//                .exchange()
+//                .expectStatus().isOk()
+//                .expectBody()
+//                .jsonPath("$.application_name").isEqualTo("itachallenge-auth")
+//                .jsonPath("$.version").isEqualTo("1.0.0-RELEASE");
+//    }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -40,12 +40,14 @@ class AuthControllerTest {
         String validCode = "valid-code";
         String accessToken = "valid-token";
         String githubUsername = "octocat";
+
         Map<String, Object> validationResult = new HashMap<>();
         validationResult.put("isValid", true);
         validationResult.put("username", githubUsername);
 
         when(authService.exchangeCodeForToken(validCode)).thenReturn(Mono.just(accessToken));
         when(authService.validateTokenWithGithub(accessToken)).thenReturn(Mono.just(validationResult));
+        when(authService.validateUserExists(githubUsername)).thenReturn(Mono.just(true));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/github/authenticate")
@@ -103,6 +105,52 @@ class AuthControllerTest {
         when(authService.exchangeCodeForToken(validCode)).thenReturn(Mono.just(accessToken));
         when(authService.validateTokenWithGithub(accessToken))
                 .thenReturn(Mono.error(new RuntimeException("Token validation failed")));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/github/authenticate")
+                .bodyValue(Map.of("code", validCode))
+                .exchange()
+                .expectStatus().is5xxServerError()
+                .expectBody()
+                .jsonPath("$.isValid").isEqualTo(false)
+                .jsonPath("$.username").isEmpty();
+    }
+
+    @Test
+    void authenticateWithGithub_UserDoesNotExist_ReturnsForbidden() {
+        String validCode = "valid-code";
+        String accessToken = "valid-token";
+        String githubUsername = "octocat";
+        Map<String, Object> validationResult = new HashMap<>();
+        validationResult.put("isValid", true);
+        validationResult.put("username", githubUsername);
+
+        when(authService.exchangeCodeForToken(validCode)).thenReturn(Mono.just(accessToken));
+        when(authService.validateTokenWithGithub(accessToken)).thenReturn(Mono.just(validationResult));
+        when(authService.validateUserExists(githubUsername)).thenReturn(Mono.just(false));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/github/authenticate")
+                .bodyValue(Map.of("code", validCode))
+                .exchange()
+                .expectStatus().isForbidden()
+                .expectBody()
+                .jsonPath("$.isValid").isEqualTo(false)
+                .jsonPath("$.message").isEqualTo("User does not exist in the database");
+    }
+
+    @Test
+    void authenticateWithGithub_UserValidationError_ReturnsInternalServerError() {
+        String validCode = "valid-code";
+        String accessToken = "valid-token";
+        String githubUsername = "octocat";
+        Map<String, Object> validationResult = new HashMap<>();
+        validationResult.put("isValid", true);
+        validationResult.put("username", githubUsername);
+
+        when(authService.exchangeCodeForToken(validCode)).thenReturn(Mono.just(accessToken));
+        when(authService.validateTokenWithGithub(accessToken)).thenReturn(Mono.just(validationResult));
+        when(authService.validateUserExists(githubUsername)).thenReturn(Mono.error(new RuntimeException("Database error")));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/github/authenticate")

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -9,12 +9,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.env.Environment;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -125,42 +123,16 @@ class AuthControllerTest {
                 .expectStatus().isBadRequest();
     }
 
-    // Old tests
-//    @Test
-//    void validateTokenOK() {
-//        String validToken = "validToken";
-//        when(authService.validateWithSSO(validToken)).thenReturn(Mono.just(true));
-//
-//        // Act & Assert
-//        StepVerifier.create(authController.validateToken(validToken))
-//                .expectNextMatches(responseEntity ->
-//                        responseEntity.getStatusCode() == HttpStatus.OK &&
-//                                responseEntity.getBody().equals("Token is valid"))
-//                .verifyComplete();
-//    }
-//
-//
-//    @Test
-//    void validateTokenNotOK() {
-//        String invalidToken = "invalidToken";
-//        when(authService.validateWithSSO(invalidToken)).thenReturn(Mono.just(false));
-//
-//        StepVerifier.create((authController.validateToken(invalidToken)))
-//                .expectNextMatches(responseEntity -> responseEntity.getStatusCode() == HttpStatus.UNAUTHORIZED &&
-//                        responseEntity.getBody().equals("Token is not valid"))
-//                .verifyComplete();
-//    }
-//
-//    @Test
-//    void getVersionTest() {
-//        String expectedVersion = env.getProperty("spring.application.version");
-//
-//        webTestClient.get()
-//                .uri("/itachallenge/api/v1/auth/version")
-//                .exchange()
-//                .expectStatus().isOk()
-//                .expectBody()
-//                .jsonPath("$.application_name").isEqualTo("itachallenge-auth")
-//                .jsonPath("$.version").isEqualTo("1.0.0-RELEASE");
-//    }
+    @Test
+    void getVersionTest() {
+        String expectedVersion = env.getProperty("spring.application.version");
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/auth/version")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.application_name").isEqualTo("itachallenge-auth")
+                .jsonPath("$.version").isEqualTo("1.0.0-RELEASE");
+    }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -1,14 +1,11 @@
 package com.itachallenge.auth.controller;
 
-import com.itachallenge.auth.service.AuthService;
 import com.itachallenge.auth.service.IAuthService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.env.Environment;

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
@@ -56,6 +57,72 @@ class AuthControllerTest {
                 .expectBody()
                 .jsonPath("$.isValid").isEqualTo(true)
                 .jsonPath("$.username").isEqualTo(githubUsername);
+    }
+
+    @Test
+    void authenticateWithGithub_InvalidCode_ReturnsUnauthorized() {
+        String invalidCode = "invalid-code";
+        String accessToken = "invalid-token";
+        Map<String, Object> validationResult = new HashMap<>();
+        validationResult.put("isValid", false);
+        validationResult.put("username", null);
+
+        when(authService.exchangeCodeForToken(invalidCode)).thenReturn(Mono.just(accessToken));
+        when(authService.validateTokenWithGithub(accessToken)).thenReturn(Mono.just(validationResult));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/github/authenticate")
+                .bodyValue(Map.of("code", invalidCode))
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .expectBody()
+                .jsonPath("$.isValid").isEqualTo(false)
+                .jsonPath("$.username").isEmpty();
+    }
+
+    @Test
+    void authenticateWithGithub_TokenExchangeError_ReturnsInternalServerError() {
+        String invalidCode = "invalid-code";
+
+        when(authService.exchangeCodeForToken(invalidCode))
+                .thenReturn(Mono.error(new RuntimeException("Token exchange failed")));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/github/authenticate")
+                .bodyValue(Map.of("code", invalidCode))
+                .exchange()
+                .expectStatus().is5xxServerError()
+                .expectBody()
+                .jsonPath("$.isValid").isEqualTo(false)
+                .jsonPath("$.username").isEmpty();
+    }
+
+    @Test
+    void authenticateWithGithub_TokenValidationError_ReturnsInternalServerError() {
+        String validCode = "valid-code";
+        String accessToken = "valid-token";
+
+        when(authService.exchangeCodeForToken(validCode)).thenReturn(Mono.just(accessToken));
+        when(authService.validateTokenWithGithub(accessToken))
+                .thenReturn(Mono.error(new RuntimeException("Token validation failed")));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/github/authenticate")
+                .bodyValue(Map.of("code", validCode))
+                .exchange()
+                .expectStatus().is5xxServerError()
+                .expectBody()
+                .jsonPath("$.isValid").isEqualTo(false)
+                .jsonPath("$.username").isEmpty();
+    }
+
+    @Test
+    void authenticateWithGithub_MissingRequestBody_ReturnsBadRequest() {
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/github/authenticate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isBadRequest();
     }
 
     // Old tests

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -18,6 +18,9 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,6 +39,29 @@ class AuthControllerTest {
     @InjectMocks
     private AuthController authController;
 
+    @Test
+    void authenticateWithGithub_ValidCode_ReturnsUsername() {
+        String validCode = "valid-code";
+        String accessToken = "valid-token";
+        String githubUsername = "octocat";
+        Map<String, Object> validationResult = new HashMap<>();
+        validationResult.put("isValid", true);
+        validationResult.put("username", githubUsername);
+
+        when(authService.exchangeCodeForToken(validCode)).thenReturn(Mono.just(accessToken));
+        when(authService.validateTokenWithGithub(accessToken)).thenReturn(Mono.just(validationResult));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/github/authenticate")
+                .bodyValue(Map.of("code", validCode))
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.isValid").isEqualTo(true)
+                .jsonPath("$.username").isEqualTo(githubUsername);
+    }
+
+    // Old tests
     @Test
     void validateTokenOK() {
         String validToken = "validToken";

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -25,7 +27,7 @@ class AuthServiceTest {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
 
-        String baseUrl = mockWebServer.url("/api/v1/tokens/validate").toString();
+        String baseUrl = mockWebServer.url("/user").toString();
         authService = new AuthService(WebClient.builder().baseUrl(baseUrl));
     }
 
@@ -33,53 +35,101 @@ class AuthServiceTest {
     void tearDown() throws IOException {
         mockWebServer.shutdown();
     }
-
-
-    @Test
-    void validateWithSSO_Successful() throws InterruptedException {
-        String responseBody = "{\"id\": \"some_id\"}";
-        mockWebServer.enqueue(new MockResponse().setBody(responseBody));
-
-        Mono<Boolean> result = authService.validateWithSSO("validToken");
-
-        assertEquals(true, result.block());
-
-        RecordedRequest request = mockWebServer.takeRequest();
-        assertEquals("/api/v1/tokens/validate", request.getPath());
-        assertEquals("POST", request.getMethod());
-        assertEquals("application/json", request.getHeader("Content-Type"));
-        assertEquals("validToken", request.getBody().readUtf8());
-    }
-
-    @Test
-    void validateWithSSO_Failure() throws InterruptedException {
-
-        String responseBody = "{\"message\":\"Token is not valid\"}";
-        mockWebServer.enqueue(new MockResponse().setBody(responseBody));
-
-        Mono<Boolean> result = authService.validateWithSSO("invalidToken");
-
-        assertEquals(false, result.block());
-
-        RecordedRequest request = mockWebServer.takeRequest();
-        assertEquals("/api/v1/tokens/validate", request.getPath());
-        assertEquals("POST", request.getMethod());
-        assertEquals("application/json", request.getHeader("Content-Type"));
-        assertEquals("invalidToken", request.getBody().readUtf8());
-    }
+//
+//    @Test
+//    void exchangeCodeForToken_Successful() throws InterruptedException {
+//        String code = "auth-code";
+//        String accessToken = "github-access-token";
+//        String mockResponse = "{\"access_token\": \"" + accessToken + "\"}";
+////
+//        mockWebServer.enqueue(new MockResponse()
+//                .setBody(mockResponse)
+//                .setResponseCode(200)
+//                .addHeader("Content-Type", "application/json"));
+//
+//        Mono<String> result = authService.exchangeCodeForToken(code);
+//
+//        StepVerifier.create(result)
+//                .expectNext(accessToken)
+//                .verifyComplete();
+//
+//        RecordedRequest request = mockWebServer.takeRequest();
+//        assertEquals("/login/oauth/access_token", request.getPath());
+//        assertEquals("application/json", request.getHeader("Accept"));
+//    }
 
     @Test
-    void validateWithSSO_Unexpected_Response() throws InterruptedException {
+    void validateTokenWithGithub_ValidToken_ReturnsUsername() throws Exception {
+        String validToken = "valid-token";
+        String githubUsername = "octocat";
+        String mockResponse = "{\"login\": \"" + githubUsername + "\"}";
 
-        String responseBody = "Invalid JSON format";
-        mockWebServer.enqueue(new MockResponse().setBody(responseBody));
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
 
-        Mono<Boolean> result = authService.validateWithSSO("someToken");
+        Mono<Map<String, Object>> result = authService.validateTokenWithGithub(validToken);
 
         StepVerifier.create(result)
-                .expectNext(false)
+                .assertNext(response -> {
+                    assertEquals(true, response.get("isValid"));
+                    assertEquals(githubUsername, response.get("username"));
+                })
                 .verifyComplete();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertEquals("/user", request.getPath());
+        assertEquals("token " + validToken, request.getHeader("Authorization"));
     }
+
+
+    // Old tests
+//    @Test
+//    void validateWithSSO_Successful() throws InterruptedException {
+//        String responseBody = "{\"id\": \"some_id\"}";
+//        mockWebServer.enqueue(new MockResponse().setBody(responseBody));
+//
+//        Mono<Boolean> result = authService.validateWithSSO("validToken");
+//
+//        assertEquals(true, result.block());
+//
+//        RecordedRequest request = mockWebServer.takeRequest();
+//        assertEquals("/api/v1/tokens/validate", request.getPath());
+//        assertEquals("POST", request.getMethod());
+//        assertEquals("application/json", request.getHeader("Content-Type"));
+//        assertEquals("validToken", request.getBody().readUtf8());
+//    }
+//
+//    @Test
+//    void validateWithSSO_Failure() throws InterruptedException {
+//
+//        String responseBody = "{\"message\":\"Token is not valid\"}";
+//        mockWebServer.enqueue(new MockResponse().setBody(responseBody));
+//
+//        Mono<Boolean> result = authService.validateWithSSO("invalidToken");
+//
+//        assertEquals(false, result.block());
+//
+//        RecordedRequest request = mockWebServer.takeRequest();
+//        assertEquals("/api/v1/tokens/validate", request.getPath());
+//        assertEquals("POST", request.getMethod());
+//        assertEquals("application/json", request.getHeader("Content-Type"));
+//        assertEquals("invalidToken", request.getBody().readUtf8());
+//    }
+//
+//    @Test
+//    void validateWithSSO_Unexpected_Response() throws InterruptedException {
+//
+//        String responseBody = "Invalid JSON format";
+//        mockWebServer.enqueue(new MockResponse().setBody(responseBody));
+//
+//        Mono<Boolean> result = authService.validateWithSSO("someToken");
+//
+//        StepVerifier.create(result)
+//                .expectNext(false)
+//                .verifyComplete();
+//    }
 
 
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -86,51 +85,4 @@ class AuthServiceTest {
         assertEquals("token " + validToken, request.getHeader("Authorization"));
     }
 
-
-    // Old tests
-//    @Test
-//    void validateWithSSO_Successful() throws InterruptedException {
-//        String responseBody = "{\"id\": \"some_id\"}";
-//        mockWebServer.enqueue(new MockResponse().setBody(responseBody));
-//
-//        Mono<Boolean> result = authService.validateWithSSO("validToken");
-//
-//        assertEquals(true, result.block());
-//
-//        RecordedRequest request = mockWebServer.takeRequest();
-//        assertEquals("/api/v1/tokens/validate", request.getPath());
-//        assertEquals("POST", request.getMethod());
-//        assertEquals("application/json", request.getHeader("Content-Type"));
-//        assertEquals("validToken", request.getBody().readUtf8());
-//    }
-//
-//    @Test
-//    void validateWithSSO_Failure() throws InterruptedException {
-//
-//        String responseBody = "{\"message\":\"Token is not valid\"}";
-//        mockWebServer.enqueue(new MockResponse().setBody(responseBody));
-//
-//        Mono<Boolean> result = authService.validateWithSSO("invalidToken");
-//
-//        assertEquals(false, result.block());
-//
-//        RecordedRequest request = mockWebServer.takeRequest();
-//        assertEquals("/api/v1/tokens/validate", request.getPath());
-//        assertEquals("POST", request.getMethod());
-//        assertEquals("application/json", request.getHeader("Content-Type"));
-//        assertEquals("invalidToken", request.getBody().readUtf8());
-//    }
-//
-//    @Test
-//    void validateWithSSO_Unexpected_Response() throws InterruptedException {
-//
-//        String responseBody = "Invalid JSON format";
-//        mockWebServer.enqueue(new MockResponse().setBody(responseBody));
-//
-//        Mono<Boolean> result = authService.validateWithSSO("someToken");
-//
-//        StepVerifier.create(result)
-//                .expectNext(false)
-//                .verifyComplete();
-//    }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -61,6 +62,38 @@ class AuthServiceTest {
     }
 
     @Test
+    void exchangeCodeForToken_InvalidCode_ReturnsError() {
+        String code = "invalid-code";
+        String mockResponse = "{\"error\": \"bad_verification_code\"}";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(400) // Simulate GitHub rejecting the code
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<String> result = authService.exchangeCodeForToken(code);
+
+        StepVerifier.create(result)
+                .expectError(WebClientResponseException.BadRequest.class)
+                .verify();
+    }
+
+
+    @Test
+    void exchangeCodeForToken_NetworkFailure_ReturnsError() {
+        String code = "auth-code";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500));
+
+        Mono<String> result = authService.exchangeCodeForToken(code);
+
+        StepVerifier.create(result)
+                .expectError(WebClientResponseException.class)
+                .verify();
+    }
+
+    @Test
     void validateTokenWithGithub_ValidToken_ReturnsUsername() throws Exception {
         String validToken = "valid-token";
         String githubUsername = "octocat";
@@ -83,6 +116,40 @@ class AuthServiceTest {
         RecordedRequest request = mockWebServer.takeRequest();
         assertEquals("/user", request.getRequestUrl().encodedPath());
         assertEquals("token " + validToken, request.getHeader("Authorization"));
+    }
+
+    @Test
+    void validateTokenWithGithub_ExpiredToken_ReturnsInvalid() {
+        String expiredToken = "expired-token";
+        String mockResponse = "{\"message\": \"Bad credentials\"}";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(401)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Map<String, Object>> result = authService.validateTokenWithGithub(expiredToken);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(false, response.get("isValid")))
+                .verifyComplete();
+    }
+
+    @Test
+    void validateTokenWithGithub_UnexpectedResponse_ReturnsError() {
+        String token = "valid-token";
+        String mockResponse = "{\"unexpected_key\": \"unexpected_value\"}";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Map<String, Object>> result = authService.validateTokenWithGithub(token);
+
+        StepVerifier.create(result)
+                .assertNext(response -> assertEquals(false, response.get("isValid")))
+                .verifyComplete();
     }
 
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
@@ -133,6 +133,4 @@ class AuthServiceTest {
 //                .expectNext(false)
 //                .verifyComplete();
 //    }
-
-
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
@@ -27,36 +27,39 @@ class AuthServiceTest {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
 
-        String baseUrl = mockWebServer.url("/user").toString();
-        authService = new AuthService(WebClient.builder().baseUrl(baseUrl));
+        String baseUrl = mockWebServer.url("").toString();
+        String githubTokenUri = baseUrl + "login/oauth/access_token";
+        String githubUserInfoUri = baseUrl + "user";
+
+        authService = new AuthService(WebClient.builder(), githubTokenUri, githubUserInfoUri, "test-client-id", "test-client-secret");
     }
 
     @AfterEach
     void tearDown() throws IOException {
         mockWebServer.shutdown();
     }
-//
-//    @Test
-//    void exchangeCodeForToken_Successful() throws InterruptedException {
-//        String code = "auth-code";
-//        String accessToken = "github-access-token";
-//        String mockResponse = "{\"access_token\": \"" + accessToken + "\"}";
-////
-//        mockWebServer.enqueue(new MockResponse()
-//                .setBody(mockResponse)
-//                .setResponseCode(200)
-//                .addHeader("Content-Type", "application/json"));
-//
-//        Mono<String> result = authService.exchangeCodeForToken(code);
-//
-//        StepVerifier.create(result)
-//                .expectNext(accessToken)
-//                .verifyComplete();
-//
-//        RecordedRequest request = mockWebServer.takeRequest();
-//        assertEquals("/login/oauth/access_token", request.getPath());
-//        assertEquals("application/json", request.getHeader("Accept"));
-//    }
+
+    @Test
+    void exchangeCodeForToken_Successful() throws InterruptedException {
+        String code = "auth-code";
+        String accessToken = "github-access-token";
+        String mockResponse = "{\"access_token\": \"" + accessToken + "\"}";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<String> result = authService.exchangeCodeForToken(code);
+
+        StepVerifier.create(result)
+                .expectNext(accessToken)
+                .verifyComplete();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertEquals("/login/oauth/access_token", request.getRequestUrl().encodedPath());
+        assertEquals("application/json", request.getHeader("Accept"));
+    }
 
     @Test
     void validateTokenWithGithub_ValidToken_ReturnsUsername() throws Exception {
@@ -79,7 +82,7 @@ class AuthServiceTest {
                 .verifyComplete();
 
         RecordedRequest request = mockWebServer.takeRequest();
-        assertEquals("/user", request.getPath());
+        assertEquals("/user", request.getRequestUrl().encodedPath());
         assertEquals("token " + validToken, request.getHeader("Authorization"));
     }
 

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
@@ -30,8 +30,15 @@ class AuthServiceTest {
         String baseUrl = mockWebServer.url("").toString();
         String githubTokenUri = baseUrl + "login/oauth/access_token";
         String githubUserInfoUri = baseUrl + "user";
+        String userServiceUrl = baseUrl;
 
-        authService = new AuthService(WebClient.builder(), githubTokenUri, githubUserInfoUri, "test-client-id", "test-client-secret");
+        authService = new AuthService(
+                WebClient.builder(),
+                githubTokenUri,
+                githubUserInfoUri,
+                "test-client-id",
+                "test-client-secret",
+                userServiceUrl);
     }
 
     @AfterEach
@@ -77,7 +84,6 @@ class AuthServiceTest {
                 .expectError(WebClientResponseException.BadRequest.class)
                 .verify();
     }
-
 
     @Test
     void exchangeCodeForToken_NetworkFailure_ReturnsError() {
@@ -149,6 +155,53 @@ class AuthServiceTest {
 
         StepVerifier.create(result)
                 .assertNext(response -> assertEquals(false, response.get("isValid")))
+                .verifyComplete();
+    }
+
+    @Test
+    void validateUserExists_UserExists_ReturnsTrue() throws InterruptedException {
+        String githubUsername = "octocat";
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("true")
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = authService.validateUserExists(githubUsername);
+
+        StepVerifier.create(result)
+                .expectNext(true)
+                .verifyComplete();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertEquals("/itachallenge/api/v1/user/validate-mentor-exists", request.getRequestUrl().encodedPath());
+        assertEquals(githubUsername, request.getRequestUrl().queryParameter("githubUsername"));
+    }
+
+    @Test
+    void validateUserExists_UserDoesNotExist_ReturnsFalse() {
+        String githubUsername = "unknown-user";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(404));
+
+        Mono<Boolean> result = authService.validateUserExists(githubUsername);
+
+        StepVerifier.create(result)
+                .expectNext(false)
+                .verifyComplete();
+    }
+
+    @Test
+    void validateUserExists_ServiceError_ReturnsFalse() {
+        String githubUsername = "octocat";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500));
+
+        Mono<Boolean> result = authService.validateUserExists(githubUsername);
+
+        StepVerifier.create(result)
+                .expectNext(false)
                 .verifyComplete();
     }
 


### PR DESCRIPTION
Added two main methods in AuthService:

- exchangeCodeForToken: takes the code sent in the request and sends it to github to obtain an authentication token. For this request we need the clientId and the clientSecret which are fixed values that we've established in our application.yml as environment variables.
- validateTokenWithGithub: sends the token to the github API to get the user authorizated. With the response, we sent the frontend the info it needs (username and token)

Also added tests for both the AuthController and AuthService. Some tests in AuthService related to the old login method have been commented out to avoid conflict (since it will no longer be implemented and we don't need to adapt these tests to work with our current setup).

Database check to verify if the user exists in our database is skipped and is to be added in future tasks.