### PR TITLE
Create mocked endpoint update Challenge in ChallengeController and test

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package com.itachallenge.challenge.controller;
 
 import com.itachallenge.challenge.annotations.ValidGenericPattern;
 import com.itachallenge.challenge.config.PropertiesConfig;
+import com.itachallenge.challenge.document.DetailDocument;
 import com.itachallenge.challenge.dto.*;
 import com.itachallenge.challenge.exception.BadRequestException;
 import com.itachallenge.challenge.exception.JwtException;
@@ -23,6 +24,8 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 @RestController
@@ -345,5 +348,45 @@ public class ChallengeController {
     )
     public Mono<GenericResultDto<TagDto>> getAllTags() {
         return tagService.getAllTags();
+    }
+
+    @PutMapping("/challenge/{challengeId}/update")
+    @Operation(
+            operationId = "Updates an existing challenge.",
+            summary = "Updates information of a challenge.",
+            description = "Allows to update any information contained in a challenge, providing ChallengeId and new information.",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = ChallengeDto.class), mediaType = "application/json")}),
+                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
+                    @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error")
+            }
+    )
+    public Mono<ResponseEntity<ChallengeDto>> updateChallenge(
+            @PathVariable String challengeId, @Valid @RequestBody ChallengeCreateDto challengeFormDto){
+
+        final DateTimeFormatter CUSTOM_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDateTime localTime = LocalDateTime.now();
+        DetailDocument detail = new DetailDocument(challengeFormDto.getDescription());
+        LanguageDto languageDto = new LanguageDto(UUID.randomUUID(), challengeFormDto.getLanguage(), null);
+        languageDto.setLanguageImage("");
+        String solutionId = "d624bae4-9a43-4515-8979-801c0d6fd88c";
+
+        ChallengeDto challengeDto = new ChallengeDto();
+        challengeDto.setChallengeId(UUID.fromString(challengeId));
+        challengeDto.setTitle(challengeFormDto.getChallengeTitle());
+        challengeDto.setLevel(challengeFormDto.getLevel() != null ?
+                String.valueOf(challengeFormDto.getLevel()) : "");
+        challengeDto.setCreationDate(localTime.format(CUSTOM_FORMATTER));
+        challengeDto.setDetail(detail);
+        challengeDto.setPopularity(10);
+        challengeDto.setPercentage(0.5F);
+        challengeDto.setLanguages(Set.of(languageDto));
+        challengeDto.setSolutions(List.of(UUID.fromString(solutionId)));
+        challengeDto.setTopic(challengeFormDto.getTopic());
+        challengeDto.setTimesFavorite(10);
+        challengeDto.setTimesBookmark(10);
+
+        return Mono.just(ResponseEntity.ok(challengeDto));
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -906,7 +906,7 @@ class ChallengeControllerTest {
                 .build();
 
         webTestClient.put()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/update")
+                .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(challengeCreateDto)
                 .exchange()
@@ -939,7 +939,7 @@ class ChallengeControllerTest {
                 .build();
 
         webTestClient.put()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/update")
+                .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(challengeCreateDto)
                 .exchange()

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -27,6 +27,8 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -58,6 +60,20 @@ class ChallengeControllerTest {
 
     @MockBean
     private JwtService jwtService;
+
+    UUID challengeId = UUID.randomUUID();
+    String challengeTitle = "Challenge modificat";
+    String level = "EASY";
+    String description = "Here are the details of the challenge.";
+    DetailDocument detail = new DetailDocument(description);
+    String language = "Java";
+    LanguageDto languageDto = new LanguageDto(UUID.randomUUID(), language, "https://default-image.com/default.png");
+    UUID solutionUuid = UUID.fromString("d624bae4-9a43-4515-8979-801c0d6fd88c");
+    String solution = "Solution proposed by IT Academy";
+    Topic topic = Topic.ALL;
+    UUID tag = UUID.randomUUID();
+    List<UUID> tags = List.of(tag);
+    String localTimeStr = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 
     //TODO - pending externalize to service layer (internal comms)
 
@@ -860,6 +876,75 @@ class ChallengeControllerTest {
                 .jsonPath("$.results[0].timesFavorite").isEqualTo(5);
     }
 
+    @Test
+    @DisplayName("PUT /challenges/{challengeId}/update must return a mock of the updated challenge")
+    void updateChallenge_allArgumentsCorrect_return200_OK_test(){
+
+        ChallengeDto expectedChallenge = ChallengeDto.builder()
+                .challengeId(challengeId)
+                .title(challengeTitle)
+                .level(level)
+                .creationDate(localTimeStr)
+                .detail(detail)
+                .popularity(10)
+                .percentage(0.5F)
+                .languages(Set.of(languageDto))
+                .solutions(List.of(solutionUuid))
+                .topic(topic)
+                .timesFavorite(10)
+                .timesBookmark(10)
+                .build();
+
+        ChallengeCreateDto challengeCreateDto = ChallengeCreateDto.builder()
+                .challengeTitle(challengeTitle)
+                .description(description)
+                .level(DifficultyLevel.EASY)
+                .language(language)
+                .solution(solution)
+                .topic(Topic.ALL)
+                .tags(tags)
+                .build();
+
+        webTestClient.put()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(challengeCreateDto)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(ChallengeDto.class)
+                .consumeWith(data -> {
+                    ChallengeDto response = data.getResponseBody();
+                    assert response != null;
+                    Assertions.assertEquals(expectedChallenge.getChallengeId(), response.getChallengeId());
+                    Assertions.assertEquals(expectedChallenge.getTitle(), response.getTitle());
+                    Assertions.assertEquals(expectedChallenge.getLevel(), response.getLevel());
+                    Assertions.assertEquals(expectedChallenge.getCreationDate(), response.getCreationDate());
+                    Assertions.assertEquals(expectedChallenge.getDetail().getDescription(), response.getDetail().getDescription());
+                    Assertions.assertEquals(expectedChallenge.getTitle(), response.getTitle());
+                    Assertions.assertEquals(expectedChallenge.getPopularity(), response.getPopularity());
+                    Assertions.assertEquals(expectedChallenge.getPercentage(), response.getPercentage());
+                    Assertions.assertTrue(expectedChallenge.getLanguages().contains(languageDto));
+                    Assertions.assertTrue(expectedChallenge.getSolutions().contains(solutionUuid));
+                    Assertions.assertEquals(expectedChallenge.getTopic(), response.getTopic());
+                    Assertions.assertEquals(expectedChallenge.getTimesFavorite(), response.getTimesFavorite());
+                    Assertions.assertEquals(expectedChallenge.getTimesBookmark(), response.getTimesBookmark());
+                });
+    }
+
+    @Test
+    @DisplayName("PUT /challenges/{challengeId}/update must return Bad Request when not valid Request body")
+    void updateChallenge_badArgument_return400_BadRequest_test(){
+        ChallengeCreateDto challengeCreateDto = ChallengeCreateDto.builder()
+                .challengeTitle("Challenge Title")
+                .build();
+
+        webTestClient.put()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(challengeCreateDto)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
 }
 
 


### PR DESCRIPTION
This PR belong to user story [#26](https://tree.taiga.io/project/luisvi-ita-challenges/us/26) "Como mentor/a, puedo editar los retos clicando un botón", and task [#224](https://tree.taiga.io/project/luisvi-ita-challenges/task/224) "[BE] Endpoint de edición de reto con respuesta mock".
It aims to set up a new endpoint "/itachallenge/api/v1/challenge/challenge/{challengeId}/update"
to update whatever information of a given challenge among the following ones:

- challenge title
- description
- level
- language
- official solution
- topic
- tags

The scope of this PR is only to enable the endpoint with mocked response, without applying any logic or check, and excluding persistence in database. The mocked response reflects the input arguments and is detailed in task Taiga #224.

It only includes the ChallengeController class, with its related test class.

Complete logic and persistence in database will be implemented in next PR.