### PR TITLE
Link challenge to database mentor id

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/config/UserClient.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/config/UserClient.java
@@ -1,0 +1,32 @@
+package com.itachallenge.challenge.config;
+
+import com.itachallenge.challenge.dto.UserDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class UserClient {
+
+    private final WebClient userWebClient;
+
+    @Autowired
+    public UserClient(WebClient userWebClient) {
+        this.userWebClient = userWebClient;
+    }
+
+    public Mono<UserDto> getUserByUsername(String username) {
+        return userWebClient.get()
+                .uri("/users/{username}", username)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response ->
+                        Mono.error(new RuntimeException("User not found"))
+                )
+                .onStatus(HttpStatusCode::is5xxServerError, response ->
+                        Mono.error(new RuntimeException("Server error in User Service"))
+                )
+                .bodyToMono(UserDto.class);
+    }
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/config/WebClientConfig.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/config/WebClientConfig.java
@@ -1,0 +1,20 @@
+package com.itachallenge.challenge.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${user.service.url}")
+    private String userServiceUrl;
+
+    @Bean
+    public WebClient userWebClient() {
+        return WebClient.builder()
+                .baseUrl(userServiceUrl)
+                .build();
+    }
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ChallengeDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ChallengeDocument.java
@@ -39,6 +39,9 @@ public class ChallengeDocument {
     @Field(name="solutions")
     private List<UUID> solutions;
 
+    @Field(name="mentor_id")
+    private UUID mentorId;
+
     @Field(name="topic")
     private Topic topic;
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeCreateDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeCreateDto.java
@@ -26,6 +26,9 @@ public class ChallengeCreateDto {
     @NotEmpty(message = "cannot be empty")
     private String solution;
 
+    @NotEmpty(message = "cannot be empty")
+    private String mentorUsername;
+
     @NotNull(message = "cannot be empty")
     private Topic topic;
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeDto.java
@@ -53,5 +53,8 @@ public class ChallengeDto {
     private List<UUID> solutions;
 
     @JsonProperty(index = 9)
+    private UUID mentorId;
+
+    @JsonProperty(index = 10)
     private Topic topic;
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/UserDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/UserDto.java
@@ -1,13 +1,13 @@
 package com.itachallenge.challenge.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.UUID;
 
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/UserDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/UserDto.java
@@ -1,0 +1,18 @@
+package com.itachallenge.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDto {
+    private UUID uuid;
+    private String username;
+    private String role;
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImp.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImp.java
@@ -355,4 +355,4 @@ public class ChallengeServiceImp implements IChallengeService {
                         .build()));
 
     }
-} //
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImp.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImp.java
@@ -1,5 +1,6 @@
 package com.itachallenge.challenge.service;
 
+import com.itachallenge.challenge.config.UserClient;
 import com.itachallenge.challenge.document.*;
 import com.itachallenge.challenge.dto.ChallengeDto;
 import com.itachallenge.challenge.dto.GenericResultDto;
@@ -58,6 +59,8 @@ public class ChallengeServiceImp implements IChallengeService {
     private DocumentToDtoConverter<LanguageDocument, LanguageDto> languageConverter = new DocumentToDtoConverter<>();
     @Autowired
     private DocumentToDtoConverter<SolutionDocument, SolutionDto> solutionConverter = new DocumentToDtoConverter<>();
+    @Autowired
+    private UserClient userClient;
 
     @Cacheable(value = "challenges", key = "#id", unless = "#result==null")
     public Mono<ChallengeDto> getChallengeById(String id) {
@@ -237,6 +240,7 @@ public class ChallengeServiceImp implements IChallengeService {
     @Override
     public Mono<ChallengeDto> addChallenge(ChallengeCreateDto challengeCreateDto) {
         String codingLanguage = challengeCreateDto.getLanguage();
+        String mentorUsername = challengeCreateDto.getMentorUsername();
 
         Topic topic;
         try {
@@ -247,24 +251,32 @@ public class ChallengeServiceImp implements IChallengeService {
 
         return languageRepository.findFirstByLanguageName(codingLanguage)
                 .switchIfEmpty(Mono.error(new LanguageNotFoundException("Language " + codingLanguage + " is not valid")))
-                .flatMap(existingLanguage -> {
-                    SolutionDocument solution = SolutionDocument.builder()
-                            .uuid(UUID.randomUUID())
-                            .solutionText(challengeCreateDto.getSolution())
-                            .idLanguage(existingLanguage.getIdLanguage())
-                            .build();
-                    return solutionRepository.save(solution)
-                            .flatMap(savedSolution -> {
-                                ChallengeDocument challenge = buildChallengeDocument(challengeCreateDto,
-                                        existingLanguage, savedSolution.getUuid(), topic);
-                                return challengeRepository.save(challenge)
-                                        .map(savedChallenge -> challengeConverter.convertDocumentToDto(challenge,
-                                                ChallengeDto.class));
-                            });
-                });
+                .flatMap(existingLanguage ->
+                        userClient.getUserByUsername(mentorUsername)
+                                .switchIfEmpty(Mono.error(new RuntimeException("Mentor not found: " + mentorUsername)))
+                                .flatMap(user -> {
+                                    if (!"ADMIN".equalsIgnoreCase(user.getRole())) {
+                                        return Mono.error(new RuntimeException("User is not a mentor: " + mentorUsername));
+                                    }
+
+                                    SolutionDocument solution = SolutionDocument.builder()
+                                            .uuid(UUID.randomUUID())
+                                            .solutionText(challengeCreateDto.getSolution())
+                                            .idLanguage(existingLanguage.getIdLanguage())
+                                            .build();
+
+                                    return solutionRepository.save(solution)
+                                            .flatMap(savedSolution -> {
+                                                ChallengeDocument challenge = buildChallengeDocument(
+                                                        challengeCreateDto, existingLanguage, savedSolution.getUuid(), user.getUuid(), topic
+                                                );
+                                                return challengeRepository.save(challenge)
+                                                        .map(savedChallenge -> challengeConverter.convertDocumentToDto(challenge, ChallengeDto.class));
+                                            });
+                                }));
     }
 
-    private ChallengeDocument buildChallengeDocument(ChallengeCreateDto dto, LanguageDocument language, UUID solutionId, Topic topic) {
+    private ChallengeDocument buildChallengeDocument(ChallengeCreateDto dto, LanguageDocument language, UUID solutionId, UUID mentorId, Topic topic) {
         DetailDocument detail = new DetailDocument(dto.getDescription());
 
         return ChallengeDocument.builder()
@@ -274,10 +286,10 @@ public class ChallengeServiceImp implements IChallengeService {
                 .detail(detail)
                 .languages(Set.of(language))
                 .solutions(List.of(solutionId))
+                .mentorId(mentorId)
                 .topic(topic)
                 .build();
     }
-
 
     private Mono<UUID> validateUUID(String id) {
         boolean validUUID = !StringUtils.isEmpty(id) && UUID_FORM.matcher(id).matches();

--- a/itachallenge-challenge/src/main/resources/application.yml
+++ b/itachallenge-challenge/src/main/resources/application.yml
@@ -66,3 +66,6 @@ validation:
 messages:
   errorMessage: "Invalid values."
 
+user:
+  service:
+    url: http://localhost:8764/itachallenge/api/v1/user

--- a/itachallenge-challenge/src/main/resources/application.yml
+++ b/itachallenge-challenge/src/main/resources/application.yml
@@ -68,4 +68,4 @@ messages:
 
 user:
   service:
-    url: http://localhost:8764/itachallenge/api/v1/user
+    url: http://apisix-gateway:9080 # IN PRODUCTION

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/config/UserClientTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/config/UserClientTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.challenge.config;
 
 import com.itachallenge.challenge.dto.UserDto;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -12,6 +13,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -35,9 +37,16 @@ public class UserClientTest {
     @InjectMocks
     private UserClient userClient;
 
+    private UUID uuid;
+    private String username;
+    private String role;
+
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        uuid = UUID.randomUUID();
+        username = "testUser";
+        role = "ADMIN";
     }
 
     @Test
@@ -97,5 +106,26 @@ public class UserClientTest {
         StepVerifier.create(result)
                 .expectError(RuntimeException.class)
                 .verify();
+    }
+
+    @Test
+    @DisplayName("Test Equals and HashCode in UserDto")
+    public void testEqualsAndHashCode() {
+        UserDto userDto1 = new UserDto(uuid, username, role);
+        UserDto userDto2 = new UserDto(uuid, username, role);
+        UserDto userDto3 = new UserDto(UUID.randomUUID(), "otherUser", "ADMIN");
+
+        assert userDto1.equals(userDto2);
+        assert !userDto1.equals(userDto3);
+        assert userDto1.hashCode() == userDto2.hashCode();
+        assert userDto1.hashCode() != userDto3.hashCode();
+    }
+
+    @Test
+    @DisplayName("Test toString Method in UserDto")
+    public void testToStringMethod() {
+        UserDto userDto = new UserDto(uuid, username, role);
+        String expected = "UserDto(uuid=" + uuid + ", username=" + username + ", role=" + role + ")";
+        assert userDto.toString().equals(expected);
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/config/UserClientTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/config/UserClientTest.java
@@ -2,7 +2,6 @@ package com.itachallenge.challenge.config;
 
 import com.itachallenge.challenge.dto.UserDto;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -13,7 +12,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -37,16 +35,9 @@ public class UserClientTest {
     @InjectMocks
     private UserClient userClient;
 
-    private UUID uuid;
-    private String username;
-    private String role;
-
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        uuid = UUID.randomUUID();
-        username = "testUser";
-        role = "ADMIN";
     }
 
     @Test
@@ -106,26 +97,5 @@ public class UserClientTest {
         StepVerifier.create(result)
                 .expectError(RuntimeException.class)
                 .verify();
-    }
-
-    @Test
-    @DisplayName("Test Equals and HashCode in UserDto")
-    public void testEqualsAndHashCode() {
-        UserDto userDto1 = new UserDto(uuid, username, role);
-        UserDto userDto2 = new UserDto(uuid, username, role);
-        UserDto userDto3 = new UserDto(UUID.randomUUID(), "otherUser", "ADMIN");
-
-        assert userDto1.equals(userDto2);
-        assert !userDto1.equals(userDto3);
-        assert userDto1.hashCode() == userDto2.hashCode();
-        assert userDto1.hashCode() != userDto3.hashCode();
-    }
-
-    @Test
-    @DisplayName("Test toString Method in UserDto")
-    public void testToStringMethod() {
-        UserDto userDto = new UserDto(uuid, username, role);
-        String expected = "UserDto(uuid=" + uuid + ", username=" + username + ", role=" + role + ")";
-        assert userDto.toString().equals(expected);
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/config/UserClientTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/config/UserClientTest.java
@@ -1,0 +1,101 @@
+package com.itachallenge.challenge.config;
+
+import com.itachallenge.challenge.dto.UserDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class UserClientTest {
+
+    @Mock
+    private WebClient userWebClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    @InjectMocks
+    private UserClient userClient;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testGetUserByUsername_Success() {
+        String username = "testUser";
+        UserDto expectedUser = new UserDto();
+        expectedUser.setUsername(username);
+
+        when(userWebClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri("/users/{username}", username)).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(Predicate.class), any(Function.class))).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(UserDto.class)).thenReturn(Mono.just(expectedUser));
+
+        Mono<UserDto> result = userClient.getUserByUsername(username);
+
+        StepVerifier.create(result)
+                .expectNext(expectedUser)
+                .verifyComplete();
+    }
+
+    @Test
+    public void testGetUserByUsername_NotFound() {
+        String username = "nonExistentUser";
+
+        when(userWebClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri("/users/{username}", username)).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(Predicate.class), any(Function.class))).thenAnswer(invocation -> {
+            ClientResponse response = ClientResponse.create(HttpStatus.NOT_FOUND).build();
+            return responseSpec;
+        });
+        when(responseSpec.bodyToMono(UserDto.class)).thenReturn(Mono.error(new RuntimeException("User not found")));
+
+        Mono<UserDto> result = userClient.getUserByUsername(username);
+
+        StepVerifier.create(result)
+                .expectError(RuntimeException.class)
+                .verify();
+    }
+
+    @Test
+    public void testGetUserByUsername_ServerError() {
+        String username = "testUser";
+
+        when(userWebClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri("/users/{username}", username)).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(Predicate.class), any(Function.class))).thenAnswer(invocation -> {
+            ClientResponse response = ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            return responseSpec;
+        });
+        when(responseSpec.bodyToMono(UserDto.class)).thenReturn(Mono.error(new RuntimeException("Server error in User Service")));
+
+        Mono<UserDto> result = userClient.getUserByUsername(username);
+
+        StepVerifier.create(result)
+                .expectError(RuntimeException.class)
+                .verify();
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -349,7 +349,7 @@ class ChallengeControllerTest {
     @Test
     void addChallenge_test_validRequest() {
         ChallengeCreateDto formData = new ChallengeCreateDto("títol", "descripció",
-                DifficultyLevel.valueOf("EASY"), "Java", "solució", Topic.LISTS);
+                DifficultyLevel.valueOf("EASY"), "Java", "solució", "mentorUser", Topic.LISTS);
 
         ChallengeDto createdChallenge = new ChallengeDto();
 
@@ -369,7 +369,7 @@ class ChallengeControllerTest {
     @Test
     void addChallenge_test_emptyField_statusBadRequest() {
         ChallengeCreateDto formData = new ChallengeCreateDto("", "descripció",
-                DifficultyLevel.valueOf("EASY"), "Java", "solució", Topic.COMPONENTS);
+                DifficultyLevel.valueOf("EASY"), "Java", "solució", "mentorUser", Topic.COMPONENTS);
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/challenge/challenges")
@@ -379,11 +379,10 @@ class ChallengeControllerTest {
                 .expectStatus().isBadRequest();
     }
 
-
     @Test
     void addChallenge_test_invalidLanguage_statusBadRequest() {
         ChallengeCreateDto formData = new ChallengeCreateDto("títol", "descripció",
-                DifficultyLevel.valueOf("EASY"), "Invalid language", "solució", Topic.COMPONENTS);
+                DifficultyLevel.valueOf("EASY"), "Invalid language", "solució", "mentorUser", Topic.COMPONENTS);
 
         when(challengeService.addChallenge(any()))
                 .thenThrow(new LanguageNotFoundException("Language not found: Invalid language"));

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
@@ -15,35 +15,35 @@ class ChallengeTest {
     @Test
     void getUuid() {
         UUID uuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument(uuid, null, null, null, null, null, null, Topic.LISTS);
+        ChallengeDocument challenge = new ChallengeDocument(uuid, null, null, null, null, null, null, null, Topic.LISTS);
         assertEquals(uuid, challenge.getUuid());
     }
 
     @Test
     void getTitle() {
         String expectedTitle = "Test challenge";
-        ChallengeDocument challenge = new ChallengeDocument(null, expectedTitle, null, null, null, null, null, Topic.COMPONENTS);
+        ChallengeDocument challenge = new ChallengeDocument(null, expectedTitle, null, null, null, null, null, null, Topic.COMPONENTS);
         assertEquals(expectedTitle, challenge.getTitle());
     }
 
     @Test
     void getLevel() {
         String level = "Intermediate";
-        ChallengeDocument challenge = new ChallengeDocument(null, null, level, null, null, null, null, Topic.COMPONENTS);
+        ChallengeDocument challenge = new ChallengeDocument(null, null, level, null, null, null, null, null, Topic.COMPONENTS);
         assertEquals(level, challenge.getLevel());
     }
 
     @Test
     void getCreationDate() {
         LocalDateTime creationDate = now();
-        ChallengeDocument challenge = new ChallengeDocument(null, null, null, creationDate, null, null, null, Topic.COMPONENTS);
+        ChallengeDocument challenge = new ChallengeDocument(null, null, null, creationDate, null, null, null, null, Topic.COMPONENTS);
         assertTrue(creationDate.truncatedTo(ChronoUnit.SECONDS).isEqual(challenge.getCreationDate().truncatedTo(ChronoUnit.SECONDS)));
     }
 
     @Test
     void getDetail() {
         DetailDocument detail = new DetailDocument(null);
-        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, detail, null, null, Topic.COMPONENTS);
+        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, detail, null, null, null, Topic.COMPONENTS);
         assertEquals(detail, challenge.getDetail());
     }
 
@@ -55,7 +55,7 @@ class ChallengeTest {
                 "https://res.cloudinary.com/itachallenge/image/upload/v1739361249/language_icon_Javascript_asgn04.svg"),
                 new LanguageDocument(uuid2, "Python", "https://res.cloudinary.com/itachallenge/image/upload/v1739361249/language_icon_Python_rphody.svg"));
 
-        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, null, languages, null, Topic.COMPONENTS);
+        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, null, languages, null, null, Topic.COMPONENTS);
         assertEquals(languages, challenge.getLanguages());
     }
 
@@ -63,7 +63,14 @@ class ChallengeTest {
     void getSolutions() {
         List<UUID> solutions = List.of(UUID.randomUUID(),UUID.randomUUID());
 
-        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, null, null, solutions, Topic.COMPONENTS);
+        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, null, null, solutions, null, Topic.COMPONENTS);
         assertEquals(solutions, challenge.getSolutions());
+    }
+
+    @Test
+    void getMentorId() {
+        UUID mentorId = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, null, null, null, mentorId, Topic.COMPONENTS);
+        assertEquals(mentorId, challenge.getMentorId());
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
@@ -1,0 +1,82 @@
+package com.itachallenge.challenge.dto;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserDtoTest {
+
+    private UUID uuid;
+    private String username;
+    private String role;
+
+    @BeforeEach
+    void setUp() {
+        uuid = UUID.randomUUID();
+        username = "testUser";
+        role = "MENTOR";
+    }
+
+    @Test
+    void testUserDto_AllArgsConstructor() {
+        UserDto userDto = new UserDto(uuid, username, role);
+
+        assertThat(userDto.getUuid()).isEqualTo(uuid);
+        assertThat(userDto.getUsername()).isEqualTo(username);
+        assertThat(userDto.getRole()).isEqualTo(role);
+    }
+
+    @Test
+    void testUserDto_NoArgsConstructor() {
+        UserDto userDto = new UserDto();
+
+        assertThat(userDto.getUuid()).isNull();
+        assertThat(userDto.getUsername()).isNull();
+        assertThat(userDto.getRole()).isNull();
+    }
+
+    @Test
+    void testUserDto_SettersAndGetters() {
+        UserDto userDto = new UserDto();
+        userDto.setUuid(uuid);
+        userDto.setUsername(username);
+        userDto.setRole(role);
+
+        assertThat(userDto.getUuid()).isEqualTo(uuid);
+        assertThat(userDto.getUsername()).isEqualTo(username);
+        assertThat(userDto.getRole()).isEqualTo(role);
+    }
+
+    @Test
+    void testUserDto_Builder() {
+        UserDto userDto = UserDto.builder()
+                .uuid(uuid)
+                .username(username)
+                .role(role)
+                .build();
+
+        assertThat(userDto.getUuid()).isEqualTo(uuid);
+        assertThat(userDto.getUsername()).isEqualTo(username);
+        assertThat(userDto.getRole()).isEqualTo(role);
+    }
+
+    @Test
+    void testUserDto_EqualsAndHashCode() {
+        UserDto userDto1 = new UserDto(uuid, username, role);
+        UserDto userDto2 = new UserDto(uuid, username, role);
+
+        assertThat(userDto1).isEqualTo(userDto2);
+        assertThat(userDto1.hashCode()).isEqualTo(userDto2.hashCode());
+    }
+
+    @Test
+    void testUserDto_ToString() {
+        UserDto userDto = new UserDto(uuid, username, role);
+
+        String expected = "UserDto(uuid=" + uuid + ", username=" + username + ", role=" + role + ")";
+        assertThat(userDto.toString()).isEqualTo(expected);
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
@@ -1,13 +1,20 @@
 package com.itachallenge.challenge.dto;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UserDtoTest {
+
+    private ObjectMapper mapper;
 
     private UUID uuid;
     private String username;
@@ -15,13 +22,15 @@ public class UserDtoTest {
 
     @BeforeEach
     void setUp() {
+        mapper = new ObjectMapper();
         uuid = UUID.randomUUID();
         username = "testUser";
         role = "MENTOR";
     }
 
     @Test
-    void testUserDto_AllArgsConstructor() {
+    @DisplayName("Test UserDto AllArgsConstructor")
+    void testAllArgsConstructor() {
         UserDto userDto = new UserDto(uuid, username, role);
 
         assertThat(userDto.getUuid()).isEqualTo(uuid);
@@ -30,28 +39,31 @@ public class UserDtoTest {
     }
 
     @Test
-    void testUserDto_NoArgsConstructor() {
+    @DisplayName("Test UserDto NoArgsConstructor")
+    void testNoArgsConstructor() {
         UserDto userDto = new UserDto();
 
-        assertThat(userDto.getUuid()).isNull();
-        assertThat(userDto.getUsername()).isNull();
-        assertThat(userDto.getRole()).isNull();
+        assertNull(userDto.getUuid());
+        assertNull(userDto.getUsername());
+        assertNull(userDto.getRole());
     }
 
     @Test
-    void testUserDto_SettersAndGetters() {
+    @DisplayName("Test UserDto Setters and Getters")
+    void testSettersAndGetters() {
         UserDto userDto = new UserDto();
         userDto.setUuid(uuid);
         userDto.setUsername(username);
         userDto.setRole(role);
 
-        assertThat(userDto.getUuid()).isEqualTo(uuid);
-        assertThat(userDto.getUsername()).isEqualTo(username);
-        assertThat(userDto.getRole()).isEqualTo(role);
+        assertEquals(uuid, userDto.getUuid());
+        assertEquals(username, userDto.getUsername());
+        assertEquals(role, userDto.getRole());
     }
 
     @Test
-    void testUserDto_Builder() {
+    @DisplayName("Test UserDto Builder")
+    void testBuilder() {
         UserDto userDto = UserDto.builder()
                 .uuid(uuid)
                 .username(username)
@@ -64,7 +76,8 @@ public class UserDtoTest {
     }
 
     @Test
-    void testUserDto_EqualsAndHashCode() {
+    @DisplayName("Test UserDto Equals and HashCode")
+    void testEqualsAndHashCode() {
         UserDto userDto1 = new UserDto(uuid, username, role);
         UserDto userDto2 = new UserDto(uuid, username, role);
 
@@ -73,10 +86,50 @@ public class UserDtoTest {
     }
 
     @Test
-    void testUserDto_ToString() {
+    @DisplayName("Test UserDto ToString")
+    void testToString() {
         UserDto userDto = new UserDto(uuid, username, role);
 
         String expected = "UserDto(uuid=" + uuid + ", username=" + username + ", role=" + role + ")";
         assertThat(userDto.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Test UserDto Serialization")
+    @SneakyThrows(JsonProcessingException.class)
+    void testSerialization() {
+        UserDto userDto = new UserDto(uuid, username, role);
+
+        String json = mapper.writeValueAsString(userDto);
+
+        assertTrue(json.contains("\"uuid\":\"" + uuid + "\""));
+        assertTrue(json.contains("\"username\":\"" + username + "\""));
+        assertTrue(json.contains("\"role\":\"" + role + "\""));
+    }
+
+    @Test
+    @DisplayName("Test UserDto Deserialization")
+    @SneakyThrows(JsonProcessingException.class)
+    void testDeserialization() {
+        String json = "{\"uuid\":\"" + uuid + "\",\"username\":\"" + username + "\",\"role\":\"" + role + "\"}";
+
+        UserDto userDto = mapper.readValue(json, UserDto.class);
+
+        assertEquals(uuid, userDto.getUuid());
+        assertEquals(username, userDto.getUsername());
+        assertEquals(role, userDto.getRole());
+    }
+
+    @Test
+    @DisplayName("Test UserDto Deserialization with Missing Fields")
+    @SneakyThrows(JsonProcessingException.class)
+    void testDeserializationWithMissingFields() {
+        String json = "{\"username\":\"" + username + "\"}";
+
+        UserDto userDto = mapper.readValue(json, UserDto.class);
+
+        assertNull(userDto.getUuid());
+        assertEquals(username, userDto.getUsername());
+        assertNull(userDto.getRole());
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
@@ -215,4 +215,25 @@ public class UserDtoTest {
         assertEquals(userDto1, userDto2);
         assertNotEquals(userDto1, userDto3);
     }
+
+    @Test
+    @DisplayName("Test Equals and HashCode in UserDto")
+    public void testEqualsAndHashCode() {
+        UserDto userDto1 = new UserDto(uuid, username, role);
+        UserDto userDto2 = new UserDto(uuid, username, role);
+        UserDto userDto3 = new UserDto(UUID.randomUUID(), "otherUser", "ADMIN");
+
+        assert userDto1.equals(userDto2);
+        assert !userDto1.equals(userDto3);
+        assert userDto1.hashCode() == userDto2.hashCode();
+        assert userDto1.hashCode() != userDto3.hashCode();
+    }
+
+    @Test
+    @DisplayName("Test toString Method in UserDto")
+    public void testToStringMethod() {
+        UserDto userDto = new UserDto(uuid, username, role);
+        String expected = "UserDto(uuid=" + uuid + ", username=" + username + ", role=" + role + ")";
+        assert userDto.toString().equals(expected);
+    }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
@@ -170,4 +170,49 @@ public class UserDtoTest {
 
         assertEquals("testValue", userMap.get(userDto));
     }
+
+    @Test
+    @DisplayName("Test Equals and HashCode with Null Object")
+    void testEqualsAndHashCodeWithNull() {
+        UserDto userDto = new UserDto(uuid, username, role);
+        assertNotEquals(userDto, null);
+    }
+
+    @Test
+    @DisplayName("Test Equals and HashCode with Different Class")
+    void testEqualsAndHashCodeWithDifferentClass() {
+        UserDto userDto = new UserDto(uuid, username, role);
+        assertNotEquals(userDto, "Una cadena qualsevol");
+    }
+
+    @Test
+    @DisplayName("Test Equals and HashCode with Null Fields")
+    void testEqualsAndHashCodeWithNullFields() {
+        UserDto userDto1 = new UserDto(null, null, null);
+        UserDto userDto2 = new UserDto(null, null, null);
+
+        assertEquals(userDto1, userDto2);
+        assertEquals(userDto1.hashCode(), userDto2.hashCode());
+    }
+
+    @Test
+    @DisplayName("Test Consistent HashCode")
+    void testConsistentHashCode() {
+        UserDto userDto1 = new UserDto(uuid, username, role);
+        int hashCode1 = userDto1.hashCode();
+        int hashCode2 = userDto1.hashCode();
+
+        assertEquals(hashCode1, hashCode2);
+    }
+
+    @Test
+    @DisplayName("Test Equals with Partially Null Fields")
+    void testEqualsWithPartiallyNullFields() {
+        UserDto userDto1 = new UserDto(uuid, username, null);
+        UserDto userDto2 = new UserDto(uuid, username, null);
+        UserDto userDto3 = new UserDto(uuid, "diferentUsername", null);
+
+        assertEquals(userDto1, userDto2);
+        assertNotEquals(userDto1, userDto3);
+    }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
@@ -76,13 +76,35 @@ public class UserDtoTest {
     }
 
     @Test
-    @DisplayName("Test UserDto Equals and HashCode")
-    void testEqualsAndHashCode() {
+    @DisplayName("Test UserDto Equals and HashCode with Same Object")
+    void testEqualsAndHashCodeSameObject() {
+        UserDto userDto = new UserDto(uuid, username, role);
+
+        assertTrue(userDto.equals(userDto)); // Test mateix objecte
+        assertEquals(userDto.hashCode(), userDto.hashCode());
+    }
+
+    @Test
+    @DisplayName("Test UserDto Equals and HashCode with Different Objects")
+    void testEqualsAndHashCodeDifferentObjects() {
         UserDto userDto1 = new UserDto(uuid, username, role);
         UserDto userDto2 = new UserDto(uuid, username, role);
+        UserDto userDto3 = new UserDto(UUID.randomUUID(), "otherUser", "ADMIN");
 
         assertThat(userDto1).isEqualTo(userDto2);
         assertThat(userDto1.hashCode()).isEqualTo(userDto2.hashCode());
+
+        assertThat(userDto1).isNotEqualTo(userDto3);
+        assertThat(userDto1.hashCode()).isNotEqualTo(userDto3.hashCode());
+    }
+
+    @Test
+    @DisplayName("Test UserDto Equals with Null and Different Class")
+    void testEqualsWithNullAndDifferentClass() {
+        UserDto userDto = new UserDto(uuid, username, role);
+
+        assertNotEquals(null, userDto); // Test amb objecte null
+        assertNotEquals(userDto, "Una cadena"); // Test amb classe diferent
     }
 
     @Test
@@ -130,6 +152,16 @@ public class UserDtoTest {
 
         assertNull(userDto.getUuid());
         assertEquals(username, userDto.getUsername());
+        assertNull(userDto.getRole());
+    }
+
+    @Test
+    @DisplayName("Test UserDto with Null Values")
+    void testUserDtoWithNullValues() {
+        UserDto userDto = new UserDto(null, null, null);
+
+        assertNull(userDto.getUuid());
+        assertNull(userDto.getUsername());
         assertNull(userDto.getRole());
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/UserDtoTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -49,7 +49,7 @@ public class UserDtoTest {
     }
 
     @Test
-    @DisplayName("Test UserDto Setters and Getters")
+    @DisplayName("Test Setters and Getters")
     void testSettersAndGetters() {
         UserDto userDto = new UserDto();
         userDto.setUuid(uuid);
@@ -76,48 +76,47 @@ public class UserDtoTest {
     }
 
     @Test
-    @DisplayName("Test UserDto Equals and HashCode with Same Object")
+    @DisplayName("Test Equals and HashCode with Same Object")
     void testEqualsAndHashCodeSameObject() {
         UserDto userDto = new UserDto(uuid, username, role);
 
-        assertTrue(userDto.equals(userDto)); // Test mateix objecte
+        assertTrue(userDto.equals(userDto)); // Mateix objecte
         assertEquals(userDto.hashCode(), userDto.hashCode());
     }
 
     @Test
-    @DisplayName("Test UserDto Equals and HashCode with Different Objects")
+    @DisplayName("Test Equals and HashCode with Different Objects")
     void testEqualsAndHashCodeDifferentObjects() {
         UserDto userDto1 = new UserDto(uuid, username, role);
         UserDto userDto2 = new UserDto(uuid, username, role);
         UserDto userDto3 = new UserDto(UUID.randomUUID(), "otherUser", "ADMIN");
 
-        assertThat(userDto1).isEqualTo(userDto2);
-        assertThat(userDto1.hashCode()).isEqualTo(userDto2.hashCode());
-
-        assertThat(userDto1).isNotEqualTo(userDto3);
-        assertThat(userDto1.hashCode()).isNotEqualTo(userDto3.hashCode());
+        assertEquals(userDto1, userDto2);
+        assertNotEquals(userDto1, userDto3);
+        assertEquals(userDto1.hashCode(), userDto2.hashCode());
+        assertNotEquals(userDto1.hashCode(), userDto3.hashCode());
     }
 
     @Test
-    @DisplayName("Test UserDto Equals with Null and Different Class")
+    @DisplayName("Test Equals with Null and Different Class")
     void testEqualsWithNullAndDifferentClass() {
         UserDto userDto = new UserDto(uuid, username, role);
 
-        assertNotEquals(null, userDto); // Test amb objecte null
-        assertNotEquals(userDto, "Una cadena"); // Test amb classe diferent
+        assertNotEquals(null, userDto);
+        assertNotEquals(userDto, "Una cadena");
     }
 
     @Test
-    @DisplayName("Test UserDto ToString")
+    @DisplayName("Test ToString")
     void testToString() {
         UserDto userDto = new UserDto(uuid, username, role);
 
         String expected = "UserDto(uuid=" + uuid + ", username=" + username + ", role=" + role + ")";
-        assertThat(userDto.toString()).isEqualTo(expected);
+        assertEquals(expected, userDto.toString());
     }
 
     @Test
-    @DisplayName("Test UserDto Serialization")
+    @DisplayName("Test Serialization")
     @SneakyThrows(JsonProcessingException.class)
     void testSerialization() {
         UserDto userDto = new UserDto(uuid, username, role);
@@ -130,7 +129,7 @@ public class UserDtoTest {
     }
 
     @Test
-    @DisplayName("Test UserDto Deserialization")
+    @DisplayName("Test Deserialization")
     @SneakyThrows(JsonProcessingException.class)
     void testDeserialization() {
         String json = "{\"uuid\":\"" + uuid + "\",\"username\":\"" + username + "\",\"role\":\"" + role + "\"}";
@@ -143,25 +142,32 @@ public class UserDtoTest {
     }
 
     @Test
-    @DisplayName("Test UserDto Deserialization with Missing Fields")
-    @SneakyThrows(JsonProcessingException.class)
-    void testDeserializationWithMissingFields() {
-        String json = "{\"username\":\"" + username + "\"}";
-
-        UserDto userDto = mapper.readValue(json, UserDto.class);
-
-        assertNull(userDto.getUuid());
-        assertEquals(username, userDto.getUsername());
-        assertNull(userDto.getRole());
-    }
-
-    @Test
-    @DisplayName("Test UserDto with Null Values")
-    void testUserDtoWithNullValues() {
+    @DisplayName("Test Null Fields in UserDto")
+    void testNullFields() {
         UserDto userDto = new UserDto(null, null, null);
 
         assertNull(userDto.getUuid());
         assertNull(userDto.getUsername());
         assertNull(userDto.getRole());
+    }
+
+    @Test
+    @DisplayName("Test UserDto in Collection")
+    void testUserDtoInCollection() {
+        UserDto userDto = new UserDto(uuid, username, role);
+        Set<UserDto> userSet = new HashSet<>();
+        userSet.add(userDto);
+
+        assertTrue(userSet.contains(userDto));
+    }
+
+    @Test
+    @DisplayName("Test UserDto in Map Key")
+    void testUserDtoAsMapKey() {
+        UserDto userDto = new UserDto(uuid, username, role);
+        Map<UserDto, String> userMap = new HashMap<>();
+        userMap.put(userDto, "testValue");
+
+        assertEquals("testValue", userMap.get(userDto));
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/helper/ChallengeDocumentToDtoConverterTest.java~
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/helper/ChallengeDocumentToDtoConverterTest.java~
@@ -14,6 +14,20 @@ import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
+import com.itachallenge.challenge.document.*;
+import com.itachallenge.challenge.dto.ChallengeDto;
+import com.itachallenge.challenge.dto.LanguageDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
 
 class ChallengeDocumentToDtoConverterTest {
 
@@ -56,10 +70,17 @@ class ChallengeDocumentToDtoConverterTest {
 
         Topic topic = Topic.DEBUGGING;
         challengeDoc1 = new ChallengeDocument(challengeRandomId1, title, level, localDateTime, detail,
-                Set.of(languageDoc1, languageDoc2), List.of(solutionsRandomId), mentorId, topic);
+<<<<<<< Updated upstream
+                Set.of(languageDoc1, languageDoc2), List.of(solutionsRandomId), topic);
 
         challengeDoc2 = new ChallengeDocument(challengeRandomId2, title, level, localDateTime, detail,
-                Set.of(languageDoc1, languageDoc2), List.of(solutionsRandomId), mentorId, topic);
+                Set.of(languageDoc1, languageDoc2), List.of(solutionsRandomId), topic);
+=======
+                Set.of(languageDoc1, languageDoc2), List.of(solutionsRandomId), mentorId);
+
+        challengeDoc2 = new ChallengeDocument(challengeRandomId2, title, level, localDateTime, detail,
+                Set.of(languageDoc1, languageDoc2), List.of(solutionsRandomId), mentorId);
+>>>>>>> Stashed changes
 
         challengeDto1 = getChallengeDtoMocked(challengeRandomId1, title, level, creationDate, detail,
                 Set.of(languageDto1, languageDto2),

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
@@ -78,10 +78,12 @@ class ChallengeIntegrationTest {
         String title1 = "Loops";
         String title2 = "If";
 
+        UUID mentorId = UUID.randomUUID();
+
         ChallengeDocument challenge = new ChallengeDocument
-                (uuid_1, title1, "Level 1", LocalDateTime.now(), detail, languageSet, solutionList, Topic.LISTS);
+                (uuid_1, title1, "Level 1", LocalDateTime.now(), detail, languageSet, solutionList, mentorId, Topic.LISTS);
         ChallengeDocument challenge2 = new ChallengeDocument
-                (uuid_2, title2, "Level 2", LocalDateTime.now(), detail, languageSet, solutionList, Topic.COMPONENTS);
+                (uuid_2, title2, "Level 2", LocalDateTime.now(), detail, languageSet, solutionList, mentorId, Topic.COMPONENTS);
 
         challengeRepository.saveAll(Flux.just(challenge, challenge2)).blockLast();
     }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ChallengeRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ChallengeRepositoryTest.java
@@ -18,7 +18,6 @@ import reactor.test.StepVerifier;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.Locale;
 
 import static org.junit.Assert.*;
 import static org.springframework.test.util.AssertionErrors.fail;
@@ -69,12 +68,14 @@ class ChallengeRepositoryTest {
         String title2 = "Challenge 2";
         String title3 = "Challenge 3";
 
+        UUID mentorId = UUID.randomUUID();
+
         ChallengeDocument challenge = new ChallengeDocument
-                (uuid_1, title1, "MEDIUM", LocalDateTime.now(), detail, languageSet, solutionList, Topic.DEBUGGING);
+                (uuid_1, title1, "MEDIUM", LocalDateTime.now(), detail, languageSet, solutionList, mentorId, Topic.DEBUGGING);
         ChallengeDocument challenge2 = new ChallengeDocument
-                (uuid_2, title2, "EASY", LocalDateTime.now(), detail, languageSet, solutionList, Topic.LISTS);
+                (uuid_2, title2, "EASY", LocalDateTime.now(), detail, languageSet, solutionList, mentorId, Topic.LISTS);
         ChallengeDocument challenge3 = new ChallengeDocument
-                (uuid_3, title3, "HARD", LocalDateTime.now(), detail, languageSet3, solutionList, Topic.COMPONENTS);
+                (uuid_3, title3, "HARD", LocalDateTime.now(), detail, languageSet3, solutionList, mentorId, Topic.COMPONENTS);
 
         challengeRepository.saveAll(Flux.just(challenge, challenge2, challenge3)).blockLast();
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImpTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImpTest.java
@@ -1,5 +1,6 @@
 package com.itachallenge.challenge.service;
 
+import com.itachallenge.challenge.config.UserClient;
 import com.itachallenge.challenge.document.*;
 import com.itachallenge.challenge.dto.*;
 import com.itachallenge.challenge.enums.DifficultyLevel;
@@ -43,6 +44,9 @@ class ChallengeServiceImpTest {
     @Mock
     private DocumentToDtoConverter<SolutionDocument, SolutionDto> solutionConverter;
 
+    @Mock
+    private UserClient userClient;
+
     @InjectMocks
     private ChallengeServiceImp challengeService;
 
@@ -62,8 +66,9 @@ class ChallengeServiceImpTest {
         String description = "Detall";
         String level = "EASY";
         String solutionBody = "Solution Text";
+        String mentorUsername = "mentorUser";
 
-        formData = new ChallengeCreateDto(title, description, DifficultyLevel.valueOf(level), languageName, solutionBody, Topic.LISTS);
+        formData = new ChallengeCreateDto(title, description, DifficultyLevel.valueOf(level), languageName, solutionBody, mentorUsername, Topic.LISTS);
 
         UUID challengeRandomId = UUID.randomUUID();
         UUID languageRandomId = UUID.randomUUID();
@@ -82,8 +87,10 @@ class ChallengeServiceImpTest {
         languageDocument = new LanguageDocument(languageRandomId, languageName, languageImage);
         LanguageDto languageDto = new LanguageDto(languageRandomId, languageName, languageImage);
 
+        UUID mentorId = UUID.randomUUID();
+
         challengeDocument = new ChallengeDocument(challengeRandomId, title, level, localDateTime, detail,
-                Set.of(ChallengeServiceImpTest.this.languageDocument), List.of(solutionsRandomId), Topic.COMPONENTS);
+                Set.of(ChallengeServiceImpTest.this.languageDocument), List.of(solutionsRandomId), mentorId, Topic.COMPONENTS);
 
         challengeDto = getChallengeDtoMocked(challengeRandomId, title, level, creationDate, detail,
                 Set.of(languageDto),
@@ -510,6 +517,13 @@ class ChallengeServiceImpTest {
 
     @Test
     void addChallenge_test_success() {
+        String mentorUsername = "mentorUser";
+        UUID mentorId = UUID.randomUUID();
+
+        // Simula la resposta del client d'usuari
+        UserDto userDto = new UserDto(mentorId, mentorUsername, "ADMIN");
+        when(userClient.getUserByUsername(eq(mentorUsername))).thenReturn(Mono.just(userDto));
+
         when(languageRepository.findFirstByLanguageName(eq(languageName))).thenReturn(Mono.just(languageDocument)); // Valid language
         when(solutionRepository.save(any(SolutionDocument.class))).thenReturn(Mono.just(solutionDocument));
         when(challengeRepository.save(any(ChallengeDocument.class))).thenReturn(Mono.just(challengeDocument));
@@ -520,6 +534,7 @@ class ChallengeServiceImpTest {
                 .expectNext(challengeDto)
                 .verifyComplete();
 
+        verify(userClient, times(1)).getUserByUsername(eq(mentorUsername));
         verify(languageRepository, times(1)).findFirstByLanguageName(eq(languageName));
         verify(solutionRepository, times(1)).save(any(SolutionDocument.class));
         verify(challengeRepository, times(1)).save(any(ChallengeDocument.class));
@@ -624,6 +639,3 @@ class ChallengeServiceImpTest {
     }
 
 }
-
-
-

--- a/itachallenge-challenge/src/test/resources/application.yml
+++ b/itachallenge-challenge/src/test/resources/application.yml
@@ -53,4 +53,4 @@ messages:
 
 user:
   service:
-    url: http://localhost:8764/itachallenge/api/v1/user
+    url: http://apisix-gateway:9080 # IN PRODUCTION

--- a/itachallenge-challenge/src/test/resources/application.yml
+++ b/itachallenge-challenge/src/test/resources/application.yml
@@ -50,3 +50,7 @@ validation:
 
 messages:
   errorMessage: "Invalid values."
+
+user:
+  service:
+    url: http://localhost:8764/itachallenge/api/v1/user


### PR DESCRIPTION
- When a challenge is created, the frontend will now also send the username of the mentor who created it.

- This will allow us to check if the user exists, if it fulfills the ADMIN role, and retrieve its ID.

- To achieve this, we had to enable communication between the challenge microservice and the user microservice using a WebClient class.

- In this way, each challenge is associated with the mentor who created it using his/her ID.