### PR TITLE
Feature/#233 create update challenge in challenge service

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -2,14 +2,12 @@ package com.itachallenge.challenge.controller;
 
 import com.itachallenge.challenge.annotations.ValidGenericPattern;
 import com.itachallenge.challenge.config.PropertiesConfig;
-import com.itachallenge.challenge.document.DetailDocument;
 import com.itachallenge.challenge.dto.*;
 import com.itachallenge.challenge.exception.BadRequestException;
 import com.itachallenge.challenge.exception.JwtException;
 import com.itachallenge.challenge.service.IChallengeService;
 import com.itachallenge.challenge.service.IJwtService;
 import com.itachallenge.challenge.service.ITagService;
-import com.itachallenge.challenge.service.JwtServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,8 +24,6 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 @RestController
@@ -348,37 +344,14 @@ public class ChallengeController {
             description = "Allows to update any information contained in a challenge, providing ChallengeId and new information.",
             responses = {
                     @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = ChallengeDto.class), mediaType = "application/json")}),
-                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
                     @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
                     @ApiResponse(responseCode = "500", description = "Internal Server Error")
             }
     )
     public Mono<ResponseEntity<ChallengeDto>> updateChallenge(
             @PathVariable String challengeId, @Valid @RequestBody ChallengeCreateDto challengeFormDto){
-
-        final DateTimeFormatter CUSTOM_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        LocalDateTime localTime = LocalDateTime.now();
-        DetailDocument detail = new DetailDocument(challengeFormDto.getDescription());
-        LanguageDto languageDto = new LanguageDto(UUID.randomUUID(), challengeFormDto.getLanguage(), null);
-        languageDto.setLanguageImage("");
-        String solutionId = "d624bae4-9a43-4515-8979-801c0d6fd88c";
-
-        ChallengeDto challengeDto = new ChallengeDto();
-        challengeDto.setChallengeId(UUID.fromString(challengeId));
-        challengeDto.setTitle(challengeFormDto.getChallengeTitle());
-        challengeDto.setLevel(challengeFormDto.getLevel() != null ?
-                String.valueOf(challengeFormDto.getLevel()) : "");
-        challengeDto.setCreationDate(localTime.format(CUSTOM_FORMATTER));
-        challengeDto.setDetail(detail);
-        challengeDto.setPopularity(10);
-        challengeDto.setPercentage(0.5F);
-        challengeDto.setLanguages(Set.of(languageDto));
-        challengeDto.setSolutions(List.of(UUID.fromString(solutionId)));
-        challengeDto.setTopic(challengeFormDto.getTopic());
-        challengeDto.setTimesFavorite(10);
-        challengeDto.setTimesBookmark(10);
-
-        return Mono.just(ResponseEntity.ok(challengeDto));
+        return challengeService.updateChallenge(challengeId, challengeFormDto)
+                .map(ResponseEntity::ok);
     }
 
     @DeleteMapping("/challenges/{challengeId}/bookmarks")

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -344,7 +344,6 @@ public class ChallengeController {
             description = "Allows to update any information contained in a challenge, providing ChallengeId and new information.",
             responses = {
                     @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = ChallengeDto.class), mediaType = "application/json")}),
-                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
                     @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
                     @ApiResponse(responseCode = "500", description = "Internal Server Error")
             }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -344,6 +344,7 @@ public class ChallengeController {
             description = "Allows to update any information contained in a challenge, providing ChallengeId and new information.",
             responses = {
                     @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = ChallengeDto.class), mediaType = "application/json")}),
+                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
                     @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
                     @ApiResponse(responseCode = "500", description = "Internal Server Error")
             }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ChallengeDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ChallengeDocument.java
