### PR TITLE
feature/282 Servicio y repositorio para obtener recursos por challengeId

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/repository/ResourceRepository.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/repository/ResourceRepository.java
@@ -25,4 +25,5 @@ public interface ResourceRepository extends ReactiveSortingRepository<ResourceDo
     Flux<ResourceDocument> saveAll(Flux<ResourceDocument> resourceDocumentFlux);
     Mono<Void> deleteAll();
 
+    Flux<ResourceDocument> findByChallengeIdsContaining(UUID challengeId);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IResourceService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IResourceService.java
@@ -1,12 +1,15 @@
 package com.itachallenge.challenge.service;
 
 import com.itachallenge.challenge.dto.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.UUID;
 
 
 public interface IResourceService {
     Mono<ResourceDto> createResource(ResourceDto resourceDto);
 
+    Flux<ResourceDto> getResourcesByChallengeId(UUID challengeId);
 }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.*;
@@ -134,5 +135,21 @@ public class ResourceServiceImpl implements IResourceService {
                     return savedDto;
                 })
                 .doOnError(error -> log.error("Error occurred when creating resource {}", error.getMessage()));
+    }
+
+
+    public Flux<ResourceDto> getResourcesByChallengeId(UUID challengeId) {
+
+        if (challengeId == null) {
+            return Flux.error(new IllegalArgumentException("Challenge ID cannot be null"));
+        }
+
+
+        return resourceRepository.findByChallengeIdsContaining(challengeId)
+                .map(resourceDoc -> resourceConverter.convertDocumentToDto(resourceDoc, ResourceDto.class))
+                .onErrorResume(error -> {
+                    log.error("Error fetching resources: {}", error.getMessage());
+                    return Flux.error(new RuntimeException("Server error while fetching resources"));
+                });
     }
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
@@ -5,6 +5,9 @@ import com.itachallenge.challenge.dto.ChallengeListDto;
 import com.itachallenge.challenge.dto.ResourceDto;
 import com.itachallenge.challenge.enums.AssociationType;
 import com.itachallenge.challenge.enums.Topic;
+import com.itachallenge.challenge.exception.BadRequestException;
+import com.itachallenge.challenge.exception.InternalServerErrorException;
+import com.itachallenge.challenge.exception.ResourceNotFoundException;
 import com.itachallenge.challenge.helper.DocumentToDtoConverter;
 import com.itachallenge.challenge.repository.ResourceRepository;
 import org.slf4j.Logger;
