### PR TITLE
Feature/205: Add delete bookmark endpoint challenge microservice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). 
-
+* Issue #843: Added DELETE endpoint in the Challenge Microservice to unbookmark a challenge.
 * Issue #829: Added bookmark POST endpoint in the Challenge Microservice to bookmark a challenge.
 * Issue #827: Added bookmark POST endpoint in the User Microservice to bookmark a challenge.
 * Issue #831: Added DELETE endpoint for user's bookmals in User Microservice.

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -380,4 +380,26 @@ public class ChallengeController {
 
         return Mono.just(ResponseEntity.ok(challengeDto));
     }
+
+    @DeleteMapping("/challenges/{challengeId}/bookmarks")
+    @Operation(
+            operationId = "Remove a challenge from the User's bookmarks.",
+            summary = "Remove a challenge from bookmarks.",
+            description = "The ID Challenge sent through the URI is removed from the user's bookmarks. User Id is determined from the headers.",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = FavoriteDto.class), mediaType = "application/json")}),
+                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
+                    @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error")
+            }
+    )
+    public Mono<ResponseEntity<BookmarkDto>> removeChallengeFromBookmarks(
+            @PathVariable String challengeId,
+            @RequestHeader(name = "Authorization", required = false) String authHeader) {
+        return Mono.fromCallable(() -> jwtService.getUserUuIdFromAuthenticationHeader(authHeader))
+                .onErrorMap(JwtException.class, e -> new BadRequestException(e.getMessage()))
+                .flatMap(userId -> challengeService.removeChallengeFromBookmarks(challengeId, userId))
+                .doOnError(error -> log.error("Error removing challenge with id {} from bookmarks: {}", challengeId, error.getMessage()))
+                .map(ResponseEntity::ok);
+    }
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ChallengeDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ChallengeDocument.java
@@ -77,4 +77,8 @@ public class ChallengeDocument {
         timesBookmark = timesBookmark == null ? 1 : timesBookmark + 1;
     }
 
+    public void decreaseTimesBookmark() {
+        timesBookmark =Integer.max(timesBookmark == null ? 0 : timesBookmark - 1, 0);
+    }
+
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -422,4 +422,31 @@ public class ChallengeServiceImpl implements IChallengeService {
                                     .map(savedChallenge -> new BookmarkDto( true, savedChallenge.getTimesBookmark())));
                 });
     }