@@ -54,19 +54,6 @@ public class ChallengeDocument {
     @Field(name = "tags")
     private List<UUID> tags;
 
-    public void setTags(UUID tag) {
-        if (tags == null) {
-            tags = new ArrayList<>();
-        }
-
-        if (tags.contains(tag)) {
-            tags.remove(tag);
-        } else {
-            tags.add(tag);
-        }
-    }
-
-
     public void increaseTimesFavorite () {
             timesFavorite = timesFavorite == null ? 1 : timesFavorite + 1;
         }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/TagDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/TagDocument.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 public class TagDocument {
 
     @Id
-    @Field(name="id_tag")
     private UUID idTag;
 
     @Field(name="tag_name")

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeDto.java
@@ -61,7 +61,7 @@ public class ChallengeDto {
     @JsonProperty(index = 11)
     private List<UUID> tags;
 
-    @JsonProperty(index = 11)
+    @JsonProperty(index = 12)
     private Integer timesBookmark;
 
     @JsonProperty(index = 12)

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.server.ResponseStatusException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -93,5 +94,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InternalServerErrorException.class)
     public ResponseEntity<MessageDto> handleCustomInternalServerErrorException(InternalServerErrorException ex) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new MessageDto(ex.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<MessageDto> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new MessageDto(e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidFormatException.class)
+    public ResponseEntity<MessageDto> handleInvalidFormat(InvalidFormatException ex) {
+        return ResponseEntity.badRequest().body(new MessageDto(ex.getMessage()));
     }
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
@@ -105,4 +105,5 @@ public class GlobalExceptionHandler {
     public ResponseEntity<MessageDto> handleInvalidFormat(InvalidFormatException ex) {
         return ResponseEntity.badRequest().body(new MessageDto(ex.getMessage()));
     }
+
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.itachallenge.challenge.exception;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.itachallenge.challenge.dto.MessageDto;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -105,5 +106,4 @@ public class GlobalExceptionHandler {
     public ResponseEntity<MessageDto> handleInvalidFormat(InvalidFormatException ex) {
         return ResponseEntity.badRequest().body(new MessageDto(ex.getMessage()));
     }
-
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -488,35 +488,34 @@ public class ChallengeServiceImpl implements IChallengeService {
                 });
     }
 
-@Override
-public Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId) {
-    Mono<UUID> challengeIdMono = validateUUID(challengeId);
-    Mono<UUID> userIdMono = validateUUID(userId);
+    @Override
+    public Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId) {
+        Mono<UUID> challengeIdMono = validateUUID(challengeId);
+        Mono<UUID> userIdMono = validateUUID(userId);
 
-    return Mono.zip(challengeIdMono, userIdMono)
-            .flatMap(uuidTuple -> {
-                UUID challengeUuid = uuidTuple.getT1();
-                UUID userUuid = uuidTuple.getT2();
+        return Mono.zip(challengeIdMono, userIdMono)
+                .flatMap(uuidTuple -> {
+                    UUID challengeUuid = uuidTuple.getT1();
+                    UUID userUuid = uuidTuple.getT2();
 
-                return challengeRepository.findByUuid(challengeUuid)
-                        .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(
-                                String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
-                        .flatMap(challenge -> {
-                            log.info("It should be connected to user service using the fields {} and {}", challengeUuid, userUuid);
+                    return challengeRepository.findByUuid(challengeUuid)
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(
+                                    String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                            .flatMap(challenge -> {
+                                log.info("It should be connected to user service using the fields {} and {}", challengeUuid, userUuid);
 
-                            //The part of the user service is not implemented yet, it should be connected to the user service in the future.
+                                //The part of the user service is not implemented yet, it should be connected to the user service in the future.
 
-                            if (Optional.ofNullable(challenge.getTimesSolved()).orElse(0) == 0) {
-                                challenge.increaseTimesSolved();
-                                return challengeRepository.save(challenge);
-                            }
+                                if (Optional.ofNullable(challenge.getTimesSolved()).orElse(0) == 0) {
+                                    challenge.increaseTimesSolved();
+                                    return challengeRepository.save(challenge);
+                                }
 
-                            return Mono.just(challenge);
-                        })
-                        .map(updatedChallenge -> new SolvedDto(true, updatedChallenge.getTimesSolved()));
-            });
-}
-
+                                return Mono.just(challenge);
+                            })
+                            .map(updatedChallenge -> new SolvedDto(true, updatedChallenge.getTimesSolved()));
+                });
+    }
 
     private SolutionDocument buildSolutionDocument(LanguageDocument language, ChallengeCreateDto challengeCreateDto){
         return SolutionDocument.builder()

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -397,6 +397,45 @@ public class ChallengeServiceImpl implements IChallengeService {
     }
 
     @Override
+    public Mono<ChallengeDto> updateChallenge(String challengeId, ChallengeCreateDto challengeCreateDto) {
+        validateUUID(String.valueOf(challengeId));
+        String codingLanguage = challengeCreateDto.getLanguage();
+        return ILanguageService.findFirstByLanguageName(codingLanguage)
+                .switchIfEmpty(Mono.error(new LanguageNotFoundException("Language " + codingLanguage + " is not valid")))
+                .flatMap(newLanguage -> validateUUID(String.valueOf(challengeId))
+                        .flatMap(validId -> challengeRepository.findByUuid(validId)
+                                .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(
+                                        String.format(CHALLENGE_NOT_FOUND_ERROR, validId))))
+                                .flatMap(challengeDocument -> {
+                                    log.info("Challenge found for challengeId: {}", validId);
+
+                                    return tagService.getValidatedTags(challengeCreateDto.getTags())
+                                            .flatMap(allTagsValid -> {
+                                                if (!allTagsValid) {
+                                                    return Mono.error(new TagNotFoundException("One or more tags are invalid"));
+                                                }
+
+                                                SolutionDocument solutionDocument = buildSolutionDocument(newLanguage, challengeCreateDto);
+                                                return solutionRepository.save(solutionDocument)
+                                                        .flatMap(savedSolution -> {
+                                                            log.info("New solution successfully saved for challengeId: {}", validId);
+                                                            ChallengeDocument newChallengeDocument = updateChallengeDocument(
+                                                                    challengeDocument, challengeCreateDto, newLanguage, solutionDocument.getUuid());
+
+                                                            return challengeRepository.save(newChallengeDocument)
+                                                                    .map(savedChallenge -> {
+                                                                        log.info("Challenge {} successfully updated in database.", validId);
+                                                                        log.debug("Saved challenge tags: {}", savedChallenge.getTags());
+                                                                        return challengeConverter.convertDocumentToDto(savedChallenge,
+                                                                                ChallengeDto.class);
+                                                                    });
+                                                        });
+                                            });
+                                }))
+                );
+    }
+
+    @Override
     public Mono<BookmarkDto> addChallengeToBookmarks(String challengeId, String userId) {
 
         Mono<UUID> challengeIdMono = validateUUID(String.valueOf(challengeId));
@@ -422,6 +461,7 @@ public class ChallengeServiceImpl implements IChallengeService {
                                     .map(savedChallenge -> new BookmarkDto( true, savedChallenge.getTimesBookmark())));
                 });
     }
+
     @Override
     public Mono<BookmarkDto> removeChallengeFromBookmarks(String challengeId, String userId) {
         Mono<UUID> challengeIdMono = validateUUID(String.valueOf(challengeId));
@@ -477,4 +517,24 @@ public Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId) {
             });
 }
 