@@ -141,15 +144,18 @@ public class ResourceServiceImpl implements IResourceService {
     public Flux<ResourceDto> getResourcesByChallengeId(UUID challengeId) {
 
         if (challengeId == null) {
-            return Flux.error(new IllegalArgumentException("Challenge ID cannot be null"));
+            throw new BadRequestException("Challenge ID cannot be null");
         }
 
 
         return resourceRepository.findByChallengeIdsContaining(challengeId)
                 .map(resourceDoc -> resourceConverter.convertDocumentToDto(resourceDoc, ResourceDto.class))
                 .onErrorResume(error -> {
-                    log.error("Error fetching resources: {}", error.getMessage());
-                    return Flux.error(new RuntimeException("Server error while fetching resources"));
+                    log.error("Error fetching resources for challenge ID {}: {}", challengeId, error.getMessage());
+                    if (error instanceof ResourceNotFoundException) {
+                        return Flux.error(error);
+                    }
+                    throw new InternalServerErrorException("Failed to fetch resources for challenge ID: " + challengeId);
                 });
     }
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
@@ -142,20 +142,18 @@ public class ResourceServiceImpl implements IResourceService {
 
 
     public Flux<ResourceDto> getResourcesByChallengeId(UUID challengeId) {
-
-        if (challengeId == null) {
-            throw new BadRequestException("Challenge ID cannot be null");
-        }
-
-
-        return resourceRepository.findByChallengeIdsContaining(challengeId)
-                .map(resourceDoc -> resourceConverter.convertDocumentToDto(resourceDoc, ResourceDto.class))
-                .onErrorResume(error -> {
-                    log.error("Error fetching resources for challenge ID {}: {}", challengeId, error.getMessage());
-                    if (error instanceof ResourceNotFoundException) {
-                        return Flux.error(error);
-                    }
-                    throw new InternalServerErrorException("Failed to fetch resources for challenge ID: " + challengeId);
-                });
+        return Mono.justOrEmpty(challengeId)
+                .switchIfEmpty(Mono.error(new BadRequestException("Challenge ID cannot be null")))
+                .flatMapMany(validChallengeId ->
+                        resourceRepository.findByChallengeIdsContaining(validChallengeId)
+                                .map(resourceDoc -> resourceConverter.convertDocumentToDto(resourceDoc, ResourceDto.class))
+                                .onErrorResume(error -> {
+                                    log.error("Error fetching resources for challenge ID {}: {}", validChallengeId, error.getMessage());
+                                    if (error instanceof ResourceNotFoundException) {
+                                        return Flux.error(error);
+                                    }
+                                    return Flux.error(new InternalServerErrorException("Failed to fetch resources for challenge ID: " + validChallengeId));
+                                })
+                );
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ResourceRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ResourceRepositoryTest.java
@@ -251,4 +251,50 @@ class ResourceRepositoryTest {
                 .expectNext(0L)
                 .verifyComplete();
     }
+
+    // Revisar + limpiar esto
+    // este test Verifica que el método findByChallengeIdsContaining
+    // del repositorio devuelve únicamente los recursos que contienen
+    // el challengeId especificado en su lista de retos asociados.
+    @Test
+    void findByChallengeIdsContaining_WhenChallengeIdExists_ReturnsResources() {
+
+        UUID targetChallengeId = UUID.fromString("8ecbfe54-fec8-11ed-be56-0242ac120002");
+
+
+        ResourceDocument resourceWithTargetChallenge = ResourceDocument.builder()
+                .resourceId(uuid1)
+                .title("Title1")
+                .description("Description1")
+                .url("http://example.com/resource1")
+                .topic(Topic.DEBUGGING)
+                .contentType(ResourceContentType.BLOG)
+                .challengeIds(List.of(targetChallengeId))
+                .build();
+
+        ResourceDocument resourceWithoutTargetChallenge = ResourceDocument.builder()
+                .resourceId(uuid2)
+                .title("Title2")
+                .description("Description2")
+                .url("http://example.com/resource2")
+                .topic(Topic.DEBUGGING)
+                .contentType(ResourceContentType.BLOG)
+                .challengeIds(List.of(UUID.randomUUID()))
+                .build();
+
+
+        resourceRepository.deleteAll().block();
+        resourceRepository.saveAll(Flux.just(resourceWithTargetChallenge, resourceWithoutTargetChallenge)).blockLast();
+
+
+        Flux<ResourceDocument> result = resourceRepository.findByChallengeIdsContaining(targetChallengeId);
+
+
+        StepVerifier.create(result)
+                .expectNextMatches(resource ->
+                        resource.getChallengeIds().contains(targetChallengeId) &&
+                                resource.getResourceId().equals(uuid1)
+                )
+                .verifyComplete();
+    }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ResourceRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ResourceRepositoryTest.java
@@ -252,10 +252,7 @@ class ResourceRepositoryTest {
                 .verifyComplete();
     }
 
-    // Revisar + limpiar esto
-    // este test Verifica que el método findByChallengeIdsContaining
-    // del repositorio devuelve únicamente los recursos que contienen
-    // el challengeId especificado en su lista de retos asociados.
+
     @Test
     void findByChallengeIdsContaining_WhenChallengeIdExists_ReturnsResources() {
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ResourceServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ResourceServiceImplTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import static org.mockito.ArgumentMatchers.*;
@@ -415,6 +416,91 @@ class ResourceServiceImplTest {
                         error.getMessage().equals("Conversion DTO to Document null"))
                 .verify();
     }
+
+    // ID CON recursos
+    @Test
+    void getResourcesByChallengeId_WhenResourcesExist_ReturnsFluxOfResources() {
+
+        UUID challengeId = UUID.randomUUID();
+        UUID resourceId1 = UUID.randomUUID();
+        UUID resourceId2 = UUID.randomUUID();
+
+
+        ResourceDocument doc1 = new ResourceDocument(
+                resourceId1, "Resource 1", "Desc 1", "https://example.com/1",
+                Topic.DEBUGGING, ResourceContentType.VIDEO, List.of(challengeId), AssociationType.ALLSAMETOPIC
+        );
+        ResourceDocument doc2 = new ResourceDocument(
+                resourceId2, "Resource 2", "Desc 2", "https://example.com/2",
+                Topic.COMPONENTS, ResourceContentType.BLOG, List.of(challengeId), AssociationType.CHOOSE
+        );
+
+        ResourceDto dto1 = new ResourceDto();
+        dto1.setResourceId(resourceId1);
+        dto1.setTitle("Resource 1");
+
+
+        ResourceDto dto2 = new ResourceDto();
+        dto2.setResourceId(resourceId2);
+        dto2.setTitle("Resource 2");
+
+
+        when(resourceRepository.findByChallengeIdsContaining(challengeId))
+                .thenReturn(Flux.just(doc1, doc2));
+        when(resourceConverter.convertDocumentToDto(doc1, ResourceDto.class)).thenReturn(dto1);
+        when(resourceConverter.convertDocumentToDto(doc2, ResourceDto.class)).thenReturn(dto2);
+
+
+        StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
+                .expectNext(dto1)
+                .expectNext(dto2)
+                .verifyComplete();
+    }
+
+    // Valido SIN recursos
+    @Test
+    void getResourcesByChallengeId_WhenNoResourcesExist_ReturnsEmptyFlux() {
+
+        UUID challengeId = UUID.randomUUID();
+        when(resourceRepository.findByChallengeIdsContaining(challengeId))
+                .thenReturn(Flux.empty());
+
+
+        StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
+                .expectNextCount(0)
+                .verifyComplete();
+    }
+
+    //ID Nulo
+    @Test
+    void getResourcesByChallengeId_WhenIdIsNull_ThrowsIllegalArgumentException() {
+
+        StepVerifier.create(resourceService.getResourcesByChallengeId(null))
+                .expectErrorMatches(ex ->
+                        ex instanceof IllegalArgumentException &&
+                                ex.getMessage().equals("Challenge ID cannot be null")
+                )
+                .verify();
+    }
+
+    //Error en el repo
+    @Test
+    void getResourcesByChallengeId_WhenRepositoryFails_PropagatesError() {
+
+        UUID challengeId = UUID.randomUUID();
+        when(resourceRepository.findByChallengeIdsContaining(challengeId))
+                .thenReturn(Flux.error(new RuntimeException("DB Connection Failed")));
+
+
+        StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
+                .expectErrorMatches(ex ->
+                        ex instanceof RuntimeException &&
+                                ex.getMessage().equals("Server error while fetching resources")
+                )
+                .verify();
+    }
+
+
 
 
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ResourceServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ResourceServiceImplTest.java
@@ -7,6 +7,9 @@ import com.itachallenge.challenge.dto.ResourceDto;
 import com.itachallenge.challenge.enums.AssociationType;
 import com.itachallenge.challenge.enums.ResourceContentType;
 import com.itachallenge.challenge.enums.Topic;
+import com.itachallenge.challenge.exception.BadRequestException;
+import com.itachallenge.challenge.exception.InternalServerErrorException;
+import com.itachallenge.challenge.exception.ResourceNotFoundException;
 import com.itachallenge.challenge.helper.DocumentToDtoConverter;
 import com.itachallenge.challenge.repository.ResourceRepository;
 import org.junit.jupiter.api.Test;
@@ -471,13 +474,11 @@ class ResourceServiceImplTest {
                 .verifyComplete();
     }
 
-    //ID Nulo
     @Test
-    void getResourcesByChallengeId_WhenIdIsNull_ThrowsIllegalArgumentException() {
-
+    void getResourcesByChallengeId_WhenIdIsNull_ThrowsBadRequestException() {
         StepVerifier.create(resourceService.getResourcesByChallengeId(null))
                 .expectErrorMatches(ex ->
-                        ex instanceof IllegalArgumentException &&
+                        ex instanceof BadRequestException &&
                                 ex.getMessage().equals("Challenge ID cannot be null")
                 )
                 .verify();
@@ -485,17 +486,32 @@ class ResourceServiceImplTest {
 
     //Error en el repo
     @Test
-    void getResourcesByChallengeId_WhenRepositoryFails_PropagatesError() {
-
+    void getResourcesByChallengeId_WhenRepositoryFails_ThrowsInternalServerErrorException() {
         UUID challengeId = UUID.randomUUID();
         when(resourceRepository.findByChallengeIdsContaining(challengeId))
                 .thenReturn(Flux.error(new RuntimeException("DB Connection Failed")));
 
-
         StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
                 .expectErrorMatches(ex ->
-                        ex instanceof RuntimeException &&
-                                ex.getMessage().equals("Server error while fetching resources")
+                        ex instanceof InternalServerErrorException &&
+                                ex.getMessage().equals("Failed to fetch resources for challenge ID: " + challengeId)
+                )
+                .verify();
+
+        verify(resourceRepository, times(1)).findByChallengeIdsContaining(challengeId);
+    }
+
+    @Test
+    void getResourcesByChallengeId_WhenResourceNotFound_PropagatesException() {
+        UUID challengeId = UUID.randomUUID();
+        ResourceNotFoundException ex = new ResourceNotFoundException("Not found");
+        when(resourceRepository.findByChallengeIdsContaining(challengeId))
+                .thenReturn(Flux.error(ex));
+
+        StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
+                .expectErrorMatches(thrownEx ->
+                        thrownEx instanceof ResourceNotFoundException &&
+                                thrownEx.getMessage().equals("Not found")
                 )
                 .verify();
     }


### PR DESCRIPTION
Se implementa la lógica de servicio y repositorio para recuperar los recursos asociados a un challengeId.
No se incluye el controlador (irá en una PR posterior).

+Añadido el método getResourcesByChallengeId(UUID challengeId) en el servicio.

+Ampliado el repositorio con findByChallengeIdsContaining(UUID challengeId).

+Añadido test para validar que el repositorio filtra correctamente los recursos.

+Manejo básico de errores y validación de entrada (challengeId != null).