+    @Override
+    public Mono<BookmarkDto> removeChallengeFromBookmarks(String challengeId, String userId) {
+        Mono<UUID> challengeIdMono = validateUUID(String.valueOf(challengeId));
+        Mono<UUID> languageIdMono = validateUUID(String.valueOf(userId));
+
+        return Mono.zip(challengeIdMono, languageIdMono)
+                .flatMap(Uuidtuple -> {
+                    UUID challengeUuid = Uuidtuple.getT1();
+                    UUID userUuid = Uuidtuple.getT2();
+
+                    return challengeRepository.findByUuid(challengeUuid)
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                            .flatMap(challenge -> userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())
+                                    .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
+                                    .flatMap(isRemovedFromUsersBookmarks -> {
+                                        if (Boolean.TRUE.equals(isRemovedFromUsersBookmarks) ||
+                                                Optional.ofNullable(challenge.getTimesBookmark()).orElse(0) == 0) {
+                                            challenge.decreaseTimesBookmark();
+                                            return challengeRepository.save(challenge);
+                                        }
+                                        return Mono.just(challenge);
+                                    })
+                                    .map(savedChallenge -> new BookmarkDto(false, savedChallenge.getTimesBookmark())));
+                });
+    }
+
+
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -40,4 +40,6 @@ public interface IChallengeService {
     Mono<BookmarkDto> addChallengeToBookmarks(String challengeId, String userId);
 
     Mono<FavoriteDto> removeChallengeFromFavorites(String challengeId, String userId);
+
+    Mono<BookmarkDto> removeChallengeFromBookmarks(String challengeId, String userId);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IUserService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IUserService.java
@@ -7,4 +7,6 @@ public interface IUserService {
 
     Mono<Boolean> addChallengeToBookmarks(String userId, String challengeId);
     Mono<Boolean> removeChallengeFromFavorites(String userId, String challengeId);
+
+    Mono<Boolean> removeChallengeFromBookmarks(String userId, String challengeId);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/UserServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/UserServiceImpl.java
@@ -47,6 +47,11 @@ public class UserServiceImpl implements IUserService {
         return callEndpoint(userId, challengeId, UserChallengeActionType.FAVORITES, X_FAVORITE_MESSAGE, HttpMethod.DELETE);
     }
 
+    @Override
+    public Mono<Boolean> removeChallengeFromBookmarks(String userId, String challengeId) {
+        return callEndpoint(userId, challengeId, UserChallengeActionType.BOOKMARKS, X_BOOKMARK_MESSAGE, HttpMethod.DELETE);
+    }
+
     private Mono<Boolean> callEndpoint(String userId, String challengeId, UserChallengeActionType type, String errorHeader, HttpMethod method) {
         String url = buildUrl(userId, challengeId, type.toString().toLowerCase());
         log.debug("Calling {} endpoint with method={} and URL={}", type.name().toLowerCase(), method, url);

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -927,6 +927,112 @@ class ChallengeControllerTest {
                 .expectStatus().isOk();
     }
 
+    @Test
+    void removeChallengeFromBookmarks_Success_Returns200() {
+        String challengeId = "existing_challengeId";
+        String userId = "existing_userId";
+        String authHeader = "validAuthHeader";
+
+        BookmarkDto expectedResponse = new BookmarkDto(false, 20);
+
+        when(challengeService.removeChallengeFromBookmarks(challengeId, userId)).thenReturn(Mono.just(expectedResponse));
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/bookmarks")
+                .header("Authorization", authHeader)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(BookmarkDto.class)
+                .isEqualTo(expectedResponse);
+
+        verify(challengeService, times(1)).removeChallengeFromBookmarks(challengeId, userId);
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_ChallengeNotFound_Returns404() {
+        String challengeId = "nonExisting_challengeId";
+        String userId = "existing_userId";
+        String authHeader = "validAuthHeader";
+
+        String errorMessage = "ErrorMessage";
+
+        when(challengeService.removeChallengeFromBookmarks(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundReturn404Exception(errorMessage)));
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/bookmarks")
+                .header("Authorization", authHeader)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(MessageDto.class)
+                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
+
+        verify(challengeService, times(1)).removeChallengeFromBookmarks(challengeId, userId);
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_InternalServerError_Returns500() {
+        String challengeId = "Existing_challengeId";
+        String userId = "existing_userId";
+        String authHeader = "validAuthHeader";
+
+        String errorMessage = "ErrorMessage";
+
+        when(challengeService.removeChallengeFromBookmarks(challengeId, userId)).thenReturn(Mono.error(new InternalServerErrorException(errorMessage)));
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/bookmarks")
+                .header("Authorization", authHeader)
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                .expectBody(MessageDto.class)
+                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
+
+        verify(challengeService, times(1)).removeChallengeFromBookmarks(challengeId, userId);
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_InvalidHeader_Returns400() {
+        String challengeId = "Existing_challengeId";
+        String authHeader = "BadHeader";
+        String errorMessage = "Error message";
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenThrow(new JwtException(errorMessage));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/bookmarks")
+                .header("Authorization", authHeader)
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.BAD_REQUEST)
+                .expectBody(MessageDto.class)
+                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
+
+        verify(challengeService, times(0)).removeChallengeFromBookmarks(anyString(), anyString());
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_MissingHeader_Returns400() {
+        String challengeId = "Existing_challengeId";
+        String errorMessage = "ErrorMessage";
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(null)).thenThrow(new JwtException(errorMessage));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/bookmarks")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.BAD_REQUEST)
+                .expectBody(MessageDto.class)
+                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
+
+        verify(challengeService, times(0)).removeChallengeFromBookmarks(anyString(), anyString());
+
+    }
+
 }
 
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -1465,6 +1465,278 @@ class ChallengeServiceImplTest {
     public static Stream<Integer> removeChallengeFromFavorites_WhenNotRemovedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToZeroAndReturnsFavoriteDTO() {
         return Stream.of(null, 0);
     }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenChallengeUuidNotValid_ReturnsError() {
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks("InvalidUuid", UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenUserUuidNotValid_ReturnsError() {
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(UUID.randomUUID().toString(), "InvalidUuid"))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenChallengeUuidIsNull_ReturnsError() {
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(null, UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenUserUuidIsNull_ReturnsError() {
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(UUID.randomUUID().toString(), null))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenChallengeNotFound_ReturnsError() {
+        String CHALLENGE_NOT_FOUND_ERROR = "Challenge with id: %s not found";
+        UUID challengeUuid = UUID.randomUUID();
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.empty());
+
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof ChallengeNotFoundReturn404Exception &&
+                                error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenUserNotFound_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new UserNotFoundException(message)));
+
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenUserServiceReturnsCustomBadRequestException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new BadRequestException(message)));
+
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenUserServiceReturnsCustomInternalServerErrorException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new InternalServerErrorException(message)));
+
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenUserServiceReturnsAnyException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new Exception(message)));
+
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof Exception &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenRemoved_DecreasesTimesBookmarkedAndReturnsBookmarkDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        int initialTimesBookmarked = 20;
+
+        challenge.setTimesBookmark(initialTimesBookmarked);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(bookmarkDto -> {
+                    return bookmarkDto.getTimesBookmarked() == initialTimesBookmarked - 1 &&
+                            !bookmarkDto.isBookmarked();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(initialTimesBookmarked - 1, challenge.getTimesBookmark());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenRemovedAndInitialTimesBookmarkedIsNull_SetsTimesBookmarkedToZeroAndReturnsBookmarkDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesFavorite(null);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesBookmarked() == 0 &&
+                            !favoriteDto.isBookmarked();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(0, challenge.getTimesBookmark());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenRemovedAndInitialTimesBookmarkedIsZero_SetsTimesBookmarkedToZeroAndReturnsBookmarkDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesFavorite(0);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesBookmarked() == 0 &&
+                            !favoriteDto.isBookmarked();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(0, challenge.getTimesBookmark());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_WhenNotRemoved_NotChangeTimesBookmarkedAndReturnsBookmarkDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        int initialTimesBookmarked = 20;
+
+        challenge.setTimesBookmark(initialTimesBookmarked);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
+
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesBookmarked() == initialTimesBookmarked &&
+                            !favoriteDto.isBookmarked();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(initialTimesBookmarked, challenge.getTimesBookmark());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(0)).save(any());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void removeChallengeFromBookmarks_WhenNotRemovedAndTimesBookmarkIsNullOrZero_SetTimesBookmarkedToZeroAndReturnsBookmarkDTO(Integer timesBookmarked) {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesBookmark(timesBookmarked);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesBookmarked() == 0 &&
+                            !favoriteDto.isBookmarked();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(0, challenge.getTimesBookmark());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    public static Stream<Integer> removeChallengeFromBookmarks_WhenNotRemovedAndTimesBookmarkIsNullOrZero_SetTimesBookmarkedToZeroAndReturnsBookmarkDTO() {
+        return Stream.of(null, 0);
+    }
 }
 
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/UserServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/UserServiceImplTest.java
@@ -437,4 +437,137 @@ public class UserServiceImplTest {
         assertEquals("DELETE", request.getMethod());
     }
 
+    @Test
+    void removeChallengeFromBookmarks_DeletedFromUser_ReturnsTrue() throws InterruptedException {
+        String userId = "someId";
+        String challengeId = "anotherId";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("true")
+                .setResponseCode(201)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = userService.removeChallengeFromBookmarks(userId, challengeId);
+
+        StepVerifier.create(result)
+                .expectNext(true)
+                .verifyComplete();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(BOOKMARKS_URL, userId, challengeId),
+                request.getRequestUrl().encodedPath());
+        assertEquals("DELETE", request.getMethod());
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_NotDeletedFromUser_ReturnsFalse() throws InterruptedException {
+        String userId = "someId";
+        String challengeId = "anotherId";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = userService.removeChallengeFromBookmarks(userId, challengeId);
+
+        StepVerifier.create(result)
+                .expectNext(false)
+                .verifyComplete();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(BOOKMARKS_URL, userId, challengeId),
+                request.getRequestUrl().encodedPath());
+        assertEquals("DELETE", request.getMethod());
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_BadRequest_ReturnsError() throws InterruptedException {
+        String userId = "someId";
+        String challengeId = "anotherId";
+        String someErrorMessage = "Some error message";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(400)
+                .addHeader(X_BOOKMARK_MESSAGE, someErrorMessage)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = userService.removeChallengeFromBookmarks(userId, challengeId);
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadRequestException.class, throwable);
+                    assertTrue(throwable.getMessage().contains(someErrorMessage));
+                })
+                .verify();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(BOOKMARKS_URL, userId, challengeId),
+                request.getRequestUrl().encodedPath());
+        assertEquals("DELETE", request.getMethod());
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_UserNotFound_ReturnsError() throws InterruptedException {
+        String userId = "someId";
+        String challengeId = "anotherId";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(404)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = userService.removeChallengeFromBookmarks(userId, challengeId);
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(UserNotFoundException.class, throwable);
+                    assertTrue(throwable.getMessage().contains("User not found"));
+                })
+                .verify();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(BOOKMARKS_URL, userId, challengeId),
+                request.getRequestUrl().encodedPath());
+        assertEquals("DELETE", request.getMethod());
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_500_ReturnsError() throws InterruptedException {
+        String userId = "someId";
+        String challengeId = "anotherId";
+        String someErrorMessage = "Some error message";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(500)
+                .addHeader(X_BOOKMARK_MESSAGE, someErrorMessage)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = userService.removeChallengeFromBookmarks(userId, challengeId);
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(InternalServerErrorException.class, throwable);
+                    assertTrue(throwable.getMessage().contains(throwable.getMessage()));
+                })
+                .verify();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(BOOKMARKS_URL, userId, challengeId),
+                request.getRequestUrl().encodedPath());
+        assertEquals("DELETE", request.getMethod());
+    }
+
 }


### PR DESCRIPTION
This PR centers on the second endpoint needed in order to successfully delete a challenge from bookmarks _(delete bookmark endpoint from User Microservice is already in development)._

The functionality is at follows:

- Checks if the Challenge exists
- Sends a request to the deteleBookmark endpoint in UserMicroservice to delete the challenge from the user's bookmarks
- Decreases the counter of the total_bookmarked of said challenge.
- Returns a BookmarkDTO (that contain if user bookmarked the challenge and the updated total times the challenge has been bookmarked)

**UPDATED FILES:**

- CHANGELOG
- Wiki endpoints page

[Taiga ticket:](https://tree.taiga.io/project/luisvi-ita-challenges/task/254) 