+
+    private SolutionDocument buildSolutionDocument(LanguageDocument language, ChallengeCreateDto challengeCreateDto){
+        return SolutionDocument.builder()
+                .uuid(UUID.randomUUID())
+                .idLanguage(language.getIdLanguage())
+                .solutionText(challengeCreateDto.getSolution())
+                .build();
+    }
+
+    private static ChallengeDocument updateChallengeDocument (ChallengeDocument currentChallenge, ChallengeCreateDto dto, LanguageDocument language, UUID solutionId){
+        currentChallenge.setTitle(dto.getChallengeTitle());
+        currentChallenge.setLevel(String.valueOf(dto.getLevel()));
+        currentChallenge.setDetail(new DetailDocument(dto.getDescription()));
+        currentChallenge.setLanguages(Set.of(language));
+        currentChallenge.setSolutions(List.of(solutionId));
+        currentChallenge.setTopic(dto.getTopic());
+        currentChallenge.setTags(dto.getTags());
+
+        return currentChallenge;
+    }
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -43,5 +43,7 @@ public interface IChallengeService {
 
     Mono<BookmarkDto> removeChallengeFromBookmarks(String challengeId, String userId);
 
+    Mono<ChallengeDto> updateChallenge(String challengeId, ChallengeCreateDto challengeCreateDto);
+
     Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ITagService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ITagService.java
@@ -13,4 +13,5 @@ public interface ITagService {
 
     Mono<GenericResultDto<TagDto>> getAllTags();
     Set<TagDocument> convertIdTagFromTagDocument(List<UUID> tags);
+    Mono<Boolean> getValidatedTags(List<UUID> tagIds);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/TagServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/TagServiceImpl.java
@@ -47,6 +47,7 @@ public class TagServiceImpl implements ITagService {
                 .collect(Collectors.toSet());
     }
 
+    @Override
     public Mono<Boolean> getValidatedTags(List<UUID> tagIds) {
         return Flux.fromIterable(tagIds)
                 .flatMap(tagId -> tagRepository.findById(tagId)

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/TagServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/TagServiceImpl.java
@@ -47,5 +47,11 @@ public class TagServiceImpl implements ITagService {
                 .collect(Collectors.toSet());
     }
 
-
+    public Mono<Boolean> getValidatedTags(List<UUID> tagIds) {
+        return Flux.fromIterable(tagIds)
+                .flatMap(tagId -> tagRepository.findById(tagId)
+                        .switchIfEmpty(Mono.error(new TagNotFoundException("Tag not found: " + tagId))))
+                .count()
+                .map(count -> count == tagIds.size());
+    }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -2,7 +2,6 @@ package com.itachallenge.challenge.controller;
 
 import com.itachallenge.challenge.config.PropertiesConfig;
 import com.itachallenge.challenge.document.DetailDocument;
-import com.itachallenge.challenge.document.SolutionDocument;
 import com.itachallenge.challenge.dto.*;
 import com.itachallenge.challenge.enums.DifficultyLevel;
 import com.itachallenge.challenge.enums.Topic;
@@ -866,55 +865,19 @@ class ChallengeControllerTest {
     @DisplayName("PUT update challenge when valid request returns 200")
 
     void updateChallengeValidRequest_test(){
-<<<<<<< HEAD
-        String userId = "existing_userId";
-        String authHeader = "validAuthHeader";
-        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
 
         when(challengeService.updateChallenge(anyString(), any(ChallengeCreateDto.class)))
                 .thenReturn(Mono.just(createdChallenge));
-=======
-
-        SolutionDocument solutionDocument = new SolutionDocument(UUID.randomUUID(), formData.getSolution(), UUID.randomUUID());
-        LanguageDto languageDto = new LanguageDto(UUID.randomUUID(), formData.getLanguage(), "default_image.png");
-        createdChallenge.setChallengeId(UUID.fromString(challengeId));
-        createdChallenge.setTitle(formData.getChallengeTitle());
-        createdChallenge.setLevel(formData.getLevel().toString());
-        createdChallenge.setSolutions(List.of(solutionDocument.getUuid()));
-        createdChallenge.setLanguages(Set.of(languageDto));
-        createdChallenge.setDetail(new DetailDocument(formData.getDescription()));
-        createdChallenge.setTopic(Topic.valueOf(formData.getTopic().toString()));
-
-        when(challengeService.updateChallenge(anyString(), any(ChallengeCreateDto.class))).thenReturn(Mono.just(createdChallenge));
->>>>>>> 8cdf4209 (Create put endpoint for update challenge calling to service)
 
         webTestClient.put()
                 .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
                 .contentType(MediaType.APPLICATION_JSON)
-<<<<<<< HEAD
-                .header("Authorization", authHeader)
-=======
->>>>>>> 8cdf4209 (Create put endpoint for update challenge calling to service)
                 .bodyValue(formData)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ChallengeDto.class)
-<<<<<<< HEAD
                 .value(Assertions::assertNotNull);
 
-        verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
-=======
-                .consumeWith(response ->{
-                    ChallengeDto body = response.getResponseBody();
-                    assert body != null;
-                    Assertions.assertEquals(challengeId, body.getChallengeId().toString());
-                    Assertions.assertEquals(formData.getChallengeTitle(), body.getTitle());
-                    Assertions.assertEquals(String.valueOf(formData.getLevel()), body.getLevel());
-                    Assertions.assertEquals(solutionDocument.getUuid(), body.getSolutions().getFirst());
-
-                });
-
->>>>>>> 8cdf4209 (Create put endpoint for update challenge calling to service)
         verify(challengeService, times(1))
                 .updateChallenge(anyString(), any(ChallengeCreateDto.class));
     }
@@ -977,7 +940,7 @@ class ChallengeControllerTest {
                 Arguments.of(String.format(baseJson, "EASY", "invalidTopic"))
         );
     }
-<<<<<<< HEAD
+
     @Test
     void removeChallengeFromBookmarks_Success_Returns200() {
         String challengeId = "existing_challengeId";
@@ -1083,9 +1046,6 @@ class ChallengeControllerTest {
         verify(challengeService, times(0)).removeChallengeFromBookmarks(anyString(), anyString());
 
     }
-
-=======
->>>>>>> 8cdf4209 (Create put endpoint for update challenge calling to service)
 }
 
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -2,7 +2,6 @@ package com.itachallenge.challenge.controller;
 
 import com.itachallenge.challenge.config.PropertiesConfig;
 import com.itachallenge.challenge.document.DetailDocument;
-import com.itachallenge.challenge.document.SolutionDocument;
 import com.itachallenge.challenge.dto.*;
 import com.itachallenge.challenge.enums.DifficultyLevel;
 import com.itachallenge.challenge.enums.Topic;
@@ -867,17 +866,8 @@ class ChallengeControllerTest {
 
     void updateChallengeValidRequest_test(){
 
-        SolutionDocument solutionDocument = new SolutionDocument(UUID.randomUUID(), formData.getSolution(), UUID.randomUUID());
-        LanguageDto languageDto = new LanguageDto(UUID.randomUUID(), formData.getLanguage(), "default_image.png");
-        createdChallenge.setChallengeId(UUID.fromString(challengeId));
-        createdChallenge.setTitle(formData.getChallengeTitle());
-        createdChallenge.setLevel(formData.getLevel().toString());
-        createdChallenge.setSolutions(List.of(solutionDocument.getUuid()));
-        createdChallenge.setLanguages(Set.of(languageDto));
-        createdChallenge.setDetail(new DetailDocument(formData.getDescription()));
-        createdChallenge.setTopic(Topic.valueOf(formData.getTopic().toString()));
-
-        when(challengeService.updateChallenge(anyString(), any(ChallengeCreateDto.class))).thenReturn(Mono.just(createdChallenge));
+        when(challengeService.updateChallenge(anyString(), any(ChallengeCreateDto.class)))
+                .thenReturn(Mono.just(createdChallenge));
 
         webTestClient.put()
                 .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
@@ -886,15 +876,7 @@ class ChallengeControllerTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ChallengeDto.class)
-                .consumeWith(response ->{
-                    ChallengeDto body = response.getResponseBody();
-                    assert body != null;
-                    Assertions.assertEquals(challengeId, body.getChallengeId().toString());
-                    Assertions.assertEquals(formData.getChallengeTitle(), body.getTitle());
-                    Assertions.assertEquals(String.valueOf(formData.getLevel()), body.getLevel());
-                    Assertions.assertEquals(solutionDocument.getUuid(), body.getSolutions().getFirst());
-
-                });
+                .value(Assertions::assertNotNull);
 
         verify(challengeService, times(1))
                 .updateChallenge(anyString(), any(ChallengeCreateDto.class));

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -889,7 +889,11 @@ class ChallengeControllerTest {
                 .consumeWith(response ->{
                     ChallengeDto body = response.getResponseBody();
                     assert body != null;
+                    Assertions.assertEquals(challengeId, body.getChallengeId().toString());
                     Assertions.assertEquals(formData.getChallengeTitle(), body.getTitle());
+                    Assertions.assertEquals(String.valueOf(formData.getLevel()), body.getLevel());
+                    Assertions.assertEquals(solutionDocument.getUuid(), body.getSolutions().getFirst());
+
                 });
 
         verify(challengeService, times(1))

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -865,6 +865,9 @@ class ChallengeControllerTest {
     @DisplayName("PUT update challenge when valid request returns 200")
 
     void updateChallengeValidRequest_test(){
+        String userId = "existing_userId";
+        String authHeader = "validAuthHeader";
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
 
         when(challengeService.updateChallenge(anyString(), any(ChallengeCreateDto.class)))
                 .thenReturn(Mono.just(createdChallenge));
@@ -872,12 +875,14 @@ class ChallengeControllerTest {
         webTestClient.put()
                 .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
                 .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", authHeader)
                 .bodyValue(formData)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ChallengeDto.class)
                 .value(Assertions::assertNotNull);
 
+        verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
         verify(challengeService, times(1))
                 .updateChallenge(anyString(), any(ChallengeCreateDto.class));
     }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.challenge.controller;
 
 import com.itachallenge.challenge.config.PropertiesConfig;
 import com.itachallenge.challenge.document.DetailDocument;
+import com.itachallenge.challenge.document.SolutionDocument;
 import com.itachallenge.challenge.dto.*;
 import com.itachallenge.challenge.enums.DifficultyLevel;
 import com.itachallenge.challenge.enums.Topic;
@@ -832,11 +833,51 @@ class ChallengeControllerTest {
     }
 
     @Test
+    void getChallengesByFilter_shouldReturnOkResponse() {
+        // Mock de respuesta vacía
+        GenericResultDto<ChallengeDto> resultDto = new GenericResultDto<>();
+        resultDto.setInfo(0, 10, 0, new ChallengeDto[0]);
+
+        UUID mockTag = UUID.randomUUID();
+        UUID languageMok = UUID.randomUUID();
+
+        when(challengeService.getChallengesByFilter(
+                Optional.of(languageMok.toString()),
+                Optional.of("EASY"),
+                Optional.of(List.of(mockTag)),
+                0,
+                2
+        )).thenReturn(Flux.just(resultDto));
+
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/itachallenge/api/v1/challenge/challenges/byFilter")
+                        .queryParam("idLanguage", languageMok.toString())
+                        .queryParam("level", "EASY")
+                        .queryParam("offset", 0)
+                        .queryParam("limit", 2)
+                        .queryParam("tags", mockTag.toString())
+                        .build())
+                .exchange()
+                .expectStatus().isOk();
+    }
+
+    @Test
     @DisplayName("PUT update challenge when valid request returns 200")
 
     void updateChallengeValidRequest_test(){
-        when(challengeService.updateChallenge(anyString(), any(ChallengeCreateDto.class)))
-                .thenReturn(Mono.just(createdChallenge));
+
+        SolutionDocument solutionDocument = new SolutionDocument(UUID.randomUUID(), formData.getSolution(), UUID.randomUUID());
+        LanguageDto languageDto = new LanguageDto(UUID.randomUUID(), formData.getLanguage(), "default_image.png");
+        createdChallenge.setChallengeId(UUID.fromString(challengeId));
+        createdChallenge.setTitle(formData.getChallengeTitle());
+        createdChallenge.setLevel(formData.getLevel().toString());
+        createdChallenge.setSolutions(List.of(solutionDocument.getUuid()));
+        createdChallenge.setLanguages(Set.of(languageDto));
+        createdChallenge.setDetail(new DetailDocument(formData.getDescription()));
+        createdChallenge.setTopic(Topic.valueOf(formData.getTopic().toString()));
+
+        when(challengeService.updateChallenge(anyString(), any(ChallengeCreateDto.class))).thenReturn(Mono.just(createdChallenge));
 
         webTestClient.put()
                 .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
@@ -845,7 +886,11 @@ class ChallengeControllerTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ChallengeDto.class)
-                .value(Assertions::assertNotNull);
+                .consumeWith(response ->{
+                    ChallengeDto body = response.getResponseBody();
+                    assert body != null;
+                    Assertions.assertEquals(formData.getChallengeTitle(), body.getTitle());
+                });
 
         verify(challengeService, times(1))
                 .updateChallenge(anyString(), any(ChallengeCreateDto.class));
@@ -909,37 +954,6 @@ class ChallengeControllerTest {
                 Arguments.of(String.format(baseJson, "EASY", "invalidTopic"))
         );
     }
-
-    @Test
-    void getChallengesByFilter_shouldReturnOkResponse() {
-        // Mock de respuesta vacía
-        GenericResultDto<ChallengeDto> resultDto = new GenericResultDto<>();
-        resultDto.setInfo(0, 10, 0, new ChallengeDto[0]);
-
-        UUID mockTag = UUID.randomUUID();
-        UUID languageMok = UUID.randomUUID();
-
-        when(challengeService.getChallengesByFilter(
-                Optional.of(languageMok.toString()),
-                Optional.of("EASY"),
-                Optional.of(List.of(mockTag)),
-                0,
-                2
-        )).thenReturn(Flux.just(resultDto));
-
-        webTestClient.get()
-                .uri(uriBuilder -> uriBuilder
-                        .path("/itachallenge/api/v1/challenge/challenges/byFilter")
-                        .queryParam("idLanguage", languageMok.toString())
-                        .queryParam("level", "EASY")
-                        .queryParam("offset", 0)
-                        .queryParam("limit", 2)
-                        .queryParam("tags", mockTag.toString())
-                        .build())
-                .exchange()
-                .expectStatus().isOk();
-    }
-
     @Test
     void removeChallengeFromBookmarks_Success_Returns200() {
         String challengeId = "existing_challengeId";

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -10,9 +10,13 @@ import com.itachallenge.challenge.service.IChallengeService;
 import com.itachallenge.challenge.service.ITagService;
 import com.itachallenge.challenge.service.JwtServiceImpl;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -27,9 +31,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -61,19 +65,19 @@ class ChallengeControllerTest {
     @MockBean
     private JwtServiceImpl jwtService;
 
-    UUID challengeId = UUID.randomUUID();
-    String challengeTitle = "Challenge modificat";
-    String level = "EASY";
-    String description = "Here are the details of the challenge.";
-    DetailDocument detail = new DetailDocument(description);
-    String language = "Java";
-    LanguageDto languageDto = new LanguageDto(UUID.randomUUID(), language, "https://default-image.com/default.png");
-    UUID solutionUuid = UUID.fromString("d624bae4-9a43-4515-8979-801c0d6fd88c");
-    String solution = "Solution proposed by IT Academy";
-    Topic topic = Topic.ALL;
-    UUID tag = UUID.randomUUID();
-    List<UUID> tags = List.of(tag);
-    String localTimeStr = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    private List<UUID> tags;
+    private String challengeId;
+    private ChallengeCreateDto formData;
+    private ChallengeDto createdChallenge;
+
+    @BeforeEach
+    void setup(){
+        tags = List.of(UUID.randomUUID());
+        challengeId = String.valueOf(UUID.randomUUID());
+        formData = new ChallengeCreateDto("títol", "descripció",
+                DifficultyLevel.valueOf("EASY"), "Java", "solució", Topic.LISTS, tags);
+        createdChallenge = new ChallengeDto();
+    }
 
     @Test
     void getOneChallenge_ChallengeFound_ReturnsOkResponse() {
@@ -828,73 +832,82 @@ class ChallengeControllerTest {
     }
 
     @Test
-    @DisplayName("PUT /challenges/{challengeId}/update must return a mock of the updated challenge")
-    void updateChallenge_allArgumentsCorrect_return200_OK_test(){
+    @DisplayName("PUT update challenge when valid request returns 200")
 
-        ChallengeDto expectedChallenge = ChallengeDto.builder()
-                .challengeId(challengeId)
-                .title(challengeTitle)
-                .level(level)
-                .creationDate(localTimeStr)
-                .detail(detail)
-                .popularity(10)
-                .percentage(0.5F)
-                .languages(Set.of(languageDto))
-                .solutions(List.of(solutionUuid))
-                .topic(topic)
-                .timesFavorite(10)
-                .timesBookmark(10)
-                .build();
-
-        ChallengeCreateDto challengeCreateDto = ChallengeCreateDto.builder()
-                .challengeTitle(challengeTitle)
-                .description(description)
-                .level(DifficultyLevel.EASY)
-                .language(language)
-                .solution(solution)
-                .topic(Topic.ALL)
-                .tags(tags)
-                .build();
+    void updateChallengeValidRequest_test(){
+        when(challengeService.updateChallenge(anyString(), any(ChallengeCreateDto.class)))
+                .thenReturn(Mono.just(createdChallenge));
 
         webTestClient.put()
                 .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
                 .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(challengeCreateDto)
+                .bodyValue(formData)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ChallengeDto.class)
-                .consumeWith(data -> {
-                    ChallengeDto response = data.getResponseBody();
-                    assert response != null;
-                    Assertions.assertEquals(expectedChallenge.getChallengeId(), response.getChallengeId());
-                    Assertions.assertEquals(expectedChallenge.getTitle(), response.getTitle());
-                    Assertions.assertEquals(expectedChallenge.getLevel(), response.getLevel());
-                    Assertions.assertEquals(expectedChallenge.getCreationDate(), response.getCreationDate());
-                    Assertions.assertEquals(expectedChallenge.getDetail().getDescription(), response.getDetail().getDescription());
-                    Assertions.assertEquals(expectedChallenge.getTitle(), response.getTitle());
-                    Assertions.assertEquals(expectedChallenge.getPopularity(), response.getPopularity());
-                    Assertions.assertEquals(expectedChallenge.getPercentage(), response.getPercentage());
-                    Assertions.assertTrue(expectedChallenge.getLanguages().contains(languageDto));
-                    Assertions.assertTrue(expectedChallenge.getSolutions().contains(solutionUuid));
-                    Assertions.assertEquals(expectedChallenge.getTopic(), response.getTopic());
-                    Assertions.assertEquals(expectedChallenge.getTimesFavorite(), response.getTimesFavorite());
-                    Assertions.assertEquals(expectedChallenge.getTimesBookmark(), response.getTimesBookmark());
-                });
+                .value(Assertions::assertNotNull);
+
+        verify(challengeService, times(1))
+                .updateChallenge(anyString(), any(ChallengeCreateDto.class));
     }
 
-    @Test
-    @DisplayName("PUT /challenges/{challengeId}/update must return Bad Request when not valid Request body")
-    void updateChallenge_badArgument_return400_BadRequest_test(){
-        ChallengeCreateDto challengeCreateDto = ChallengeCreateDto.builder()
-                .challengeTitle("Challenge Title")
-                .build();
+    @ParameterizedTest
+    @MethodSource("provideEmptyFields")
+    void updateChallengeEmptyField_returnsBadRequest_test(Consumer<ChallengeCreateDto> fieldSetter){
+
+        fieldSetter.accept(formData);
+        webTestClient.put()
+                .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(formData)
+                .exchange()
+                .expectStatus().isBadRequest();
+
+        verifyNoInteractions(challengeService);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidEnumValues")
+    void updateChallengeInvalidEnumValue_returnsBadRequest_test(String jsonBody){
 
         webTestClient.put()
                 .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
                 .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(challengeCreateDto)
+                .bodyValue(jsonBody)
                 .exchange()
                 .expectStatus().isBadRequest();
+
+        verifyNoInteractions(challengeService);
+    }
+
+    private static Stream<Arguments> provideEmptyFields() {
+        return Stream.of(
+                Arguments.of((Consumer<ChallengeCreateDto>) dto -> dto.setChallengeTitle("")),
+                Arguments.of((Consumer<ChallengeCreateDto>) dto -> dto.setDescription("")),
+                Arguments.of((Consumer<ChallengeCreateDto>) dto -> dto.setLanguage("")),
+                Arguments.of((Consumer<ChallengeCreateDto>) dto -> dto.setSolution(null)),
+                Arguments.of((Consumer<ChallengeCreateDto>) dto -> dto.setTopic(null))
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidEnumValues() {
+
+        String baseJson = """
+        {
+          "challengeTitle": "Title",
+          "description": "Description",
+          "level": "%s",
+          "language": "Java",
+          "solution": "valid solution",
+          "topic": "%s",
+          "tags": {}
+        }
+        """;
+
+        return Stream.of(
+                Arguments.of(String.format(baseJson, "invalidLevel", "ALL")),
+                Arguments.of(String.format(baseJson, "EASY", "invalidTopic"))
+        );
     }
 
     @Test

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -907,7 +907,11 @@ class ChallengeControllerTest {
                 .consumeWith(response ->{
                     ChallengeDto body = response.getResponseBody();
                     assert body != null;
+                    Assertions.assertEquals(challengeId, body.getChallengeId().toString());
                     Assertions.assertEquals(formData.getChallengeTitle(), body.getTitle());
+                    Assertions.assertEquals(String.valueOf(formData.getLevel()), body.getLevel());
+                    Assertions.assertEquals(solutionDocument.getUuid(), body.getSolutions().getFirst());
+
                 });
 
 >>>>>>> 8cdf4209 (Create put endpoint for update challenge calling to service)

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.challenge.controller;
 
 import com.itachallenge.challenge.config.PropertiesConfig;
 import com.itachallenge.challenge.document.DetailDocument;
+import com.itachallenge.challenge.document.SolutionDocument;
 import com.itachallenge.challenge.dto.*;
 import com.itachallenge.challenge.enums.DifficultyLevel;
 import com.itachallenge.challenge.enums.Topic;
@@ -865,24 +866,51 @@ class ChallengeControllerTest {
     @DisplayName("PUT update challenge when valid request returns 200")
 
     void updateChallengeValidRequest_test(){
+<<<<<<< HEAD
         String userId = "existing_userId";
         String authHeader = "validAuthHeader";
         when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
 
         when(challengeService.updateChallenge(anyString(), any(ChallengeCreateDto.class)))
                 .thenReturn(Mono.just(createdChallenge));
+=======
+
+        SolutionDocument solutionDocument = new SolutionDocument(UUID.randomUUID(), formData.getSolution(), UUID.randomUUID());
+        LanguageDto languageDto = new LanguageDto(UUID.randomUUID(), formData.getLanguage(), "default_image.png");
+        createdChallenge.setChallengeId(UUID.fromString(challengeId));
+        createdChallenge.setTitle(formData.getChallengeTitle());
+        createdChallenge.setLevel(formData.getLevel().toString());
+        createdChallenge.setSolutions(List.of(solutionDocument.getUuid()));
+        createdChallenge.setLanguages(Set.of(languageDto));
+        createdChallenge.setDetail(new DetailDocument(formData.getDescription()));
+        createdChallenge.setTopic(Topic.valueOf(formData.getTopic().toString()));
+
+        when(challengeService.updateChallenge(anyString(), any(ChallengeCreateDto.class))).thenReturn(Mono.just(createdChallenge));
+>>>>>>> 8cdf4209 (Create put endpoint for update challenge calling to service)
 
         webTestClient.put()
                 .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
                 .contentType(MediaType.APPLICATION_JSON)
+<<<<<<< HEAD
                 .header("Authorization", authHeader)
+=======
+>>>>>>> 8cdf4209 (Create put endpoint for update challenge calling to service)
                 .bodyValue(formData)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ChallengeDto.class)
+<<<<<<< HEAD
                 .value(Assertions::assertNotNull);
 
         verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
+=======
+                .consumeWith(response ->{
+                    ChallengeDto body = response.getResponseBody();
+                    assert body != null;
+                    Assertions.assertEquals(formData.getChallengeTitle(), body.getTitle());
+                });
+
+>>>>>>> 8cdf4209 (Create put endpoint for update challenge calling to service)
         verify(challengeService, times(1))
                 .updateChallenge(anyString(), any(ChallengeCreateDto.class));
     }
@@ -945,6 +973,7 @@ class ChallengeControllerTest {
                 Arguments.of(String.format(baseJson, "EASY", "invalidTopic"))
         );
     }
+<<<<<<< HEAD
     @Test
     void removeChallengeFromBookmarks_Success_Returns200() {
         String challengeId = "existing_challengeId";
@@ -1051,6 +1080,8 @@ class ChallengeControllerTest {
 
     }
 
+=======
+>>>>>>> 8cdf4209 (Create put endpoint for update challenge calling to service)
 }
 
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
@@ -253,6 +253,4 @@ class ChallengeTest {
         assertTrue(tags.contains(firstTagId), "Debe contener el primer tag");
         assertTrue(tags.contains(secondTagId), "Debe contener el nuevo tag");
     }
-
-
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
@@ -234,7 +234,8 @@ class ChallengeTest {
     @Test
     void setTagsTest() {
         UUID firstTagId = UUID.randomUUID();
-        TagDocument firstTag = new TagDocument(firstTagId, "POO", "bla bla bla");
+        UUID secondTagId = UUID.randomUUID();
+        List<UUID> tags = List.of(firstTagId, secondTagId);
 
         ChallengeDocument challenge = new ChallengeDocument(
                 null, null, null, null, null, null, null,
@@ -242,17 +243,13 @@ class ChallengeTest {
                 20,
                 null,
                 null,
-                new ArrayList<UUID>(List.of(firstTag.getIdTag())) {
+                new ArrayList<UUID>() {
                 }
         );
 
-        UUID secondTagId = UUID.randomUUID();
-        TagDocument secondTag = new TagDocument(secondTagId, "Estructura", "bla bla bla");
+        challenge.setTags(tags);
 
-        challenge.setTags(secondTag.getIdTag());
-
-        List<UUID> tags = challenge.getTags();
-        assertEquals(2, tags.size(), "El challenge debería tener 2 tags");
+        assertEquals(2, challenge.getTags().size(), "El challenge debería tener 2 tags");
         assertTrue(tags.contains(firstTagId), "Debe contener el primer tag");
         assertTrue(tags.contains(secondTagId), "Debe contener el nuevo tag");
     }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
@@ -230,7 +230,6 @@ class ChallengeTest {
         assertEquals(4, challenge.getTimesSolved());
     }
 
-
     @Test
     void setTagsTest() {
         UUID firstTagId = UUID.randomUUID();

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -24,7 +24,10 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
@@ -81,7 +84,8 @@ class ChallengeServiceImplTest {
         String description = "Detall";
         String level = "EASY";
         String solutionBody = "Solution Text";
-        List<UUID> tags = List.of(UUID.randomUUID());
+        List<UUID> tags = new ArrayList<>();
+        tags.add(UUID.randomUUID());
 
         formData = new ChallengeCreateDto(title, description, DifficultyLevel.valueOf(level),
                 languageName, solutionBody, Topic.LISTS, tags);
@@ -110,7 +114,7 @@ class ChallengeServiceImplTest {
         challengeDto = getChallengeDtoMocked(challengeRandomId, title, level, creationDate, detail,
                 Set.of(languageDto),
                 List.of(solutionsRandomId),
-                popularity, percentage);
+                popularity, percentage, tags);
     }
 
 
@@ -523,7 +527,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
     private ChallengeDto getChallengeDtoMocked(UUID challengeId, String title, String level, String creationDate, DetailDocument detail,
                                                Set<LanguageDto> languages,
-                                               List<UUID> solutions, Integer popularity, Float percentage) {
+                                               List<UUID> solutions, Integer popularity, Float percentage, List<UUID> tags) {
         ChallengeDto challengeDocMocked = mock(ChallengeDto.class);
         when(challengeDocMocked.getChallengeId()).thenReturn(challengeId);
         when(challengeDocMocked.getTitle()).thenReturn(title);
@@ -534,6 +538,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
         when(challengeDocMocked.getSolutions()).thenReturn(solutions);
         when(challengeDocMocked.getPopularity()).thenReturn(popularity);
         when(challengeDocMocked.getPercentage()).thenReturn(percentage);
+        when(challengeDocMocked.getTags()).thenReturn(tags);
         return challengeDocMocked;
     }
 
@@ -1866,7 +1871,141 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     public static Stream<Integer> removeChallengeFromBookmarks_WhenNotRemovedAndTimesBookmarkIsNullOrZero_SetTimesBookmarkedToZeroAndReturnsBookmarkDTO() {
         return Stream.of(null, 0);
     }
+
+    @Test
+    void updateChallenge_success_test(){
+
+        String challengeId = challengeDocument.getUuid().toString();
+        AtomicReference<SolutionDocument> savedSolutionDocument = new AtomicReference<>();
+
+        when(ILanguageService.findFirstByLanguageName(anyString()))
+                .thenReturn(Mono.just(languageDocument));
+        when(challengeRepository.findByUuid(UUID.fromString(challengeId))).thenReturn(Mono.just(challengeDocument));
+        when(tagService.getValidatedTags(formData.getTags())).thenReturn(Mono.just(true));
+        when(solutionRepository.save(any(SolutionDocument.class))).thenAnswer(resp -> {
+            SolutionDocument solutionDocument1 = resp.getArgument(0);
+            savedSolutionDocument.set(solutionDocument1);
+            return Mono.just(solutionDocument1);
+        });
+        when(challengeRepository.save(any(ChallengeDocument.class)))
+                .thenAnswer(resp -> {
+                    ChallengeDocument updatedChallengeDocument = resp.getArgument(0);
+                    return Mono.just(updatedChallengeDocument);
+                });
+        when(challengeConverter.convertDocumentToDto(any(ChallengeDocument.class), eq(ChallengeDto.class)))
+                .thenAnswer(invocation -> buildChallengeDtoFromDocument(invocation.getArgument(0)));
+
+        StepVerifier.create(challengeService.updateChallenge(challengeId, formData))
+                .consumeNextWith(responseDto ->{
+                    boolean languageMatch = responseDto.getLanguages().stream()
+                            .anyMatch(lang -> formData.getLanguage().equals(lang.getLanguageName()));
+                    SolutionDocument solutionDocument1 = savedSolutionDocument.get();
+
+                    Assertions.assertAll(
+                            () -> Assertions.assertEquals(challengeId, responseDto.getChallengeId().toString()),
+                            () -> Assertions.assertEquals(formData.getChallengeTitle(), responseDto.getTitle()),
+                            () -> Assertions.assertEquals(String.valueOf(formData.getLevel()), responseDto.getLevel()),
+                            () -> Assertions.assertEquals("2023-06-05", responseDto.getCreationDate()),
+                            () -> Assertions.assertEquals(formData.getDescription(), responseDto.getDetail().getDescription()),
+                            () -> Assertions.assertEquals(challengeDocument.getTimesFavorite(), responseDto.getTimesFavorite()),
+                            () -> Assertions.assertEquals(1, responseDto.getLanguages().size()),
+                            () -> Assertions.assertTrue(languageMatch, "language does not match."),
+                            () -> Assertions.assertEquals(formData.getSolution(), solutionDocument1.getSolutionText()),
+                            () -> Assertions.assertEquals(formData.getTopic(), responseDto.getTopic()),
+                            () -> Assertions.assertEquals(challengeDocument.getTimesBookmark(), responseDto.getTimesBookmark()),
+                            () -> Assertions.assertEquals(formData.getTags(), responseDto.getTags())
+                    );
+                })
+                .verifyComplete();
+        verify(ILanguageService, times(1)).findFirstByLanguageName(languageName);
+        verify(challengeRepository, times(1)).findByUuid(UUID.fromString(challengeId));
+        verify(solutionRepository, times(1)).save(any(SolutionDocument.class));
+        verify(challengeRepository, times(1)).save(any(ChallengeDocument.class));
+        verify(challengeConverter, times(1)).convertDocumentToDto(any(ChallengeDocument.class), eq(ChallengeDto.class));
+    }
+
+    @Test
+    void updateChallengeWhenChallengeDoesNotExist_returnsError_test(){
+        String CHALLENGE_NOT_FOUND_ERROR = "Challenge with id: %s not found";
+        String challengeId = challengeDocument.getUuid().toString();
+        when(ILanguageService.findFirstByLanguageName(anyString()))
+                .thenReturn(Mono.just(languageDocument));
+        when(challengeRepository.findByUuid(UUID.fromString(challengeId))).thenReturn(Mono.empty());
+
+        StepVerifier.create(challengeService.updateChallenge(challengeId, formData))
+                .expectErrorMatches(error ->
+                        error instanceof ChallengeNotFoundReturn404Exception &&
+                                error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeId)))
+                .verify();
+
+        verify(ILanguageService, times(1)).findFirstByLanguageName(languageName);
+        verify(challengeRepository, times(1)).findByUuid(UUID.fromString(challengeId));
+        verifyNoInteractions(solutionRepository, challengeConverter, tagService);
+        verifyNoMoreInteractions(challengeRepository);
+    }
+
+    @Test
+    void updateChallengeWhenLanguageDoesNotExist_returnsError_test(){
+
+        String LANGUAGE_NOT_FOUND_ERROR = "Language %s is not valid";
+        String challengeId = challengeDocument.getUuid().toString();
+        when(ILanguageService.findFirstByLanguageName(anyString()))
+                .thenReturn(Mono.empty());
+
+        StepVerifier.create(challengeService.updateChallenge(challengeId, formData))
+                .expectErrorMatches(error ->
+                        error instanceof LanguageNotFoundException &&
+                                error.getMessage().equals(String.format(LANGUAGE_NOT_FOUND_ERROR, formData.getLanguage())))
+                .verify();
+
+        verify(ILanguageService, times(1)).findFirstByLanguageName(languageName);
+        verifyNoInteractions(challengeRepository, solutionRepository, challengeConverter, tagService);
+    }
+
+    @Test
+    void updateChallengeWhenChallengeIdNotValid_returnError_test(){
+        String challengeId = "InvalidId";
+        when(ILanguageService.findFirstByLanguageName(anyString())).thenReturn(Mono.just(languageDocument));
+        StepVerifier.create(challengeService.updateChallenge(challengeId, formData))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+        verify(ILanguageService, times(1)).findFirstByLanguageName(languageName);
+        verifyNoInteractions(challengeRepository, solutionRepository, challengeConverter, tagService);
+    }
+
+    @Test
+    void updateChallengeWhenChallengeUuidIsNull_ReturnsError() {
+
+        when(ILanguageService.findFirstByLanguageName(anyString())).thenReturn(Mono.just(languageDocument));
+
+        StepVerifier.create(challengeService.updateChallenge(null, formData))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+        verify(ILanguageService, times(1)).findFirstByLanguageName(languageName);
+        verifyNoInteractions(challengeRepository, solutionRepository, challengeConverter, tagService);
+    }
+
+    private ChallengeDto buildChallengeDtoFromDocument(ChallengeDocument doc) {
+        Set<LanguageDto> languageDtos = doc.getLanguages().stream()
+                .map(lang -> new LanguageDto(lang.getIdLanguage(), lang.getLanguageName(), lang.getLanguageImage()))
+                .collect(Collectors.toSet());
+
+        return ChallengeDto.builder()
+                .challengeId(doc.getUuid())
+                .title(doc.getTitle())
+                .level(doc.getLevel())
+                .creationDate(doc.getCreationDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .detail(doc.getDetail())
+                .languages(languageDtos)
+                .solutions(doc.getSolutions())
+                .topic(doc.getTopic())
+                .timesFavorite(doc.getTimesFavorite())
+                .tags(doc.getTags())
+                .timesBookmark(doc.getTimesBookmark())
+                .build();
+    }
 }
-
-
-

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/TagServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/TagServiceImplTest.java
@@ -7,6 +7,7 @@ import com.itachallenge.challenge.dto.TagDto;
 import com.itachallenge.challenge.exception.TagNotFoundException;
 import com.itachallenge.challenge.helper.DocumentToDtoConverter;
 import com.itachallenge.challenge.repository.TagRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -138,7 +139,6 @@ class TagServiceImplTest {
                 .expectNext(true).verifyComplete();
         verify(tagRepository).findById(tagDocument.getIdTag());
     }
-
 }
 
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/TagServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/TagServiceImplTest.java
@@ -115,6 +115,30 @@ class TagServiceImplTest {
         verify(tagRepository).findById(missingId);
     }
 
+    @Test
+    @DisplayName("Get exception when tag is not found")
+    void getValidatedTags_notFound_test(){
+        UUID missingId = UUID.randomUUID();
+        when(tagRepository.findById(missingId)).thenReturn(Mono.empty());
+        List<UUID> tagsAssigned = List.of(missingId);
+
+        StepVerifier.create(tagService.getValidatedTags(tagsAssigned))
+                .expectError(TagNotFoundException.class)
+                .verify();
+        verify(tagRepository).findById(missingId);
+    }
+
+    @Test
+    @DisplayName("Returns Mono<true> when tag has been found")
+    void getValidatedTags_returnsTrue_test(){
+        TagDocument tagDocument = new TagDocument(UUID.randomUUID(), "Tag Title", "Tag Description");
+        when(tagRepository.findById(tagDocument.getIdTag())).thenReturn(Mono.just(tagDocument));
+        List<UUID> tagsAssigned = List.of(tagDocument.getIdTag());
+        StepVerifier.create(tagService.getValidatedTags(tagsAssigned))
+                .expectNext(true).verifyComplete();
+        verify(tagRepository).findById(tagDocument.getIdTag());
+    }
+
 }
 
 

--- a/postman/ITA-Challenges.postman_collection.json
+++ b/postman/ITA-Challenges.postman_collection.json
@@ -912,6 +912,41 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Update challenge",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\"challengeTitle\": \"New challenge Title\",\n\"description\": \"This is the new description of this challenge\",\n\"level\": \"EASY\",\n\"language\": \"Java\",\n\"solution\": \"This is the new solution of this challenge.\",\n\"topic\": \"STYLES\",\n\"tags\": [\"08208208-2082-0820-8208-208208208207\"]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://{{ip}}:{{challenge_port}}/itachallenge/api/v1/challenge/challenges/challenge/c13d4f5a-3cf5-46f8-acea-f0db63088863/update",
+							"protocol": "http",
+							"host": [
+								"{{ip}}"
+							],
+							"port": "{{challenge_port}}",
+							"path": [
+								"itachallenge",
+								"api",
+								"v1",
+								"challenge",
+								"challenges",
+								"challenge",
+								"c13d4f5a-3cf5-46f8-acea-f0db63088863",
+								"update"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},

--- a/postman/ITA-Challenges.postman_collection.json
+++ b/postman/ITA-Challenges.postman_collection.json
@@ -612,6 +612,41 @@
 					"response": []
 				},
 				{
+					"name": "Update challenge",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\"challengeTitle\": \"New challenge Title\",\n\"description\": \"This is the new description of this challenge\",\n\"level\": \"EASY\",\n\"language\": \"Java\",\n\"solution\": \"This is the new solution of this challenge.\",\n\"topic\": \"STYLES\",\n\"tags\": [\"08208208-2082-0820-8208-208208208207\"]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://{{ip}}:{{challenge_port}}/itachallenge/api/v1/challenge/challenges/challenge/c13d4f5a-3cf5-46f8-acea-f0db63088863/update",
+							"protocol": "http",
+							"host": [
+								"{{ip}}"
+							],
+							"port": "{{challenge_port}}",
+							"path": [
+								"itachallenge",
+								"api",
+								"v1",
+								"challenge",
+								"challenges",
+								"challenge",
+								"c13d4f5a-3cf5-46f8-acea-f0db63088863",
+								"update"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Challenges/{idChallenge}/related",
 					"request": {
 						"method": "GET",


### PR DESCRIPTION
This PR is related with taiga task #233 https://tree.taiga.io/project/luisvi-ita-challenges/task/233 and creates the endpoint to update an existing challenge including all mandatory logic, but without securization. It's a second step after first PR that only implemented the endpoint returning a mocked ChallengeDto.

Endpoint receives a body with the same ChallengeCreateDto structure as that received when creating a challenge and also returns the same ChallengeDto body with updated data.

Service updateChallenge receives 2 arguments ChallengeCreateDto and challengeId, and makes the following checks:

- new Language must exist
- validates UUIDs
- Existing challenge must exist
- new tags must exist (new method added to check valid tags)

It follows the same steps than addChallenge() for global coherence.

It includes fixes for

- TagDocument: remove of the field annotation for the id field, so that the id is recognized as _id internal identifier in MongoDb (binary) as it is in other collections.
- ChallengeDto: duplicate index 11 in last fields has been split into indexes 11 and 12.
