### PR TITLE
Feature/243 change autowired annotation from user

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/filter/ContentLengthFilter.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/filter/ContentLengthFilter.java
@@ -3,18 +3,18 @@ package com.itachallenge.user.filter;
 import com.itachallenge.user.config.TomcatConfig;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class ContentLengthFilter implements Filter {
 
     private final TomcatConfig tomcatConfig;
-
-    public ContentLengthFilter(TomcatConfig tomcatConfig) {
-        this.tomcatConfig = tomcatConfig;
-    }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)

--- a/itachallenge-user/src/main/java/com/itachallenge/user/filter/ContentLengthFilter.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/filter/ContentLengthFilter.java
@@ -3,7 +3,6 @@ package com.itachallenge.user.filter;
 import com.itachallenge.user.config.TomcatConfig;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -13,7 +12,6 @@ public class ContentLengthFilter implements Filter {
 
     private final TomcatConfig tomcatConfig;
 
-    @Autowired
     public ContentLengthFilter(TomcatConfig tomcatConfig) {
         this.tomcatConfig = tomcatConfig;
     }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/filter/ContentLengthFilter.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/filter/ContentLengthFilter.java
@@ -5,13 +5,12 @@ import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
 @Component
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 public class ContentLengthFilter implements Filter {
 
     private final TomcatConfig tomcatConfig;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/filter/MaxLengthURIFilter.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/filter/MaxLengthURIFilter.java
@@ -4,6 +4,7 @@ import com.itachallenge.user.config.PropertiesConfig;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -12,9 +13,9 @@ import java.io.IOException;
 
 @Component
 @Order(1)
+@RequiredArgsConstructor
 public class MaxLengthURIFilter implements Filter {
 
-    @Autowired
     PropertiesConfig prpsConfig;
 
     @Override

--- a/itachallenge-user/src/main/java/com/itachallenge/user/filter/MaxLengthURIFilter.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/filter/MaxLengthURIFilter.java
@@ -4,6 +4,7 @@ import com.itachallenge.user.config.PropertiesConfig;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -12,10 +13,10 @@ import java.io.IOException;
 
 @Component
 @Order(1)
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class MaxLengthURIFilter implements Filter {
 
-    @Autowired()
-    PropertiesConfig prpsConfig;
+    private final PropertiesConfig prpsConfig;
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/filter/MaxLengthURIFilter.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/filter/MaxLengthURIFilter.java
@@ -4,7 +4,6 @@ import com.itachallenge.user.config.PropertiesConfig;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -13,10 +12,10 @@ import java.io.IOException;
 
 @Component
 @Order(1)
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class MaxLengthURIFilter implements Filter {
 
-    private final PropertiesConfig prpsConfig;
+    @Autowired
+    PropertiesConfig prpsConfig;
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {


### PR DESCRIPTION
**ContextLenghtFilter.java**

1. The constructor with anotation Autowired has been deleted.
2. The anotation `@RequiredArgsConstructor(onConstructor = @__(@Autowired))` has been added to substitute the old constructor

**MaxLengthURIFilter.java**

1. The bracket from the anotation `@Autowired` has been deleted, to keep the standard.