### PR TITLE
Add bookmark to User - User Microservice

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -119,13 +119,13 @@ public class UserController {
             description = "Adds challenge to user favorites",
             parameters = {
                     @Parameter(
-                            name = "User ID",
+                            name = "userId",
                             description = "User ID",
                             required = true,
                             in = ParameterIn.PATH
                     ),
                     @Parameter(
-                            name = "Challenge ID",
+                            name = "challengeId",
                             description = "Challenge ID",
                             required = true,
                             in = ParameterIn.PATH
@@ -230,13 +230,13 @@ public class UserController {
             description = "Adds challenge to user Bookmarks",
             parameters = {
                     @Parameter(
-                            name = "User ID",
+                            name = "userId",
                             description = "User ID",
                             required = true,
                             in = ParameterIn.PATH
                     ),
                     @Parameter(
-                            name = "Challenge ID",
+                            name = "challengeId",
                             description = "Challenge ID",
                             required = true,
                             in = ParameterIn.PATH
@@ -317,13 +317,13 @@ public class UserController {
             description = "Deletes challenge from user favorites",
             parameters = {
                     @Parameter(
-                            name = "",
+                            name = "userId",
                             description = "User ID",
                             required = true,
                             in = ParameterIn.PATH
                     ),
                     @Parameter(
-                            name = "",
+                            name = "challengeId",
                             description = "Challenge ID",
                             required = true,
                             in = ParameterIn.PATH

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -273,19 +273,19 @@ public class UserController {
 
     @PostMapping("/users/{userId}/bookmarks/{challengeId}")
     public Mono<ResponseEntity<Boolean>> addToBookmarks(@PathVariable String userId, @PathVariable String challengeId) {
-        return userService.addChallengeToFavorites(userId, challengeId)
+        return userService.addChallengeToBookmarks(userId, challengeId)
                 .map(added -> {
                     if (Boolean.TRUE.equals(added)) {
                         log.info("Challenge '{}' added to user '{}' favorites", challengeId, userId);
                         return ResponseEntity.status(HttpStatus.CREATED)
                                 .header(X_BOOKMARK_ADDED, "True")
-                                .header(X_BOOKMARK_MESSAGE, "Challenge added to favorites.")
+                                .header(X_BOOKMARK_MESSAGE, "Challenge added to Bookmarks.")
                                 .body(true);
                     }
                     log.info("User's '{}' bookmarks already contain Challenge '{}'", userId, challengeId);
                     return ResponseEntity.ok()
                             .header(X_BOOKMARK_ADDED, FALSE)
-                            .header(X_BOOKMARK_MESSAGE, "Challenge is already in favorites.")
+                            .header(X_BOOKMARK_MESSAGE, "Challenge is already in Bookmarks.")
                             .body(false);
                 })
                 .onErrorResume(throwable -> {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -35,6 +35,8 @@ public class UserController {
     public static final String X_FAVORITE_DELETED = "X-Favorite-Deleted";
     public static final String X_FAVORITE_MESSAGE = "X-Favorite-Message";
     public static final String X_VALIDATION_STATUS = "X-Validation-Status";
+    public static final String X_BOOKMARK_ADDED = "X-Bookmark-Added";
+    public static final String X_BOOKMARK_MESSAGE = "X-Bookmark-Message";
     public static final String X_ERROR_MESSAGE = "X-Error-Message";
     public static final String X_GITHUB_USERNAME ="X-Github-Username";
     public static final String FALSE = "False";
@@ -223,6 +225,93 @@ public class UserController {
         return Mono.just(ResponseEntity.status(HttpStatus.OK).body(userSolutionResponseDto));
     }
   
+    @Operation(
+            summary = "Add Challenge to User Bookmark Challenges",
+            description = "Adds challenge to user Bookmarks",
+            parameters = {
+                    @Parameter(
+                            name = "User ID",
+                            description = "User ID",
+                            required = true,
+                            in = ParameterIn.PATH
+                    ),
+                    @Parameter(
+                            name = "Challenge ID",
+                            description = "Challenge ID",
+                            required = true,
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Challenge is already in bookmarks",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "Challenge added to bookmarks",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Bad Request. The provided IDs have a bad format",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Not found. No user is found with the provided user id.",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "Internal server error. An unexpected error occurred.",
+                            content = @Content(mediaType = "application/json")
+                    )
+            }
+    )
+
+    @PostMapping("/users/{userId}/bookmarks/{challengeId}")
+    public Mono<ResponseEntity<Boolean>> addToBookmarks(@PathVariable String userId, @PathVariable String challengeId) {
+        return userService.addChallengeToFavorites(userId, challengeId)
+                .map(added -> {
+                    if (Boolean.TRUE.equals(added)) {
+                        log.info("Challenge '{}' added to user '{}' favorites", challengeId, userId);
+                        return ResponseEntity.status(HttpStatus.CREATED)
+                                .header(X_BOOKMARK_ADDED, "True")
+                                .header(X_BOOKMARK_MESSAGE, "Challenge added to favorites.")
+                                .body(true);
+                    }
+                    log.info("User's '{}' bookmarks already contain Challenge '{}'", userId, challengeId);
+                    return ResponseEntity.ok()
+                            .header(X_BOOKMARK_ADDED, FALSE)
+                            .header(X_BOOKMARK_MESSAGE, "Challenge is already in favorites.")
+                            .body(false);
+                })
+                .onErrorResume(throwable -> {
+                    if (throwable instanceof NotFoundException) {
+                        log.warn("No User not found with id: {}", userId);
+                        return Mono.just(ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .header(X_BOOKMARK_ADDED, FALSE)
+                                .header(X_BOOKMARK_MESSAGE, "User not found.")
+                                .body(false));
+                    }
+                    if (throwable instanceof BadUUIDException) {
+                        log.error("The provided IDs are not valid.");
+                        return Mono.just(ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .header(X_BOOKMARK_ADDED, FALSE)
+                                .header(X_BOOKMARK_MESSAGE, "The provided IDs are not valid.")
+                                .body(false));
+                    }
+                    log.error("Unexpected error: {}", throwable.getMessage());
+                    return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                            .header(X_BOOKMARK_ADDED, FALSE)
+                            .header(X_BOOKMARK_MESSAGE, "Unexpected server error.")
+                            .body(false));
+                });
+    }
+
+
     @Operation(
             summary = "Delete Challenge from User Favorite Challenges",
             description = "Deletes challenge from user favorites",

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -276,7 +276,7 @@ public class UserController {
         return userService.addChallengeToBookmarks(userId, challengeId)
                 .map(added -> {
                     if (Boolean.TRUE.equals(added)) {
-                        log.info("Challenge '{}' added to user '{}' favorites", challengeId, userId);
+                        log.info("Challenge '{}' added to user '{}' bookmarks", challengeId, userId);
                         return ResponseEntity.status(HttpStatus.CREATED)
                                 .header(X_BOOKMARK_ADDED, "True")
                                 .header(X_BOOKMARK_MESSAGE, "Challenge added to Bookmarks.")

--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/UserDocument.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/UserDocument.java
@@ -31,6 +31,9 @@ public class UserDocument {
     @Field("favorite_challenges")
     private Set<UUID> favoriteChallenges;
 
+    @Field("bookmark_challenges")
+    private Set<UUID> bookmarkChallenges;
+
     @Override
     public String toString() {
         StringJoiner joiner = new StringJoiner(", ", "UserDocument{", "}");
@@ -47,6 +50,12 @@ public class UserDocument {
         if (favoriteChallenges != null && !favoriteChallenges.isEmpty()) {
             joiner.add("favoriteChallenges='");
             joiner.add(favoriteChallenges.stream()
+                    .map(String::valueOf)
+                    .collect(Collectors.joining(", ")));
+        }
+        if (bookmarkChallenges != null && !bookmarkChallenges.isEmpty()) {
+            joiner.add("bookmarkChallenges='");
+            joiner.add(bookmarkChallenges.stream()
                     .map(String::valueOf)
                     .collect(Collectors.joining(", ")));
         }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
@@ -11,6 +11,8 @@ public interface UserService {
 
     Mono<Boolean> addChallengeToFavorites(String userId, String challengeId);
 
+    Mono<Boolean> addChallengeToBookmarks(String userId, String challengeId);
+
     Mono<Boolean> deleteChallengeFromFavorites(String userId, String challengeId);
 
     Mono<Set<UUID>> getUserFavorites(String userId);

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -87,7 +87,7 @@ public class UserServiceImpl implements UserService {
         boolean added = bookmarks.add(challengeUuid);
 
         if (added) {
-            user.setFavoriteChallenges(bookmarks);
+            user.setBookmarkChallenges(bookmarks);
             return userRepository.save(user).then(Mono.just(true));
         }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -41,6 +41,19 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public Mono<Boolean> addChallengeToBookmarks(String userId, String challengeId) {
+        return Mono.zip(parseAndValidateUUID(userId), parseAndValidateUUID(challengeId))
+                .flatMap(uuidTuple -> {
+                    UUID userUuid = uuidTuple.getT1();
+                    UUID challengeUuid = uuidTuple.getT2();
+
+                    return userRepository.findById(userUuid)
+                            .switchIfEmpty(Mono.error(new NotFoundException("User not found")))
+                            .flatMap(user -> addToBookmarks(user, challengeUuid));
+                });
+    }
+
+    @Override
     public Mono<Boolean> deleteChallengeFromFavorites(String userId, String challengeId) {
         return Mono.zip(parseAndValidateUUID(userId), parseAndValidateUUID(challengeId))
                 .flatMap(uuidTuple -> {
@@ -61,6 +74,20 @@ public class UserServiceImpl implements UserService {
 
         if (added) {
             user.setFavoriteChallenges(favorites);
+            return userRepository.save(user).then(Mono.just(true));
+        }
+
+        return Mono.just(false);
+    }
+
+    private Mono<Boolean> addToBookmarks(UserDocument user, UUID challengeUuid) {
+        Set<UUID> bookmarks = Optional.ofNullable(user.getBookmarkChallenges())
+                .orElseGet(HashSet::new);
+
+        boolean added = bookmarks.add(challengeUuid);
+
+        if (added) {
+            user.setFavoriteChallenges(bookmarks);
             return userRepository.save(user).then(Mono.just(true));
         }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -58,7 +58,7 @@ class UserControllerTest {
     @Test
     void getUser_WhenUserExists_Returns200() {
         String githubUsername = "existingUser";
-        UserDocument expectedUser = new UserDocument(UUID.randomUUID(), githubUsername, Role.ADMIN, null);
+        UserDocument expectedUser = new UserDocument(UUID.randomUUID(), githubUsername, Role.ADMIN, null, null);
         when(userService.getUser(githubUsername)).thenReturn(Mono.just(expectedUser));
 
         webTestClient.get()
@@ -126,6 +126,24 @@ class UserControllerTest {
     }
 
     @Test
+    void addToBookmarks_WhenAdded_Returns201() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(userService.addChallengeToBookmarks(userId, challengeId))
+                .thenReturn(Mono.just(true));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.CREATED)
+                .expectHeader().valueEquals("X-Bookmark-Added", "True")
+                .expectHeader().valueEquals("X-Bookmark-Message", "Challenge added to Bookmarks.")
+                .expectBody(Boolean.class).isEqualTo(true);
+
+        verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
+    }
+
+    @Test
     void addToFavorites_WhenAlreadyInFavorites_Returns200() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
@@ -141,6 +159,24 @@ class UserControllerTest {
                 .expectBody(Boolean.class).isEqualTo(false);
 
         verify(userService, times(1)).addChallengeToFavorites(userId, challengeId);
+    }
+
+    @Test
+    void addToBookmarks_WhenAlreadyInBookmarks_Returns200() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(userService.addChallengeToBookmarks(userId, challengeId))
+                .thenReturn(Mono.just(false));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.OK)
+                .expectHeader().valueEquals("X-Bookmark-Added", "False")
+                .expectHeader().valueEquals("X-Bookmark-Message", "Challenge is already in Bookmarks.")
+                .expectBody(Boolean.class).isEqualTo(false);
+
+        verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }
 
     @Test
@@ -162,6 +198,24 @@ class UserControllerTest {
     }
 
     @Test
+    void addToBookmarks_WhenUserNotExists_Returns404() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(userService.addChallengeToBookmarks(userId, challengeId))
+                .thenReturn(Mono.error(new NotFoundException("User not found")));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
+                .expectHeader().valueEquals("X-Bookmark-Added", "False")
+                .expectHeader().valueEquals("X-Bookmark-Message", "User not found.")
+                .expectBody(Boolean.class).isEqualTo(false);
+
+        verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
+    }
+
+    @Test
     void addToFavorites_WhenBadFormattedId_Returns404() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
@@ -180,6 +234,24 @@ class UserControllerTest {
     }
 
     @Test
+    void addToBookmarks_WhenBadFormattedId_Returns404() {
+        String userId = "invalidUuid";
+        String challengeId = "invalidUUid";
+        when(userService.addChallengeToBookmarks(userId, challengeId))
+                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+                .expectHeader().valueEquals("X-Bookmark-Added", "False")
+                .expectHeader().valueEquals("X-Bookmark-Message", "The provided IDs are not valid.")
+                .expectBody(Boolean.class).isEqualTo(false);
+
+        verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
+    }
+
+    @Test
     void addToFavorites_WhenUnexpectedError_Returns500() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
@@ -195,6 +267,24 @@ class UserControllerTest {
                 .expectBody(Boolean.class).isEqualTo(false);
 
         verify(userService, times(1)).addChallengeToFavorites(userId, challengeId);
+    }
+
+    @Test
+    void addToBookmarks_WhenUnexpectedError_Returns500() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(userService.addChallengeToBookmarks(userId, challengeId))
+                .thenReturn(Mono.error(new Exception()));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                .expectHeader().valueEquals("X-Bookmark-Added", "False")
+                .expectHeader().valueEquals("X-Bookmark-Message", "Unexpected server error.")
+                .expectBody(Boolean.class).isEqualTo(false);
+
+        verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -216,7 +216,7 @@ class UserControllerTest {
     }
 
     @Test
-    void addToFavorites_WhenBadFormattedId_Returns404() {
+    void addToFavorites_WhenBadFormattedId_Returns400() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.addChallengeToFavorites(userId, challengeId))
@@ -234,7 +234,7 @@ class UserControllerTest {
     }
 
     @Test
-    void addToBookmarks_WhenBadFormattedId_Returns404() {
+    void addToBookmarks_WhenBadFormattedId_Returns400() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.addChallengeToBookmarks(userId, challengeId))

--- a/itachallenge-user/src/test/java/com/itachallenge/user/document/UserDocumentTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/document/UserDocumentTest.java
@@ -15,6 +15,7 @@ class UserDocumentTest {
     private Role role;
     private UserDocument userDocument;
     private Set<UUID> favoriteChallenges;
+    private Set<UUID> bookmarkChallenges;
     private UUID favoriteChallenge;
 
     @BeforeEach
@@ -40,6 +41,7 @@ class UserDocumentTest {
         assertEquals(username, userDocument.getUsername());
         assertEquals(role, userDocument.getRole());
         assertEquals(favoriteChallenges, userDocument.getFavoriteChallenges());
+        assertEquals(bookmarkChallenges, userDocument.getBookmarkChallenges());
     }
 
     @Test
@@ -48,16 +50,19 @@ class UserDocumentTest {
         String newUsername = "newUser";
         Role newRole = Role.USER;
         Set<UUID> newFavoriteChallenges = Set.of(UUID.randomUUID());
+        Set<UUID> newBookmarkChallenges = Set.of(UUID.randomUUID());
 
         userDocument.setUuid(newUuid);
         userDocument.setUsername(newUsername);
         userDocument.setRole(newRole);
         userDocument.setFavoriteChallenges(newFavoriteChallenges);
+        userDocument.setBookmarkChallenges(newBookmarkChallenges);
 
         assertEquals(newUuid, userDocument.getUuid());
         assertEquals(newUsername, userDocument.getUsername());
         assertEquals(newRole, userDocument.getRole());
         assertEquals(newFavoriteChallenges, userDocument.getFavoriteChallenges());
+        assertEquals(newBookmarkChallenges, userDocument.getBookmarkChallenges());
     }
 
     @Test
@@ -67,6 +72,7 @@ class UserDocumentTest {
                 .username(username)
                 .role(role)
                 .favoriteChallenges(favoriteChallenges)
+                .bookmarkChallenges(bookmarkChallenges)
                 .build();
 
         assertNotNull(user);
@@ -74,6 +80,7 @@ class UserDocumentTest {
         assertEquals(username, user.getUsername());
         assertEquals(role, user.getRole());
         assertEquals(favoriteChallenges, user.getFavoriteChallenges());
+        assertEquals(bookmarkChallenges, user.getBookmarkChallenges());
     }
 
     @Test
@@ -84,22 +91,24 @@ class UserDocumentTest {
         assertNull(emptyUser.getUsername());
         assertNull(emptyUser.getRole());
         assertNull(emptyUser.getFavoriteChallenges());
+        assertNull(emptyUser.getBookmarkChallenges());
     }
 
     @Test
     void allArgsConstructor() {
-        UserDocument user = new UserDocument(uuid, username, role, favoriteChallenges);
+        UserDocument user = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
         assertNotNull(user);
         assertEquals(uuid, user.getUuid());
         assertEquals(username, user.getUsername());
         assertEquals(role, user.getRole());
         assertEquals(favoriteChallenges, user.getFavoriteChallenges());
+        assertEquals(bookmarkChallenges, user.getBookmarkChallenges());
     }
 
     @Test
     void equalsAndHashCode() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges);
+        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
 
         assertEquals(user1, user2);
         assertEquals(user1.hashCode(), user2.hashCode());
@@ -116,6 +125,7 @@ class UserDocumentTest {
         assertTrue(toString.contains(username), "ToString should contain username");
         assertTrue(toString.contains(role.toString()), "ToString should contain role");
         assertTrue(toString.contains(favoriteChallenge.toString()), "ToString should contain favorite challenge");
+        assertTrue(toString.contains(bookmarkChallenges.toString()), "ToString should contain bookmark challenge");
     }
 
     @Test
@@ -130,7 +140,7 @@ class UserDocumentTest {
 
     @Test
     void equalsAndHashCodeWithDifferentUUIDs() {
-        UserDocument differentUser = new UserDocument(UUID.randomUUID(), username, role, favoriteChallenges);
+        UserDocument differentUser = new UserDocument(UUID.randomUUID(), username, role, favoriteChallenges, bookmarkChallenges);
 
         assertNotEquals(userDocument, differentUser);
         assertNotEquals(userDocument.hashCode(), differentUser.hashCode());
@@ -138,7 +148,7 @@ class UserDocumentTest {
 
     @Test
     void equalsAndHashCodeWithDifferentUsernames() {
-        UserDocument sameUuidDifferentUsername = new UserDocument(uuid, "differentUser", Role.USER, favoriteChallenges);
+        UserDocument sameUuidDifferentUsername = new UserDocument(uuid, "differentUser", Role.USER, favoriteChallenges, bookmarkChallenges);
 
         assertNotEquals(userDocument, sameUuidDifferentUsername);
         assertNotEquals(userDocument.hashCode(), sameUuidDifferentUsername.hashCode());
@@ -146,22 +156,25 @@ class UserDocumentTest {
 
     @Test
     void equalsAndHashCodeWithNullFields() {
-        UserDocument userWithNullUuid = new UserDocument(null, username, role, favoriteChallenges);
-        UserDocument userWithNullUsername = new UserDocument(uuid, null, role, favoriteChallenges);
-        UserDocument userWithNullRole = new UserDocument(uuid, username, null, favoriteChallenges);
-        UserDocument userWithNullFavoriteChallenges = new UserDocument(uuid, username, role, null);
-        UserDocument completelyNullUser = new UserDocument(null, null, null, null);
+        UserDocument userWithNullUuid = new UserDocument(null, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument userWithNullUsername = new UserDocument(uuid, null, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument userWithNullRole = new UserDocument(uuid, username, null, favoriteChallenges, bookmarkChallenges);
+        UserDocument userWithNullFavoriteChallenges = new UserDocument(uuid, username, role, null, bookmarkChallenges);
+        UserDocument userWithNullBookmarkChallenges = new UserDocument(uuid, username, role, favoriteChallenges, null);
+        UserDocument completelyNullUser = new UserDocument(null, null, null, null, null);
 
         assertNotEquals(userDocument, userWithNullUuid);
         assertNotEquals(userDocument, userWithNullUsername);
         assertNotEquals(userDocument, userWithNullRole);
         assertNotEquals(userDocument, userWithNullFavoriteChallenges);
+        assertNotEquals(userDocument, userWithNullBookmarkChallenges);
         assertNotEquals(userDocument, completelyNullUser);
 
         assertNotEquals(userDocument.hashCode(), userWithNullUuid.hashCode());
         assertNotEquals(userDocument.hashCode(), userWithNullUsername.hashCode());
         assertNotEquals(userDocument.hashCode(), userWithNullRole.hashCode());
         assertNotEquals(userDocument.hashCode(), userWithNullFavoriteChallenges.hashCode());
+        assertNotEquals(userDocument.hashCode(), userWithNullBookmarkChallenges.hashCode());
         assertNotEquals(userDocument.hashCode(), completelyNullUser.hashCode());
     }
 
@@ -178,8 +191,8 @@ class UserDocumentTest {
 
     @Test
     void equalsConsistencyTest() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges);
+        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
 
         assertEquals(user1, user2);
         assertEquals(user1, user2); // Repeated check for consistency
@@ -193,9 +206,9 @@ class UserDocumentTest {
 
     @Test
     void equalsTransitivityTest() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges);
-        UserDocument user3 = new UserDocument(uuid, username, role, favoriteChallenges);
+        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user3 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
 
         assertEquals(user1, user2);
         assertEquals(user2, user3);
@@ -204,8 +217,8 @@ class UserDocumentTest {
 
     @Test
     void equalsSymmetryTest() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges);
+        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
 
         assertEquals(user1, user2);
         assertEquals(user2, user1);
@@ -213,24 +226,24 @@ class UserDocumentTest {
 
     @Test
     void hashCodeEqualityForEqualObjects() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges);
+        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
 
         assertEquals(user1.hashCode(), user2.hashCode());
     }
 
     @Test
     void hashCodeDifferenceForNonEqualObjects() {
-        UserDocument user1 = new UserDocument(UUID.randomUUID(), "user1", Role.ADMIN, favoriteChallenges);
-        UserDocument user2 = new UserDocument(UUID.randomUUID(), "user2", Role.ADMIN, favoriteChallenges);
+        UserDocument user1 = new UserDocument(UUID.randomUUID(), "user1", Role.ADMIN, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(UUID.randomUUID(), "user2", Role.ADMIN, favoriteChallenges, bookmarkChallenges);
 
         assertNotEquals(user1.hashCode(), user2.hashCode());
     }
 
     @Test
     void equalsWithNullAttributes() {
-        UserDocument user1 = new UserDocument(null, null, null, null);
-        UserDocument user2 = new UserDocument(null, null, null, null);
+        UserDocument user1 = new UserDocument(null, null, null, null, null);
+        UserDocument user2 = new UserDocument(null, null, null, null, null);
 
         assertEquals(user1, user2);
         assertEquals(user1.hashCode(), user2.hashCode());
@@ -238,8 +251,8 @@ class UserDocumentTest {
 
     @Test
     void equalsWithOneNullUuid() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges);
-        UserDocument user2 = new UserDocument(null, username, role, favoriteChallenges);
+        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(null, username, role, favoriteChallenges, bookmarkChallenges);
 
         assertNotEquals(user1, user2);
         assertNotEquals(user1.hashCode(), user2.hashCode());
@@ -247,8 +260,8 @@ class UserDocumentTest {
 
     @Test
     void equalsWithOneNullUsername() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges);
-        UserDocument user2 = new UserDocument(uuid, null, role, favoriteChallenges);
+        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(uuid, null, role, favoriteChallenges, bookmarkChallenges);
 
         assertNotEquals(user1, user2);
         assertNotEquals(user1.hashCode(), user2.hashCode());
@@ -256,8 +269,8 @@ class UserDocumentTest {
 
     @Test
     void equalsWithOneNullRole() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges);
-        UserDocument user2 = new UserDocument(uuid, username, null, favoriteChallenges);
+        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(uuid, username, null, favoriteChallenges, bookmarkChallenges);
 
         assertNotEquals(user1, user2);
         assertNotEquals(user1.hashCode(), user2.hashCode());
@@ -265,17 +278,25 @@ class UserDocumentTest {
 
     @Test
     void equalsWithOneNullFavoriteChallenges() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges);
-        UserDocument user2 = new UserDocument(uuid, username, role, null);
+        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(uuid, username, role, null, bookmarkChallenges);
 
         assertNotEquals(user1, user2);
         assertNotEquals(user1.hashCode(), user2.hashCode());
     }
 
+    @Test
+    void equalsWithOneNullBookmarkChallenges() {
+        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, null);
+
+        assertNotEquals(user1, user2);
+        assertNotEquals(user1.hashCode(), user2.hashCode());
+    }
 
     @Test
     void toStringHandlesNullValues() {
-        UserDocument user = new UserDocument(null, null, null, null);
+        UserDocument user = new UserDocument(null, null, null, null, null);
         String toString = user.toString();
 
         assertTrue(toString.contains("UserDocument"), "ToString should contain class name");
@@ -283,6 +304,7 @@ class UserDocumentTest {
         assertFalse(toString.contains("username="), "ToString should not contain 'username=' when null");
         assertFalse(toString.contains("role="), "ToString should not contain 'role=' when null");
         assertFalse(toString.contains("favoriteChallenges="), "ToString should not contain 'favoriteChallenges=' when null");
+        assertFalse(toString.contains("bookmarkChallenges="), "ToString should not contain 'bookmarkChallenges=' when null");
         assertEquals("UserDocument{}", toString, "ToString should return an empty object representation");
     }
 
@@ -294,6 +316,7 @@ class UserDocumentTest {
                 .username(null)
                 .role(null)
                 .favoriteChallenges(null)
+                .bookmarkChallenges(null)
                 .build();
 
         assertNotNull(user);
@@ -301,6 +324,7 @@ class UserDocumentTest {
         assertNull(user.getUsername());
         assertNull(user.getRole());
         assertNull(user.getFavoriteChallenges());
+        assertNull(user.getBookmarkChallenges());
     }
 
     @Test
@@ -309,17 +333,19 @@ class UserDocumentTest {
         userDocument.setUsername(null);
         userDocument.setRole(null);
         userDocument.setFavoriteChallenges(null);
+        userDocument.setBookmarkChallenges(null);
 
         assertNull(userDocument.getUuid());
         assertNull(userDocument.getUsername());
         assertNull(userDocument.getRole());
         assertNull(userDocument.getFavoriteChallenges());
+        assertNull(userDocument.getBookmarkChallenges());
     }
 
     @Test
     void hashCodeDifferentForDifferentObjects() {
-        UserDocument user1 = new UserDocument(UUID.randomUUID(), "UserA", Role.ADMIN, favoriteChallenges);
-        UserDocument user2 = new UserDocument(UUID.randomUUID(), "UserB", Role.ADMIN, favoriteChallenges);
+        UserDocument user1 = new UserDocument(UUID.randomUUID(), "UserA", Role.ADMIN, favoriteChallenges, bookmarkChallenges);
+        UserDocument user2 = new UserDocument(UUID.randomUUID(), "UserB", Role.ADMIN, favoriteChallenges, bookmarkChallenges);
 
         assertNotEquals(user1.hashCode(), user2.hashCode());
     }
@@ -374,11 +400,29 @@ class UserDocumentTest {
     }
 
     @Test
+    void builderHandlesOnlyBookmarkChallenges() {
+        UserDocument user = UserDocument.builder()
+                .favoriteChallenges(bookmarkChallenges)
+                .build();
+
+        assertNotNull(user);
+        assertNull(user.getUuid());
+        assertNull(user.getUsername());
+        assertNull(user.getRole());
+        assertEquals(bookmarkChallenges, user.getBookmarkChallenges());
+    }
+
+    @Test
     void builderCreatesNewInstances() {
         UserDocument user1 = UserDocument.builder().uuid(uuid).username(username).role(role)
-                .favoriteChallenges(favoriteChallenges).build();
+                .favoriteChallenges(favoriteChallenges)
+                .bookmarkChallenges(bookmarkChallenges)
+                .build();
+
         UserDocument user2 = UserDocument.builder().uuid(uuid).username(username).role(role)
-                .favoriteChallenges(favoriteChallenges).build();
+                .favoriteChallenges(favoriteChallenges)
+                .bookmarkChallenges(bookmarkChallenges)
+                .build();
 
         assertNotSame(user1, user2);
         assertEquals(user1, user2);
@@ -393,22 +437,27 @@ class UserDocumentTest {
         assertNull(user.getUsername());
         assertNull(user.getRole());
         assertNull(user.getFavoriteChallenges());
+        assertNull(user.getBookmarkChallenges());
     }
 
     @Test
     void modifyingBuiltObjectDoesNotAffectOriginalBuilder() {
         UserDocument.UserDocumentBuilder builder = UserDocument.builder().uuid(uuid).username(username).role(role)
-                .favoriteChallenges(favoriteChallenges);
+                .favoriteChallenges(favoriteChallenges)
+                .bookmarkChallenges(bookmarkChallenges);
 
         UserDocument user1 = builder.build();
         UserDocument user2 = builder.uuid(UUID.randomUUID()).username("newUser").role(Role.USER)
-                .favoriteChallenges(new HashSet<>()).build();
+                .favoriteChallenges(new HashSet<>())
+                .bookmarkChallenges(new HashSet<>())
+                .build();
 
         assertNotEquals(user1, user2);
         assertNotEquals(user1.getUuid(), user2.getUuid());
         assertNotEquals(user1.getUsername(), user2.getUsername());
         assertNotEquals(user1.getRole(), user2.getRole());
         assertNotEquals(user1.getFavoriteChallenges(), user2.getFavoriteChallenges());
+        assertNotEquals(user1.getBookmarkChallenges(), user2.getBookmarkChallenges());
     }
 
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/document/UserDocumentTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/document/UserDocumentTest.java
@@ -17,6 +17,7 @@ class UserDocumentTest {
     private Set<UUID> favoriteChallenges;
     private Set<UUID> bookmarkChallenges;
     private UUID favoriteChallenge;
+    private UUID bookmarkChallenge;
 
     @BeforeEach
     void setUp() {
@@ -26,11 +27,15 @@ class UserDocumentTest {
         favoriteChallenges = new HashSet<>();
         favoriteChallenge = UUID.randomUUID();
         favoriteChallenges.add(favoriteChallenge);
+        bookmarkChallenges = new HashSet<>();
+        bookmarkChallenge = UUID.randomUUID();
+        bookmarkChallenges.add(bookmarkChallenge);
         userDocument = UserDocument.builder()
                 .uuid(uuid)
                 .username(username)
                 .role(role)
                 .favoriteChallenges(favoriteChallenges)
+                .bookmarkChallenges(bookmarkChallenges)
                 .build();
     }
 
@@ -125,7 +130,7 @@ class UserDocumentTest {
         assertTrue(toString.contains(username), "ToString should contain username");
         assertTrue(toString.contains(role.toString()), "ToString should contain role");
         assertTrue(toString.contains(favoriteChallenge.toString()), "ToString should contain favorite challenge");
-        assertTrue(toString.contains(bookmarkChallenges.toString()), "ToString should contain bookmark challenge");
+        assertTrue(toString.contains(bookmarkChallenge.toString()), "ToString should contain bookmark challenge");
     }
 
     @Test
@@ -402,7 +407,7 @@ class UserDocumentTest {
     @Test
     void builderHandlesOnlyBookmarkChallenges() {
         UserDocument user = UserDocument.builder()
-                .favoriteChallenges(bookmarkChallenges)
+                .bookmarkChallenges(bookmarkChallenges)
                 .build();
 
         assertNotNull(user);

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -47,7 +47,7 @@ class UserServiceImplTest {
     @Test
     void getUser_ShouldReturnUser_WhenUserExists() {
         String username = "existingUser";
-        UserDocument existingUser = new UserDocument(UUID.randomUUID(), username, Role.ADMIN, null);
+        UserDocument existingUser = new UserDocument(UUID.randomUUID(), username, Role.ADMIN, null, null);
         when(userRepository.findByUsername(username)).thenReturn(Mono.just(existingUser));
 
         StepVerifier.create(userService.getUser(username))
@@ -73,7 +73,7 @@ class UserServiceImplTest {
     void addChallengeToFavorites_ShouldReturnTrue_WhenFavoritesIsNull() {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, null);
+        UserDocument user = new UserDocument(userId, "testUser", null, null, null);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(userRepository.save(user)).thenReturn(Mono.just(user));
@@ -90,10 +90,30 @@ class UserServiceImplTest {
     }
 
     @Test
+    void addChallengeToBookmarks_ShouldReturnTrue_WhenBookmarksIsNull() {
+        UUID challengeId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument(userId, "testUser", null, null, null);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(userRepository.save(user)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addChallengeToBookmarks(userId.toString(), challengeId.toString()))
+                .expectNext(true)
+                .verifyComplete();
+
+        assertNotNull(user.getBookmarkChallenges());
+        assertTrue(user.getBookmarkChallenges().contains(challengeId));
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).save(user);
+    }
+
+    @Test
     void addChallengeToFavorites_ShouldReturnTrue_WhenFavoritesIsEmpty() {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, new HashSet<>());
+        UserDocument user = new UserDocument(userId, "testUser", null, new HashSet<>(), null);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(userRepository.save(user)).thenReturn(Mono.just(user));
@@ -104,6 +124,26 @@ class UserServiceImplTest {
 
         assertNotNull(user.getFavoriteChallenges());
         assertTrue(user.getFavoriteChallenges().contains(challengeId));
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).save(user);
+    }
+
+    @Test
+    void addChallengeToBookmarks_ShouldReturnTrue_WhenBookmarksIsEmpty() {
+        UUID challengeId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument(userId, "testUser", null, null, new HashSet<>());
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(userRepository.save(user)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addChallengeToBookmarks(userId.toString(), challengeId.toString()))
+                .expectNext(true)
+                .verifyComplete();
+
+        assertNotNull(user.getBookmarkChallenges());
+        assertTrue(user.getBookmarkChallenges().contains(challengeId));
 
         verify(userRepository, times(1)).findById(userId);
         verify(userRepository, times(1)).save(user);
@@ -114,7 +154,7 @@ class UserServiceImplTest {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Set<UUID> favorites = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID()));
-        UserDocument user = new UserDocument(userId, "testUser", null, favorites);
+        UserDocument user = new UserDocument(userId, "testUser", null, favorites, null);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(userRepository.save(user)).thenReturn(Mono.just(user));
@@ -131,11 +171,32 @@ class UserServiceImplTest {
     }
 
     @Test
+    void addChallengeToBookmarks_ShouldReturnTrue_WhenBookmarksHasValues() {
+        UUID challengeId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        Set<UUID> bookmarks = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID()));
+        UserDocument user = new UserDocument(userId, "testUser", null, null, bookmarks);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(userRepository.save(user)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addChallengeToBookmarks(userId.toString(), challengeId.toString()))
+                .expectNext(true)
+                .verifyComplete();
+
+        assertNotNull(user.getBookmarkChallenges());
+        assertTrue(user.getBookmarkChallenges().contains(challengeId));
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).save(user);
+    }
+
+    @Test
     void addChallengeToFavorites_ShouldReturnFalse_WhenFavoritesAlreadyContainsChallenge() {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Set<UUID> favorites = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID(), challengeId));
-        UserDocument user = new UserDocument(userId, "testUser", null, favorites);
+        UserDocument user = new UserDocument(userId, "testUser", null, favorites, null);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
 
@@ -151,11 +212,47 @@ class UserServiceImplTest {
     }
 
     @Test
+    void addChallengeToBookmarks_ShouldReturnFalse_WhenBookmarksAlreadyContainsChallenge() {
+        UUID challengeId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        Set<UUID> bookmarks = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID(), challengeId));
+        UserDocument user = new UserDocument(userId, "testUser", null, null, bookmarks);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addChallengeToBookmarks(userId.toString(), challengeId.toString()))
+                .expectNext(false)
+                .verifyComplete();
+
+        assertNotNull(user.getBookmarkChallenges());
+        assertTrue(user.getBookmarkChallenges().contains(challengeId));
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
     void addChallengeToFavorites_ShouldThrowNotFoundException_WhenUserNotFound() {
 
         when(userRepository.findById(any(UUID.class))).thenReturn(Mono.empty());
 
         StepVerifier.create(userService.addChallengeToFavorites(UUID.randomUUID().toString(), UUID.randomUUID().toString()))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(NotFoundException.class, throwable);
+                    assertEquals("User not found", throwable.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(1)).findById(any(UUID.class));
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    void addChallengeToBookmarks_ShouldThrowNotFoundException_WhenUserNotFound() {
+
+        when(userRepository.findById(any(UUID.class))).thenReturn(Mono.empty());
+
+        StepVerifier.create(userService.addChallengeToBookmarks(UUID.randomUUID().toString(), UUID.randomUUID().toString()))
                 .expectErrorSatisfies(throwable -> {
                     assertInstanceOf(NotFoundException.class, throwable);
                     assertEquals("User not found", throwable.getMessage());
@@ -180,8 +277,34 @@ class UserServiceImplTest {
     }
 
     @Test
+    void addChallengeToBookmarks_ShouldThrowBadRequestException_WhenUserUuidIsNull() {
+        StepVerifier.create(userService.addChallengeToBookmarks(null, UUID.randomUUID().toString()))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadUUIDException.class, throwable);
+                    assertEquals("Invalid ID format", throwable.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(0)).findById(any(UUID.class));
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
     void addChallengeToFavorites_ShouldThrowBadRequestException_WhenChallengeUuidIsNull() {
         StepVerifier.create(userService.addChallengeToFavorites(UUID.randomUUID().toString(), null))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadUUIDException.class, throwable);
+                    assertEquals("Invalid ID format", throwable.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(0)).findById(any(UUID.class));
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    void addChallengeToBookmarks_ShouldThrowBadRequestException_WhenChallengeUuidIsNull() {
+        StepVerifier.create(userService.addChallengeToBookmarks(UUID.randomUUID().toString(), null))
                 .expectErrorSatisfies(throwable -> {
                     assertInstanceOf(BadUUIDException.class, throwable);
                     assertEquals("Invalid ID format", throwable.getMessage());
@@ -206,8 +329,34 @@ class UserServiceImplTest {
     }
 
     @Test
+    void addChallengeToBookmarks_ShouldThrowBadRequestException_WhenUserUuidIsNotValid() {
+        StepVerifier.create(userService.addChallengeToBookmarks("invalidUuid", UUID.randomUUID().toString()))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadUUIDException.class, throwable);
+                    assertEquals("Invalid ID format", throwable.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(0)).findById(any(UUID.class));
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
     void addChallengeToFavorites_ShouldThrowBadRequestException_WhenChallengeUuidIsNotValid() {
         StepVerifier.create(userService.addChallengeToFavorites(UUID.randomUUID().toString(), "invalidUuid"))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadUUIDException.class, throwable);
+                    assertEquals("Invalid ID format", throwable.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(0)).findById(any(UUID.class));
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    void addChallengeToBookmarks_ShouldThrowBadRequestException_WhenChallengeUuidIsNotValid() {
+        StepVerifier.create(userService.addChallengeToBookmarks(UUID.randomUUID().toString(), "invalidUuid"))
                 .expectErrorSatisfies(throwable -> {
                     assertInstanceOf(BadUUIDException.class, throwable);
                     assertEquals("Invalid ID format", throwable.getMessage());
@@ -222,7 +371,7 @@ class UserServiceImplTest {
     void deleteChallengeFromFavorites_ShouldReturnFalse_WhenFavoritesIsNull() {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, null);
+        UserDocument user = new UserDocument(userId, "testUser", null, null, null);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
 
@@ -240,7 +389,7 @@ class UserServiceImplTest {
     void deleteChallengeFromFavorites_ShouldReturnFalse_WhenFavoritesIsEmpty() {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, new HashSet<>());
+        UserDocument user = new UserDocument(userId, "testUser", null, new HashSet<>(), null);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
 
@@ -260,7 +409,7 @@ class UserServiceImplTest {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Set<UUID> favorites = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID()));
-        UserDocument user = new UserDocument(userId, "testUser", null, favorites);
+        UserDocument user = new UserDocument(userId, "testUser", null, favorites, null);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
 
@@ -280,7 +429,7 @@ class UserServiceImplTest {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Set<UUID> favorites = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID(), challengeId));
-        UserDocument user = new UserDocument(userId, "testUser", null, favorites);
+        UserDocument user = new UserDocument(userId, "testUser", null, favorites, null);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(userRepository.save(user)).thenReturn(Mono.just(user));


### PR DESCRIPTION
Implemented "A User can add a bookmark" functionality in the User Microservice, through a new endpoint (addToBookmarks).

Opted for mimicking the addToFavorite behaviour for better consistency and discarded the option of restoring the former deleted addBookmarks endpoint since addToFavorite is more completed and up to date with our current goals and restoring the former endpoint could create some discrepancy in behaviour between these two entites. 

Created a new set of tests for testing bookmark functionality and modified the ones that needed to too.

Left to do in the future:
Parametrized tests (so we could unify both Favorite and Bookmark test batches into a single one).