### PR TITLE
Delete of unnecesary Autowired - DocumentController

### DIFF
--- a/itachallenge-document/src/main/java/com/itachallenge/document/controller/DocumentController.java
+++ b/itachallenge-document/src/main/java/com/itachallenge/document/controller/DocumentController.java
@@ -35,7 +35,6 @@ public class DocumentController {
     @Value("${spring.application.name}")
     private String appName;
 
-    @Autowired
     public DocumentController(OpenApiConfig openApiConfig, DocumentService documentService) {
         this.openApiConfig = openApiConfig;
         this.documentService = documentService;

--- a/itachallenge-document/src/main/java/com/itachallenge/document/controller/DocumentController.java
+++ b/itachallenge-document/src/main/java/com/itachallenge/document/controller/DocumentController.java
@@ -3,8 +3,6 @@ package com.itachallenge.document.controller;
 import com.itachallenge.document.config.OpenApiConfig;
 import com.itachallenge.document.service.DocumentService;
 import io.swagger.v3.oas.models.OpenAPI;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,19 +22,12 @@ public class DocumentController {
 
     private final OpenApiConfig openApiConfig;
     private final DocumentService documentService;
-
-    @Autowired
     private Environment env;
 
-    @Value("${spring.application.version}")
-    private String version;
-
-    @Value("${spring.application.name}")
-    private String appName;
-
-    public DocumentController(OpenApiConfig openApiConfig, DocumentService documentService) {
+    public DocumentController(OpenApiConfig openApiConfig, DocumentService documentService, Environment env) {
         this.openApiConfig = openApiConfig;
         this.documentService = documentService;
+        this.env = env;
     }
 
     @GetMapping(value = "/api-docs/{apiname}", produces = {"application/json"})

--- a/itachallenge-document/src/test/java/com/itachallenge/document/controller/DocumentControllerTest.java
+++ b/itachallenge-document/src/test/java/com/itachallenge/document/controller/DocumentControllerTest.java
@@ -9,16 +9,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -40,8 +37,7 @@ class DocumentControllerTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        documentController = new DocumentController(openApiConfig, documentService);
-        ReflectionTestUtils.setField(documentController, "env", env);
+        documentController = new DocumentController(openApiConfig, documentService, env);
     }
 
     @Test


### PR DESCRIPTION
When using constructor injection, Spring automatically injects the dependencies without requiring the @Autowired annotation. So We can safely remove it from the constructor.

