### PR TITLE
Feature/788 add new programming languages

### DIFF
--- a/itachallenge-challenge/src/main/resources/mongodb-test-data/languages.json
+++ b/itachallenge-challenge/src/main/resources/mongodb-test-data/languages.json
@@ -33,6 +33,6 @@
     "_id" : {
       "$uuid" : "5caa6142-a49e-4415-a8fc-439669777d1d"
     },
-    "language_name": "TypeScript"
+    "language_name": "Typescript"
   }
 ]

--- a/itachallenge-challenge/src/main/resources/mongodb-test-data/languages.json
+++ b/itachallenge-challenge/src/main/resources/mongodb-test-data/languages.json
@@ -22,5 +22,17 @@
       "$uuid" : "409c9fe8-74de-4db3-81a1-a55280cf92ef"
     },
     "language_name": "Python"
+  },
+  {
+    "_id" : {
+      "$uuid" : "129568b8-b09a-4589-a0bb-053dd120f0bb"
+    },
+    "language_name": "SQL"
+  },
+  {
+    "_id" : {
+      "$uuid" : "5caa6142-a49e-4415-a8fc-439669777d1d"
+    },
+    "language_name": "TypeScript"
   }
 ]


### PR DESCRIPTION
(Holi, en verdad debí haber terminado esto antes de irme, que lo dejé a medias.)

Added Typescript and SQL as languages in the json that feeds local database. Also modified the remote database languages collection.

"Typescript" is named like that (with the lowercase "s") because "Javascript" existed already in the same fashion, and there seem to be lots of tests that have it like that.