### PR TITLE
feature/275 solvedCounter: Method addChallengeToSolved from ChallengeService.challenge

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ChallengeDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ChallengeDocument.java
@@ -48,6 +48,9 @@ public class ChallengeDocument {
     @Field(name="times_bookmark")
     private Integer timesBookmark;
 
+    @Field(name="times_solved")
+    private Integer timesSolved;
+
     @Field(name = "tags")
     private List<UUID> tags;
 
@@ -75,6 +78,10 @@ public class ChallengeDocument {
 
     public void increaseTimesBookmark() {
         timesBookmark = timesBookmark == null ? 1 : timesBookmark + 1;
+    }
+
+    public void increaseTimesSolved() {
+        timesSolved = timesSolved == null ? 1 : timesSolved + 1;
     }
 
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeDto.java
@@ -63,4 +63,8 @@ public class ChallengeDto {
 
     @JsonProperty(index = 11)
     private Integer timesBookmark;
+
+    @JsonProperty(index = 12)
+    private Integer timesSolved;
+    
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/SolvedDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/SolvedDto.java
@@ -1,0 +1,14 @@
+package com.itachallenge.challenge.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class SolvedDto {
+
+    private boolean isSolved;
+
+    private int timesSolved;
+
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/enums/UserChallengeActionType.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/enums/UserChallengeActionType.java
@@ -2,5 +2,6 @@ package com.itachallenge.challenge.enums;
 
 public enum UserChallengeActionType {
     BOOKMARKS,
-    FAVORITES
+    FAVORITES,
+    SOLVED
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/helper/DocumentToDtoConverter.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/helper/DocumentToDtoConverter.java
@@ -54,7 +54,8 @@ public class DocumentToDtoConverter<S,D> {
                     .addMapping(ChallengeDocument::getTitle, ChallengeDto::setTitle)
                     .addMapping(ChallengeDocument::getTimesFavorite, ChallengeDto::setTimesFavorite)
                     .addMapping(ChallengeDocument::getTags, ChallengeDto::setTags)
-                    .addMapping(ChallengeDocument::getTimesBookmark, ChallengeDto::setTimesBookmark);
+                    .addMapping(ChallengeDocument::getTimesBookmark, ChallengeDto::setTimesBookmark)
+                    .addMapping(ChallengeDocument::getTimesSolved, ChallengeDto::setTimesSolved);
             mapper.addConverter(converterFromLocalDateTimeToString);
         }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -422,4 +422,32 @@ public class ChallengeServiceImpl implements IChallengeService {
                                     .map(savedChallenge -> new BookmarkDto( true, savedChallenge.getTimesBookmark())));
                 });
     }
+
+    @Override
+    public Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId) {
+
+        Mono<UUID> challengeIdMono = validateUUID(String.valueOf(challengeId));
+        Mono<UUID> userIdMono = validateUUID(String.valueOf(userId));
+
+        return Mono.zip(challengeIdMono, userIdMono)
+                .flatMap(Uuidtuple -> {
+                    UUID challengeUuid = Uuidtuple.getT1();
+                    UUID userUuid = Uuidtuple.getT2();
+
+                    return challengeRepository.findByUuid(challengeUuid)
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                            .flatMap(challenge -> userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())
+                                    .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
+                                    .flatMap(isAddedToUsersSolved -> {
+                                        if (Boolean.TRUE.equals(isAddedToUsersSolved) ||
+                                                Optional.ofNullable(challenge.getTimesSolved()).orElse(0) == 0) {
+                                            challenge.increaseTimesSolved();
+                                            return challengeRepository.save(challenge);
+                                        }
+                                        return Mono.just(challenge);
+                                    })
+                                    .map(savedChallenge -> new SolvedDto(true, savedChallenge.getTimesSolved())));
+                });
+    }
+
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -40,4 +40,6 @@ public interface IChallengeService {
     Mono<BookmarkDto> addChallengeToBookmarks(String challengeId, String userId);
 
     Mono<FavoriteDto> removeChallengeFromFavorites(String challengeId, String userId);
+
+    Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId);
 }


### PR DESCRIPTION
This PR contains the following changes:

- New method `addChallengeToSolved` was added to the **IChallengeService**.
- New method `addChallengeToSolved` was added to the **ChallengeServiceImpl**.

Here’s a simplified summary of the `addChallengeToSolved` method:

1. **Validate IDs**: Ensures `challengeId` and `userId` are valid UUIDs.
2. **Find Challenge**: Looks up the challenge in the repository by its UUID.
3. **Add to User's Solved List**: Calls the user service to mark the challenge as solved for the user.
4. **Update Challenge**: If successful or if the challenge hasn't been solved before, increments the `timesSolved` count and saves the updated challenge.
5. **Return Result**: Returns a `SolvedDto` with the success status and updated `timesSolved` count.