### PR TITLE
Feat/281 Controlador y endpoint completo para ver recursos de un reto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-* Issue #844: Added value SOLVED to enum UserChallengeActionType
 * Issue #843: Added DELETE endpoint in the Challenge Microservice to unbookmark a challenge.
 * Issue #829: Added bookmark POST endpoint in the Challenge Microservice to bookmark a challenge.
 * Issue #827: Added bookmark POST endpoint in the User Microservice to bookmark a challenge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## CHANGELOG
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). 
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+* Issue #844: Added value SOLVED to enum UserChallengeActionType
 * Issue #843: Added DELETE endpoint in the Challenge Microservice to unbookmark a challenge.
 * Issue #829: Added bookmark POST endpoint in the Challenge Microservice to bookmark a challenge.
 * Issue #827: Added bookmark POST endpoint in the User Microservice to bookmark a challenge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+* Issue #849: Added GET endpoint to retrieve all User's bookmarked challenges.
 * Issue #843: Added DELETE endpoint in the Challenge Microservice to unbookmark a challenge.
 * Issue #829: Added bookmark POST endpoint in the Challenge Microservice to bookmark a challenge.
 * Issue #827: Added bookmark POST endpoint in the User Microservice to bookmark a challenge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). 
 
+* Issue #852: Added GET endpoint for retrieving resources from a challenge
 * Issue #829: Added bookmark POST endpoint in the Challenge Microservice to bookmark a challenge.
 * Issue #827: Added bookmark POST endpoint in the User Microservice to bookmark a challenge.
 * Issue #831: Added DELETE endpoint for user's bookmals in User Microservice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+* Issue #852: Added GET endpoint in the Challenge Microservice to retrieve resources associated to a challenge
 * Issue #849: Added GET endpoint to retrieve all User's bookmarked challenges.
 * Issue #843: Added DELETE endpoint in the Challenge Microservice to unbookmark a challenge.
+* Issue #852: Added GET endpoint for retrieving resources from a challenge
 * Issue #829: Added bookmark POST endpoint in the Challenge Microservice to bookmark a challenge.
 * Issue #827: Added bookmark POST endpoint in the User Microservice to bookmark a challenge.
 * Issue #831: Added DELETE endpoint for user's bookmals in User Microservice.

--- a/contributors.md
+++ b/contributors.md
@@ -83,3 +83,4 @@
 * Alexandra Bonet - https://github.com/AlexandraBonetCanela
 * Gwénaël Le Moing - https://github.com/g-lemoing
 * Matías Meza - https://github.com/RustyGearBox
+* Marc Bernabeu Rodriguez - https://github.com/trisk910

--- a/contributors.md
+++ b/contributors.md
@@ -84,3 +84,4 @@
 * Gwénaël Le Moing - https://github.com/g-lemoing
 * Matías Meza - https://github.com/RustyGearBox
 * Marc Bernabeu Rodriguez - https://github.com/trisk910
+* Toni Jiménez - https://github.com/tonijimenez72

--- a/contributors.md
+++ b/contributors.md
@@ -85,3 +85,4 @@
 * Matías Meza - https://github.com/RustyGearBox
 * Marc Bernabeu Rodriguez - https://github.com/trisk910
 * Toni Jiménez - https://github.com/tonijimenez72
+* Enric Vicente - https://github.com/EnricW

--- a/contributors.md
+++ b/contributors.md
@@ -83,3 +83,4 @@
 * Alexandra Bonet - https://github.com/AlexandraBonetCanela
 * Gwénaël Le Moing - https://github.com/g-lemoing
 * Matías Meza - https://github.com/RustyGearBox
+* Santiago Hernandez Beltran - https://github.com/shernandez334

--- a/contributors.md
+++ b/contributors.md
@@ -86,6 +86,5 @@
 * Marc Bernabeu Rodriguez - https://github.com/trisk910
 * Toni Jiménez - https://github.com/tonijimenez72
 * Enric Vicente - https://github.com/EnricW
-* Santiago Hernandez Beltran - https://github.com/shernandez334
 * Ismael Peiró - https://github.com/IsmaPeiro
 * Santiago Hernandez Beltran - https://github.com/shernandez334

--- a/contributors.md
+++ b/contributors.md
@@ -86,3 +86,4 @@
 * Marc Bernabeu Rodriguez - https://github.com/trisk910
 * Toni Jiménez - https://github.com/tonijimenez72
 * Enric Vicente - https://github.com/EnricW
+* Ismael Peiró - https://github.com/IsmaPeiro

--- a/contributors.md
+++ b/contributors.md
@@ -88,3 +88,4 @@
 * Enric Vicente - https://github.com/EnricW
 * Ismael Peiró - https://github.com/IsmaPeiro
 * Santiago Hernandez Beltran - https://github.com/shernandez334
+* Inga Demetrashvili - https://github.com/IngaD89

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -39,7 +38,6 @@ public class AuthService implements IAuthService {
 
     private final String clientSecret;
 
-    @Autowired
     public AuthService(WebClient.Builder webClientBuilder,
                        @Value("${spring.security.oauth2.client.provider.github.token-uri}") String githubTokenUri,
                        @Value("${spring.security.oauth2.client.provider.github.user-info-uri}") String githubUserInfoUri,

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeSolvedController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeSolvedController.java
@@ -1,0 +1,53 @@
+package com.itachallenge.challenge.controller;
+
+import com.itachallenge.challenge.dto.SolvedDto;
+import com.itachallenge.challenge.exception.BadRequestException;
+import com.itachallenge.challenge.exception.JwtException;
+import com.itachallenge.challenge.service.IChallengeService;
+import com.itachallenge.challenge.service.IJwtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@Validated
+@RequestMapping(value = "/itachallenge/api/v1/challenge")
+@RequiredArgsConstructor
+public class ChallengeSolvedController {
+
+    private static final Logger log = LoggerFactory.getLogger(ChallengeSolvedController.class);
+
+    private IChallengeService challengeService;
+    private IJwtService jwtService;
+
+    @PostMapping("/challenges/{challengeId}/solved")
+    @Operation(
+            operationId = "Add a challenge to User's solved challenges.",
+            summary = "Add a challenge to solved challenges.",
+            description = "The ID Challenge sent through the URI is added to the user's solved challenges. User Id is determined from the headers.",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = SolvedDto.class), mediaType = "application/json")}),
+                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
+                    @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error")
+            }
+    )
+    public Mono<ResponseEntity<SolvedDto>> addChallengeToSolved(
+            @PathVariable String challengeId,
+            @RequestHeader(name = "Authorization", required = false) String authHeader) {
+        return Mono.fromCallable(() -> jwtService.getUserUuIdFromAuthenticationHeader(authHeader))
+                .onErrorMap(JwtException.class, e -> new BadRequestException(e.getMessage()))
+                .flatMap(userId -> challengeService.addChallengeToSolved(challengeId, userId))
+                .doOnError(error -> log.error("Error adding challenge to solved: {}", error.getMessage()))
+                .map(ResponseEntity::ok);
+    }
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
@@ -46,7 +46,7 @@ public class ResourceController {
                 .map(createdResource -> ResponseEntity.ok().body(createdResource));
     }
 
-    @GetMapping("/challenge/resources")
+    @GetMapping("/resources")
     @Operation(
             summary = "Get resources by Challenge ID",
             description = "Retrieve all resources associated with a specific challenge.",

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
@@ -58,7 +58,8 @@ public class ResourceController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Resources found"),
             @ApiResponse(responseCode = "400", description = "Invalid challenge ID"),
-            @ApiResponse(responseCode = "404", description = "No resources found")
+            @ApiResponse(responseCode = "404", description = "No resources found"),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error")
     })
     public Flux<ResourceDto> getResourcesByChallengeId(@PathVariable UUID challengeId) {
         return resourceService.getResourcesByChallengeId(challengeId);

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
@@ -6,12 +6,16 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 @RestController
 @Validated
@@ -40,6 +44,23 @@ public class ResourceController {
         log.info("Creating a new resource {}", resourceDto);
         return resourceService.createResource(resourceDto)
                 .map(createdResource -> ResponseEntity.ok().body(createdResource));
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "Get resources by Challenge ID",
+            description = "Retrieve all resources associated with a specific challenge.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Resources found", content = @Content(schema = @Schema(implementation = ResourceDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid challenge ID"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Flux<ResourceDto> getResourcesByChallengeId(
+            @RequestParam @NotNull UUID challengeId
+    ) {
+        log.info("Fetching resources for challenge ID: {}", challengeId);
+        return resourceService.getResourcesByChallengeId(challengeId);
     }
 }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
@@ -46,7 +46,7 @@ public class ResourceController {
                 .map(createdResource -> ResponseEntity.ok().body(createdResource));
     }
 
-    @GetMapping
+    @GetMapping("/challenge/resources")
     @Operation(
             summary = "Get resources by Challenge ID",
             description = "Retrieve all resources associated with a specific challenge.",

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
@@ -1,17 +1,23 @@
 package com.itachallenge.challenge.controller;
 import com.itachallenge.challenge.dto.ResourceDto;
+
 import com.itachallenge.challenge.service.IResourceService;
 import io.swagger.v3.oas.annotations.Operation;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -46,20 +52,15 @@ public class ResourceController {
                 .map(createdResource -> ResponseEntity.ok().body(createdResource));
     }
 
-    @GetMapping("/resources")
-    @Operation(
-            summary = "Get resources by Challenge ID",
-            description = "Retrieve all resources associated with a specific challenge.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "Resources found", content = @Content(schema = @Schema(implementation = ResourceDto.class))),
-                    @ApiResponse(responseCode = "400", description = "Invalid challenge ID"),
-                    @ApiResponse(responseCode = "500", description = "Internal server error")
-            }
-    )
-    public Flux<ResourceDto> getResourcesByChallengeId(
-            @RequestParam @NotNull UUID challengeId
-    ) {
-        log.info("Fetching resources for challenge ID: {}", challengeId);
+
+    @GetMapping("/challenge/{challengeId}")
+    @Operation(summary = "Get resources by challenge ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Resources found"),
+            @ApiResponse(responseCode = "400", description = "Invalid challenge ID"),
+            @ApiResponse(responseCode = "404", description = "No resources found")
+    })
+    public Flux<ResourceDto> getResourcesByChallengeId(@PathVariable UUID challengeId) {
         return resourceService.getResourcesByChallengeId(challengeId);
     }
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ChallengeDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/ChallengeDocument.java
@@ -48,6 +48,9 @@ public class ChallengeDocument {
     @Field(name="times_bookmark")
     private Integer timesBookmark;
 
+    @Field(name="times_solved")
+    private Integer timesSolved;
+
     @Field(name = "tags")
     private List<UUID> tags;
 
@@ -75,6 +78,10 @@ public class ChallengeDocument {
 
     public void increaseTimesBookmark() {
         timesBookmark = timesBookmark == null ? 1 : timesBookmark + 1;
+    }
+
+    public void increaseTimesSolved() {
+        timesSolved = timesSolved == null ? 1 : timesSolved + 1;
     }
 
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeDto.java
@@ -63,4 +63,8 @@ public class ChallengeDto {
 
     @JsonProperty(index = 11)
     private Integer timesBookmark;
+
+    @JsonProperty(index = 12)
+    private Integer timesSolved;
+    
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/SolvedDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/SolvedDto.java
@@ -1,0 +1,14 @@
+package com.itachallenge.challenge.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class SolvedDto {
+
+    private boolean isSolved;
+
+    private int timesSolved;
+
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/enums/UserChallengeActionType.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/enums/UserChallengeActionType.java
@@ -2,5 +2,6 @@ package com.itachallenge.challenge.enums;
 
 public enum UserChallengeActionType {
     BOOKMARKS,
-    FAVORITES
+    FAVORITES,
+    SOLVED
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
@@ -62,7 +62,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<MessageDto> handleResourceNotFoundException(ResourceNotFoundException ex) {
-        return ResponseEntity.ok().body(new MessageDto(ex.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new MessageDto(ex.getMessage()));
     }
 
     @ExceptionHandler(LanguageNotFoundException.class)

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/helper/DocumentToDtoConverter.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/helper/DocumentToDtoConverter.java
@@ -54,7 +54,8 @@ public class DocumentToDtoConverter<S,D> {
                     .addMapping(ChallengeDocument::getTitle, ChallengeDto::setTitle)
                     .addMapping(ChallengeDocument::getTimesFavorite, ChallengeDto::setTimesFavorite)
                     .addMapping(ChallengeDocument::getTags, ChallengeDto::setTags)
-                    .addMapping(ChallengeDocument::getTimesBookmark, ChallengeDto::setTimesBookmark);
+                    .addMapping(ChallengeDocument::getTimesBookmark, ChallengeDto::setTimesBookmark)
+                    .addMapping(ChallengeDocument::getTimesSolved, ChallengeDto::setTimesSolved);
             mapper.addConverter(converterFromLocalDateTimeToString);
         }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/repository/ResourceRepository.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/repository/ResourceRepository.java
@@ -25,4 +25,5 @@ public interface ResourceRepository extends ReactiveSortingRepository<ResourceDo
     Flux<ResourceDocument> saveAll(Flux<ResourceDocument> resourceDocumentFlux);
     Mono<Void> deleteAll();
 
+    Flux<ResourceDocument> findByChallengeIdsContaining(UUID challengeId);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -451,20 +451,20 @@ public class ChallengeServiceImpl implements IChallengeService {
     @Override
     public Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId) {
 
-        Mono<UUID> challengeIdMono = validateUUID(String.valueOf(challengeId));
-        Mono<UUID> userIdMono = validateUUID(String.valueOf(userId));
+        Mono<UUID> challengeIdMono = validateUUID(challengeId);
+        Mono<UUID> userIdMono = validateUUID(userId);
 
         return Mono.zip(challengeIdMono, userIdMono)
-                .flatMap(Uuidtuple -> {
-                    UUID challengeUuid = Uuidtuple.getT1();
-                    UUID userUuid = Uuidtuple.getT2();
+                .flatMap(uuidTuple -> {
+                    UUID challengeUuid = uuidTuple.getT1();
+                    UUID userUuid = uuidTuple.getT2();
 
                     return challengeRepository.findByUuid(challengeUuid)
                             .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
                             .flatMap(challenge -> userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())
                                     .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
-                                    .flatMap(isAddedToUsersSolved -> {
-                                        if (Boolean.TRUE.equals(isAddedToUsersSolved) ||
+                                    .flatMap(challengeWasAddedToUserSolvedList -> {
+                                        if (Boolean.TRUE.equals(challengeWasAddedToUserSolvedList) ||
                                                 Optional.ofNullable(challenge.getTimesSolved()).orElse(0) == 0) {
                                             challenge.increaseTimesSolved();
                                             return challengeRepository.save(challenge);

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -1,6 +1,12 @@
 package com.itachallenge.challenge.service;
 
 import com.itachallenge.challenge.document.*;
+import com.itachallenge.challenge.dto.ChallengeDto;
+import com.itachallenge.challenge.dto.GenericResultDto;
+import com.itachallenge.challenge.dto.SolutionDto;
+import com.itachallenge.challenge.document.ChallengeDocument;
+import com.itachallenge.challenge.document.LanguageDocument;
+import com.itachallenge.challenge.document.SolutionDocument;
 import com.itachallenge.challenge.dto.*;
 import com.itachallenge.challenge.enums.Topic;
 import com.itachallenge.challenge.exception.*;

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -448,5 +448,31 @@ public class ChallengeServiceImpl implements IChallengeService {
                 });
     }
 
+    @Override
+    public Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId) {
+
+        Mono<UUID> challengeIdMono = validateUUID(String.valueOf(challengeId));
+        Mono<UUID> userIdMono = validateUUID(String.valueOf(userId));
+
+        return Mono.zip(challengeIdMono, userIdMono)
+                .flatMap(Uuidtuple -> {
+                    UUID challengeUuid = Uuidtuple.getT1();
+                    UUID userUuid = Uuidtuple.getT2();
+
+                    return challengeRepository.findByUuid(challengeUuid)
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                            .flatMap(challenge -> userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())
+                                    .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
+                                    .flatMap(isAddedToUsersSolved -> {
+                                        if (Boolean.TRUE.equals(isAddedToUsersSolved) ||
+                                                Optional.ofNullable(challenge.getTimesSolved()).orElse(0) == 0) {
+                                            challenge.increaseTimesSolved();
+                                            return challengeRepository.save(challenge);
+                                        }
+                                        return Mono.just(challenge);
+                                    })
+                                    .map(savedChallenge -> new SolvedDto(true, savedChallenge.getTimesSolved())));
+                });
+    }
 
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -1,12 +1,6 @@
 package com.itachallenge.challenge.service;
 
 import com.itachallenge.challenge.document.*;
-import com.itachallenge.challenge.dto.ChallengeDto;
-import com.itachallenge.challenge.dto.GenericResultDto;
-import com.itachallenge.challenge.dto.SolutionDto;
-import com.itachallenge.challenge.document.ChallengeDocument;
-import com.itachallenge.challenge.document.LanguageDocument;
-import com.itachallenge.challenge.document.SolutionDocument;
 import com.itachallenge.challenge.dto.*;
 import com.itachallenge.challenge.enums.Topic;
 import com.itachallenge.challenge.exception.*;
@@ -448,31 +442,33 @@ public class ChallengeServiceImpl implements IChallengeService {
                 });
     }
 
-    @Override
-    public Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId) {
+@Override
+public Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId) {
+    Mono<UUID> challengeIdMono = validateUUID(challengeId);
+    Mono<UUID> userIdMono = validateUUID(userId);
 
-        Mono<UUID> challengeIdMono = validateUUID(challengeId);
-        Mono<UUID> userIdMono = validateUUID(userId);
+    return Mono.zip(challengeIdMono, userIdMono)
+            .flatMap(uuidTuple -> {
+                UUID challengeUuid = uuidTuple.getT1();
+                UUID userUuid = uuidTuple.getT2();
 
-        return Mono.zip(challengeIdMono, userIdMono)
-                .flatMap(uuidTuple -> {
-                    UUID challengeUuid = uuidTuple.getT1();
-                    UUID userUuid = uuidTuple.getT2();
+                return challengeRepository.findByUuid(challengeUuid)
+                        .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(
+                                String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                        .flatMap(challenge -> {
+                            log.info("It should be connected to user service using the fields {} and {}", challengeUuid, userUuid);
 
-                    return challengeRepository.findByUuid(challengeUuid)
-                            .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
-                            .flatMap(challenge -> userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())
-                                    .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
-                                    .flatMap(challengeWasAddedToUserSolvedList -> {
-                                        if (Boolean.TRUE.equals(challengeWasAddedToUserSolvedList) ||
-                                                Optional.ofNullable(challenge.getTimesSolved()).orElse(0) == 0) {
-                                            challenge.increaseTimesSolved();
-                                            return challengeRepository.save(challenge);
-                                        }
-                                        return Mono.just(challenge);
-                                    })
-                                    .map(savedChallenge -> new SolvedDto(true, savedChallenge.getTimesSolved())));
-                });
-    }
+                            //The part of the user service is not implemented yet, it should be connected to the user service in the future.
+
+                            if (Optional.ofNullable(challenge.getTimesSolved()).orElse(0) == 0) {
+                                challenge.increaseTimesSolved();
+                                return challengeRepository.save(challenge);
+                            }
+
+                            return Mono.just(challenge);
+                        })
+                        .map(updatedChallenge -> new SolvedDto(true, updatedChallenge.getTimesSolved()));
+            });
+}
 
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -42,4 +42,6 @@ public interface IChallengeService {
     Mono<FavoriteDto> removeChallengeFromFavorites(String challengeId, String userId);
 
     Mono<BookmarkDto> removeChallengeFromBookmarks(String challengeId, String userId);
+
+    Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IResourceService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IResourceService.java
@@ -1,12 +1,15 @@
 package com.itachallenge.challenge.service;
 
 import com.itachallenge.challenge.dto.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.UUID;
 
 
 public interface IResourceService {
     Mono<ResourceDto> createResource(ResourceDto resourceDto);
 
+    Flux<ResourceDto> getResourcesByChallengeId(UUID challengeId);
 }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IUserService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IUserService.java
@@ -9,4 +9,6 @@ public interface IUserService {
     Mono<Boolean> removeChallengeFromFavorites(String userId, String challengeId);
 
     Mono<Boolean> removeChallengeFromBookmarks(String userId, String challengeId);
+
+    Mono<Boolean> addChallengeToSolved(String userId, String challengeId);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.*;
@@ -134,5 +135,21 @@ public class ResourceServiceImpl implements IResourceService {
                     return savedDto;
                 })
                 .doOnError(error -> log.error("Error occurred when creating resource {}", error.getMessage()));
+    }
+
+
+    public Flux<ResourceDto> getResourcesByChallengeId(UUID challengeId) {
+
+        if (challengeId == null) {
+            return Flux.error(new IllegalArgumentException("Challenge ID cannot be null"));
+        }
+
+
+        return resourceRepository.findByChallengeIdsContaining(challengeId)
+                .map(resourceDoc -> resourceConverter.convertDocumentToDto(resourceDoc, ResourceDto.class))
+                .onErrorResume(error -> {
+                    log.error("Error fetching resources: {}", error.getMessage());
+                    return Flux.error(new RuntimeException("Server error while fetching resources"));
+                });
     }
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
@@ -5,6 +5,9 @@ import com.itachallenge.challenge.dto.ChallengeListDto;
 import com.itachallenge.challenge.dto.ResourceDto;
 import com.itachallenge.challenge.enums.AssociationType;
 import com.itachallenge.challenge.enums.Topic;
+import com.itachallenge.challenge.exception.BadRequestException;
+import com.itachallenge.challenge.exception.InternalServerErrorException;
+import com.itachallenge.challenge.exception.ResourceNotFoundException;
 import com.itachallenge.challenge.helper.DocumentToDtoConverter;
 import com.itachallenge.challenge.repository.ResourceRepository;
 import org.slf4j.Logger;
@@ -141,15 +144,18 @@ public class ResourceServiceImpl implements IResourceService {
     public Flux<ResourceDto> getResourcesByChallengeId(UUID challengeId) {
 
         if (challengeId == null) {
-            return Flux.error(new IllegalArgumentException("Challenge ID cannot be null"));
+            throw new BadRequestException("Challenge ID cannot be null");
         }
 
 
         return resourceRepository.findByChallengeIdsContaining(challengeId)
                 .map(resourceDoc -> resourceConverter.convertDocumentToDto(resourceDoc, ResourceDto.class))
                 .onErrorResume(error -> {
-                    log.error("Error fetching resources: {}", error.getMessage());
-                    return Flux.error(new RuntimeException("Server error while fetching resources"));
+                    log.error("Error fetching resources for challenge ID {}: {}", challengeId, error.getMessage());
+                    if (error instanceof ResourceNotFoundException) {
+                        return Flux.error(error);
+                    }
+                    throw new InternalServerErrorException("Failed to fetch resources for challenge ID: " + challengeId);
                 });
     }
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
@@ -142,20 +142,18 @@ public class ResourceServiceImpl implements IResourceService {
 
 
     public Flux<ResourceDto> getResourcesByChallengeId(UUID challengeId) {
-
-        if (challengeId == null) {
-            throw new BadRequestException("Challenge ID cannot be null");
-        }
-
-
-        return resourceRepository.findByChallengeIdsContaining(challengeId)
-                .map(resourceDoc -> resourceConverter.convertDocumentToDto(resourceDoc, ResourceDto.class))
-                .onErrorResume(error -> {
-                    log.error("Error fetching resources for challenge ID {}: {}", challengeId, error.getMessage());
-                    if (error instanceof ResourceNotFoundException) {
-                        return Flux.error(error);
-                    }
-                    throw new InternalServerErrorException("Failed to fetch resources for challenge ID: " + challengeId);
-                });
+        return Mono.justOrEmpty(challengeId)
+                .switchIfEmpty(Mono.error(new BadRequestException("Challenge ID cannot be null")))
+                .flatMapMany(validChallengeId ->
+                        resourceRepository.findByChallengeIdsContaining(validChallengeId)
+                                .map(resourceDoc -> resourceConverter.convertDocumentToDto(resourceDoc, ResourceDto.class))
+                                .onErrorResume(error -> {
+                                    log.error("Error fetching resources for challenge ID {}: {}", validChallengeId, error.getMessage());
+                                    if (error instanceof ResourceNotFoundException) {
+                                        return Flux.error(error);
+                                    }
+                                    return Flux.error(new InternalServerErrorException("Failed to fetch resources for challenge ID: " + validChallengeId));
+                                })
+                );
     }
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ResourceServiceImpl.java
@@ -146,6 +146,7 @@ public class ResourceServiceImpl implements IResourceService {
                 .switchIfEmpty(Mono.error(new BadRequestException("Challenge ID cannot be null")))
                 .flatMapMany(validChallengeId ->
                         resourceRepository.findByChallengeIdsContaining(validChallengeId)
+                                .switchIfEmpty(Mono.error(new ResourceNotFoundException("No resources found for challenge ID: " + validChallengeId))) // Lanzar 404 si no se encuentra nada
                                 .map(resourceDoc -> resourceConverter.convertDocumentToDto(resourceDoc, ResourceDto.class))
                                 .onErrorResume(error -> {
                                     log.error("Error fetching resources for challenge ID {}: {}", validChallengeId, error.getMessage());

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/UserServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/UserServiceImpl.java
@@ -45,7 +45,7 @@ public class UserServiceImpl implements IUserService {
 
     @Override
     public Mono<Boolean> addChallengeToSolved(String userId, String challengeId) {
-        return callEndpoint(userId, challengeId, UserChallengeActionType.SOLVED, X_SOLVED_MESSAGE, HttpMethod.DELETE);
+        return callEndpoint(userId, challengeId, UserChallengeActionType.SOLVED, X_SOLVED_MESSAGE, HttpMethod.POST);
     }
 
     @Override

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/UserServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/UserServiceImpl.java
@@ -24,6 +24,7 @@ public class UserServiceImpl implements IUserService {
     private final String userServiceUrl;
     private final String X_FAVORITE_MESSAGE = "X-Favorite-Message";
     private final String X_BOOKMARK_MESSAGE = "X-Bookmark-Message";
+    private final String X_SOLVED_MESSAGE = "X-Solved-Message";
 
     public UserServiceImpl(
             WebClient.Builder webClientBuilder,
@@ -40,6 +41,11 @@ public class UserServiceImpl implements IUserService {
     @Override
     public Mono<Boolean> addChallengeToBookmarks(String userId, String challengeId) {
         return callEndpoint(userId, challengeId, UserChallengeActionType.BOOKMARKS, X_BOOKMARK_MESSAGE, HttpMethod.POST);
+    }
+
+    @Override
+    public Mono<Boolean> addChallengeToSolved(String userId, String challengeId) {
+        return callEndpoint(userId, challengeId, UserChallengeActionType.SOLVED, X_SOLVED_MESSAGE, HttpMethod.DELETE);
     }
 
     @Override

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeSolvedControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeSolvedControllerTest.java
@@ -1,0 +1,97 @@
+package com.itachallenge.challenge.controller;
+
+import com.itachallenge.challenge.dto.SolvedDto;
+import com.itachallenge.challenge.exception.BadRequestException;
+import com.itachallenge.challenge.exception.JwtException;
+import com.itachallenge.challenge.service.IChallengeService;
+import com.itachallenge.challenge.service.IJwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+
+class ChallengeSolvedControllerTest {
+
+    @Mock
+    private IChallengeService challengeService;
+
+    @Mock
+    private IJwtService jwtService;
+
+    @InjectMocks
+    private ChallengeSolvedController challengeSolvedController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void addChallengeToSolved_Success() {
+        String challengeId = "123";
+        String authHeader = "Bearer validToken";
+        String userId = "user123";
+        SolvedDto solvedDto = new SolvedDto();
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+        when(challengeService.addChallengeToSolved(challengeId, userId)).thenReturn(Mono.just(solvedDto));
+
+        Mono<ResponseEntity<SolvedDto>> result = challengeSolvedController.addChallengeToSolved(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCodeValue());
+                    assertEquals(solvedDto, response.getBody());
+                })
+                .verifyComplete();
+
+        verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
+        verify(challengeService, times(1)).addChallengeToSolved(challengeId, userId);
+    }
+
+    @Test
+    void addChallengeToSolved_InvalidAuthHeader() {
+        String challengeId = "123";
+        String authHeader = "invalidToken";
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenThrow(new JwtException("Invalid token"));
+
+        Mono<ResponseEntity<SolvedDto>> result = challengeSolvedController.addChallengeToSolved(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof BadRequestException &&
+                        throwable.getMessage().equals("Invalid token"))
+                .verify();
+
+        verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
+        verifyNoInteractions(challengeService);
+    }
+
+    @Test
+    void addChallengeToSolved_ServiceError() {
+        String challengeId = "123";
+        String authHeader = "Bearer validToken";
+        String userId = "user123";
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+        when(challengeService.addChallengeToSolved(challengeId, userId)).thenReturn(Mono.error(new RuntimeException("Service error")));
+
+        Mono<ResponseEntity<SolvedDto>> result = challengeSolvedController.addChallengeToSolved(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof RuntimeException &&
+                        throwable.getMessage().equals("Service error"))
+                .verify();
+
+        verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
+        verify(challengeService, times(1)).addChallengeToSolved(challengeId, userId);
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ResourceControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ResourceControllerTest.java
@@ -1,9 +1,11 @@
 package com.itachallenge.challenge.controller;
 
+
 import com.itachallenge.challenge.dto.ResourceDto;
 import com.itachallenge.challenge.enums.AssociationType;
 import com.itachallenge.challenge.enums.ResourceContentType;
 import com.itachallenge.challenge.enums.Topic;
+import com.itachallenge.challenge.exception.ResourceNotFoundException;
 import com.itachallenge.challenge.service.IResourceService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +26,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
 
 
+import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.UUID;
 
@@ -108,56 +111,78 @@ class ResourceControllerTest {
         verify(resourceService, never()).createResource(any(ResourceDto.class));
     }
 
-
-
     @Test
     void getResourcesByChallengeId_ValidId_ReturnsResources() {
-        // 1. Datos de prueba
+
         UUID challengeId = UUID.randomUUID();
-        ResourceDto resource1 = ResourceDto.builder()
+        ResourceDto mockResource = ResourceDto.builder()
                 .resourceId(UUID.randomUUID())
-                .title("Resource 1")
-                .description("Desc 1")
-                .url("https://example.com/1")
-                .topic(Topic.DEBUGGING)
+                .title("Test Resource")
+                .description("Test Description")
+                .url("http://test.com")
+                .topic(Topic.COMPONENTS)
                 .contentType(ResourceContentType.VIDEO)
                 .challengeIds(List.of(challengeId))
+                .associationType(AssociationType.ALLSAMETOPIC)
                 .build();
 
-        ResourceDto resource2 = ResourceDto.builder()
-                .resourceId(UUID.randomUUID())
-                .title("Resource 2")
-                .description("Desc 2")
-                .url("https://example.com/2")
-                .topic(Topic.COMPONENTS)
-                .contentType(ResourceContentType.BLOG)
-                .challengeIds(List.of(challengeId))
-                .build();
-
-        // 2. Mock del servicio
         when(resourceService.getResourcesByChallengeId(challengeId))
-                .thenReturn(Flux.just(resource1, resource2));
+                .thenReturn(Flux.just(mockResource));
 
-        // 3. Ejecutar y verificar la petición HTTP
+
         webTestClient.get()
-                .uri(uriBuilder -> uriBuilder
-                        .path("/itachallenge/api/v1/resource/resources")
-                        .queryParam("challengeId", challengeId.toString())
-                        .build())
+                .uri("/itachallenge/api/v1/resource/challenge/" + challengeId) // Ruta completa
                 .exchange()
                 .expectStatus().isOk()
                 .expectBodyList(ResourceDto.class)
-                .hasSize(2)
-                .value(resources -> {
-                    assertEquals(resource1.getTitle(), resources.get(0).getTitle());
-                    assertEquals(resource2.getUrl(), resources.get(1).getUrl());
-                });
+                .hasSize(1)
+                .contains(mockResource);
 
-        // 4. Verificar interacción con el servicio
+        verify(resourceService, times(1)).getResourcesByChallengeId(challengeId);
+    }
+
+    @Test
+    void getResourcesByChallengeId_InvalidId_ReturnsBadRequest() {
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/resource/challenge/null") // Ruta completa con ID inválido
+                .exchange()
+                .expectStatus().isBadRequest();
+
+
+        verify(resourceService, never()).getResourcesByChallengeId(any());
+    }
+
+    @Test
+    void getResourcesByChallengeId_NoResources_ReturnsNotFoundWithMessage() {
+
+        UUID challengeId = UUID.randomUUID();
+        String errorMessage = "No resources found for challenge ID: " + challengeId;
+
+        when(resourceService.getResourcesByChallengeId(challengeId))
+                .thenReturn(Flux.error(new ResourceNotFoundException(errorMessage)));
+
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/resource/challenge/" + challengeId)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo(errorMessage);
+
         verify(resourceService, times(1)).getResourcesByChallengeId(challengeId);
     }
 
 
-
-
 }
+
+
+
+
+
+
+
+
+
+
+

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ResourceControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ResourceControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import static org.junit.Assert.*;
@@ -106,6 +107,57 @@ class ResourceControllerTest {
 
         verify(resourceService, never()).createResource(any(ResourceDto.class));
     }
+
+
+
+    @Test
+    void getResourcesByChallengeId_ValidId_ReturnsResources() {
+        // 1. Datos de prueba
+        UUID challengeId = UUID.randomUUID();
+        ResourceDto resource1 = ResourceDto.builder()
+                .resourceId(UUID.randomUUID())
+                .title("Resource 1")
+                .description("Desc 1")
+                .url("https://example.com/1")
+                .topic(Topic.DEBUGGING)
+                .contentType(ResourceContentType.VIDEO)
+                .challengeIds(List.of(challengeId))
+                .build();
+
+        ResourceDto resource2 = ResourceDto.builder()
+                .resourceId(UUID.randomUUID())
+                .title("Resource 2")
+                .description("Desc 2")
+                .url("https://example.com/2")
+                .topic(Topic.COMPONENTS)
+                .contentType(ResourceContentType.BLOG)
+                .challengeIds(List.of(challengeId))
+                .build();
+
+        // 2. Mock del servicio
+        when(resourceService.getResourcesByChallengeId(challengeId))
+                .thenReturn(Flux.just(resource1, resource2));
+
+        // 3. Ejecutar y verificar la petición HTTP
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/itachallenge/api/v1/resource")
+                        .queryParam("challengeId", challengeId.toString())
+                        .build())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(ResourceDto.class)
+                .hasSize(2)
+                .value(resources -> {
+                    assertEquals(resource1.getTitle(), resources.get(0).getTitle());
+                    assertEquals(resource2.getUrl(), resources.get(1).getUrl());
+                });
+
+        // 4. Verificar interacción con el servicio
+        verify(resourceService, times(1)).getResourcesByChallengeId(challengeId);
+    }
+
+
 
 
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ResourceControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ResourceControllerTest.java
@@ -141,7 +141,7 @@ class ResourceControllerTest {
         // 3. Ejecutar y verificar la petición HTTP
         webTestClient.get()
                 .uri(uriBuilder -> uriBuilder
-                        .path("/itachallenge/api/v1/resource")
+                        .path("/itachallenge/api/v1/resource/resources")
                         .queryParam("challengeId", challengeId.toString())
                         .build())
                 .exchange()

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
@@ -208,31 +208,25 @@ class ChallengeTest {
 
     @Test
     void increaseTimesSolved_whenTimesSolvedIsNull_shouldSetToOne() {
-        // Given
         ChallengeDocument challenge = ChallengeDocument.builder()
                 .uuid(UUID.randomUUID())
                 .timesSolved(null)
                 .build();
 
-        // When
         challenge.increaseTimesSolved();
 
-        // Then
         assertEquals(1, challenge.getTimesSolved());
     }
 
     @Test
     void increaseTimesSolved_whenTimesSolvedIsNonNull_shouldIncrementByOne() {
-        // Given
         ChallengeDocument challenge = ChallengeDocument.builder()
                 .uuid(UUID.randomUUID())
                 .timesSolved(3)
                 .build();
 
-        // When
         challenge.increaseTimesSolved();
 
-        // Then
         assertEquals(4, challenge.getTimesSolved());
     }
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
@@ -28,6 +28,7 @@ class ChallengeTest {
                 Topic.LISTS,
                 null,
                 null,
+                null,
                 tags);
         assertEquals(uuid, challenge.getUuid());
     }
@@ -43,6 +44,7 @@ class ChallengeTest {
                 null,
                 null,
                 Topic.COMPONENTS,
+                null,
                 null,
                 null,
                 tags);
@@ -62,6 +64,7 @@ class ChallengeTest {
                 Topic.COMPONENTS,
                 null,
                 null,
+                null,
                 tags);
         assertEquals(level, challenge.getLevel());
     }
@@ -77,6 +80,7 @@ class ChallengeTest {
                 null,
                 null,
                 Topic.COMPONENTS,
+                null,
                 null,
                 null,
                 tags);
@@ -96,6 +100,7 @@ class ChallengeTest {
                 Topic.COMPONENTS,
                 null,
                 null,
+                null,
                 tags);
         assertEquals(detail, challenge.getDetail());
     }
@@ -108,7 +113,7 @@ class ChallengeTest {
                 "https://res.cloudinary.com/itachallenge/image/upload/v1739361249/language_icon_Javascript_asgn04.svg"),
                 new LanguageDocument(uuid2, "Python", "https://res.cloudinary.com/itachallenge/image/upload/v1739361249/language_icon_Python_rphody.svg"));
 
-        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, null, languages, null, Topic.COMPONENTS, null, null, tags);
+        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, null, languages, null, Topic.COMPONENTS, null, null,null, tags);
         assertEquals(languages, challenge.getLanguages());
     }
 
@@ -124,6 +129,7 @@ class ChallengeTest {
                 null,
                 solutions,
                 Topic.COMPONENTS,
+                null,
                 null,
                 null,
                 tags);
@@ -144,6 +150,7 @@ class ChallengeTest {
                 Topic.COMPONENTS,
                 timesFavorite,
                 null,
+                null,
                 tags);
         assertEquals(timesFavorite, challenge.getTimesFavorite());
     }
@@ -152,8 +159,27 @@ class ChallengeTest {
     void getTimesBookmark(){
         int timesBookmark = 30;
 
-        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, null, null, null, Topic.COMPONENTS, null, timesBookmark, tags);
+        ChallengeDocument challenge = new ChallengeDocument(null, null, null, null, null, null, null, Topic.COMPONENTS, null, timesBookmark,null, tags);
         assertEquals(timesBookmark, challenge.getTimesBookmark());
+    }
+
+    @Test
+    void getTimesSolved() {
+        int timesSolved = 21;
+
+        ChallengeDocument challenge = new ChallengeDocument(null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Topic.COMPONENTS,
+                null,
+                null,
+                timesSolved,
+                tags);
+        assertEquals(timesSolved, challenge.getTimesSolved());
     }
 
     @Test
@@ -172,6 +198,7 @@ class ChallengeTest {
                 Topic.COMPONENTS,
                 20,
                 null,
+                null,
                 List.of(tag.getIdTag())
         );
 
@@ -189,6 +216,7 @@ class ChallengeTest {
                 null, null, null, null, null, null, null,
                 Topic.COMPONENTS,
                 20,
+                null,
                 null,
                 new ArrayList<UUID>(List.of(firstTag.getIdTag())) {
                 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
@@ -206,6 +206,36 @@ class ChallengeTest {
         assertEquals(1, challenge.getTags().size());
     }
 
+    @Test
+    void increaseTimesSolved_whenTimesSolvedIsNull_shouldSetToOne() {
+        // Given
+        ChallengeDocument challenge = ChallengeDocument.builder()
+                .uuid(UUID.randomUUID())
+                .timesSolved(null)
+                .build();
+
+        // When
+        challenge.increaseTimesSolved();
+
+        // Then
+        assertEquals(1, challenge.getTimesSolved());
+    }
+
+    @Test
+    void increaseTimesSolved_whenTimesSolvedIsNonNull_shouldIncrementByOne() {
+        // Given
+        ChallengeDocument challenge = ChallengeDocument.builder()
+                .uuid(UUID.randomUUID())
+                .timesSolved(3)
+                .build();
+
+        // When
+        challenge.increaseTimesSolved();
+
+        // Then
+        assertEquals(4, challenge.getTimesSolved());
+    }
+
 
     @Test
     void setTagsTest() {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/SolvedDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/SolvedDtoTest.java
@@ -1,0 +1,46 @@
+package com.itachallenge.challenge.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SolvedDtoTest {
+
+    @Test
+    void testNoArgsConstructorAndSetters() {
+        SolvedDto dto = new SolvedDto();
+        dto.setSolved(true);
+        dto.setTimesSolved(5);
+
+        assertTrue(dto.isSolved());
+        assertEquals(5, dto.getTimesSolved());
+    }
+
+    @Test
+    void testAllArgsConstructor() {
+        SolvedDto dto = new SolvedDto(false, 3);
+
+        assertFalse(dto.isSolved());
+        assertEquals(3, dto.getTimesSolved());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        SolvedDto dto1 = new SolvedDto(true, 2);
+        SolvedDto dto2 = new SolvedDto(true, 2);
+        SolvedDto dto3 = new SolvedDto(false, 5);
+
+        assertEquals(dto1, dto2);
+        assertEquals(dto1.hashCode(), dto2.hashCode());
+        assertNotEquals(dto1, dto3);
+    }
+
+    @Test
+    void testToString() {
+        SolvedDto dto = new SolvedDto(true, 7);
+        String result = dto.toString();
+
+        assertTrue(result.contains("isSolved=true"));
+        assertTrue(result.contains("timesSolved=7"));
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/helper/ChallengeDocumentToDtoConverterTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/helper/ChallengeDocumentToDtoConverterTest.java
@@ -126,6 +126,7 @@ class ChallengeDocumentToDtoConverterTest {
         when(challengeDocMocked.getTopic()).thenReturn(Topic.DEBUGGING);
         when(challengeDocMocked.getTimesFavorite()).thenReturn(20);
         when(challengeDocMocked.getTimesBookmark()).thenReturn(30);
+        when(challengeDocMocked.getTimesSolved()).thenReturn(40);
         when(challengeDocMocked.getTags()).thenReturn(tags);
         return challengeDocMocked;
     }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/helper/ChallengeDocumentToDtoConverterTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/helper/ChallengeDocumentToDtoConverterTest.java
@@ -59,12 +59,13 @@ class ChallengeDocumentToDtoConverterTest {
         Topic topic = Topic.DEBUGGING;
         int timesFavorite = 20;
         int timesBookmark = 30;
+        int timesSolved = 40;
 
         challengeDoc1 = new ChallengeDocument(challengeRandomId1, title, level, localDateTime, detail,
-                Set.of(languageDoc1, languageDoc2), List.of(solutionsRandomId), topic, timesFavorite, timesBookmark, tags);
+                Set.of(languageDoc1, languageDoc2), List.of(solutionsRandomId), topic, timesFavorite, timesBookmark, timesSolved, tags);
 
         challengeDoc2 = new ChallengeDocument(challengeRandomId2, title, level, localDateTime, detail,
-                Set.of(languageDoc1, languageDoc2), List.of(solutionsRandomId), topic, timesFavorite, timesBookmark, tags);
+                Set.of(languageDoc1, languageDoc2), List.of(solutionsRandomId), topic, timesFavorite, timesBookmark, timesSolved, tags);
 
         challengeDto1 = getChallengeDtoMocked(challengeRandomId1, title, level, creationDate, detail,
                 Set.of(languageDto1, languageDto2),

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
@@ -83,10 +83,10 @@ class ChallengeIntegrationTest {
 
         ChallengeDocument challenge = new ChallengeDocument
                 (uuid_1, title1, "Level 1", LocalDateTime.now(), detail, languageSet,
-                        solutionList, Topic.LISTS, 20, 5, tags);
+                        solutionList, Topic.LISTS, 20, 5,2, tags);
         ChallengeDocument challenge2 = new ChallengeDocument
                 (uuid_2, title2, "Level 2", LocalDateTime.now(), detail, languageSet,
-                        solutionList, Topic.COMPONENTS, 20, 30, tags);
+                        solutionList, Topic.COMPONENTS, 20, 30,2, tags);
 
         challengeRepository.saveAll(Flux.just(challenge, challenge2)).blockLast();
     }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ChallengeRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ChallengeRepositoryTest.java
@@ -18,7 +18,6 @@ import reactor.test.StepVerifier;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.Locale;
 
 import static org.junit.Assert.*;
 import static org.springframework.test.util.AssertionErrors.fail;
@@ -66,6 +65,8 @@ class ChallengeRepositoryTest {
 
         List<UUID> favoritedByList = List.of(UUID.randomUUID(),UUID.randomUUID());
 
+        List<UUID> solvedByList = List.of(UUID.randomUUID(),UUID.randomUUID());
+
         DetailDocument detail = new DetailDocument(description);
 
         String title1 = "Loops";
@@ -74,13 +75,13 @@ class ChallengeRepositoryTest {
 
         ChallengeDocument challenge = new ChallengeDocument
                 (uuid_1, title1, "MEDIUM", LocalDateTime.now(), detail, languageSet, solutionList,
-                        Topic.DEBUGGING, 5, 3, tags);
+                        Topic.DEBUGGING, 5, 3, 4, tags);
         ChallengeDocument challenge2 = new ChallengeDocument
                 (uuid_2, title2, "EASY", LocalDateTime.now(), detail, languageSet, solutionList,
-                        Topic.LISTS, 10, 2, tags);
+                        Topic.LISTS, 10, 2, 7, tags);
         ChallengeDocument challenge3 = new ChallengeDocument
                 (uuid_3, title3, "HARD", LocalDateTime.now(), detail, languageSet3, solutionList,
-                        Topic.COMPONENTS, 15, 1, tags);
+                        Topic.COMPONENTS, 15, 1, 9, tags);
 
         challengeRepository.saveAll(Flux.just(challenge, challenge2, challenge3)).blockLast();
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ResourceRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ResourceRepositoryTest.java
@@ -251,4 +251,50 @@ class ResourceRepositoryTest {
                 .expectNext(0L)
                 .verifyComplete();
     }
+
+    // Revisar + limpiar esto
+    // este test Verifica que el método findByChallengeIdsContaining
+    // del repositorio devuelve únicamente los recursos que contienen
+    // el challengeId especificado en su lista de retos asociados.
+    @Test
+    void findByChallengeIdsContaining_WhenChallengeIdExists_ReturnsResources() {
+
+        UUID targetChallengeId = UUID.fromString("8ecbfe54-fec8-11ed-be56-0242ac120002");
+
+
+        ResourceDocument resourceWithTargetChallenge = ResourceDocument.builder()
+                .resourceId(uuid1)
+                .title("Title1")
+                .description("Description1")
+                .url("http://example.com/resource1")
+                .topic(Topic.DEBUGGING)
+                .contentType(ResourceContentType.BLOG)
+                .challengeIds(List.of(targetChallengeId))
+                .build();
+
+        ResourceDocument resourceWithoutTargetChallenge = ResourceDocument.builder()
+                .resourceId(uuid2)
+                .title("Title2")
+                .description("Description2")
+                .url("http://example.com/resource2")
+                .topic(Topic.DEBUGGING)
+                .contentType(ResourceContentType.BLOG)
+                .challengeIds(List.of(UUID.randomUUID()))
+                .build();
+
+
+        resourceRepository.deleteAll().block();
+        resourceRepository.saveAll(Flux.just(resourceWithTargetChallenge, resourceWithoutTargetChallenge)).blockLast();
+
+
+        Flux<ResourceDocument> result = resourceRepository.findByChallengeIdsContaining(targetChallengeId);
+
+
+        StepVerifier.create(result)
+                .expectNextMatches(resource ->
+                        resource.getChallengeIds().contains(targetChallengeId) &&
+                                resource.getResourceId().equals(uuid1)
+                )
+                .verifyComplete();
+    }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ResourceRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ResourceRepositoryTest.java
@@ -252,10 +252,7 @@ class ResourceRepositoryTest {
                 .verifyComplete();
     }
 
-    // Revisar + limpiar esto
-    // este test Verifica que el método findByChallengeIdsContaining
-    // del repositorio devuelve únicamente los recursos que contienen
-    // el challengeId especificado en su lista de retos asociados.
+
     @Test
     void findByChallengeIdsContaining_WhenChallengeIdExists_ReturnsResources() {
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -316,6 +316,78 @@ class ChallengeServiceImplTest {
         verify(solutionConverter, never()).convertDocumentFluxToDtoFlux(any(), any());
     }
 
+@Test
+void addChallengeToSolved_WhenChallengeTimesSolvedIsNull_IncreasesTimesSolvedAndReturnsSolvedDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesSolved(null);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                        .expectNextMatches(solvedDto -> {
+                                return solvedDto.getTimesSolved() == 1 &&
+                                                solvedDto.isSolved();
+                        })
+                        .verifyComplete();
+
+        Assertions.assertEquals(1, challenge.getTimesSolved());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(challengeRepository, times(1)).save(challenge);
+}
+
+@Test
+void addChallengeToSolved_WhenChallengeTimesSolvedIsZero_IncreasesTimesSolvedAndReturnsSolvedDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesSolved(0);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                        .expectNextMatches(solvedDto -> {
+                                return solvedDto.getTimesSolved() == 1 &&
+                                                solvedDto.isSolved();
+                        })
+                        .verifyComplete();
+
+        Assertions.assertEquals(1, challenge.getTimesSolved());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(challengeRepository, times(1)).save(challenge);
+}
+
+@Test
+void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedAndReturnsSolvedDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        int initialTimesSolved = 5;
+
+        challenge.setTimesSolved(initialTimesSolved);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                        .expectNextMatches(solvedDto -> {
+                                return solvedDto.getTimesSolved() == initialTimesSolved &&
+                                                solvedDto.isSolved();
+                        })
+                        .verifyComplete();
+
+        Assertions.assertEquals(initialTimesSolved, challenge.getTimesSolved());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(challengeRepository, times(0)).save(any());
+}
+
     @Test
     void addSolution_ValidChallengeIdAndLanguageId_SolutionAdded() {
         // Arrange
@@ -733,27 +805,6 @@ class ChallengeServiceImplTest {
     }
 
     @Test
-    void addChallengeToSolved_WhenUserNotFound_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new UserNotFoundException(message)));
-
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof InternalServerErrorException &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
     void addChallengeToFavorites_WhenUserServiceReturnsCustomBadRequestException_ReturnsError() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -793,27 +844,6 @@ class ChallengeServiceImplTest {
 
         verify(challengeRepository, times(1)).findByUuid(challengeUuid);
         verify(userService, times(1)).addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
-    void addChallengeToSolved_WhenUserServiceReturnsCustomBadRequestException_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new BadRequestException(message)));
-
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof InternalServerErrorException &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
     }
 
     @Test
@@ -859,27 +889,6 @@ class ChallengeServiceImplTest {
     }
 
     @Test
-    void addChallengeToSolved_WhenUserServiceReturnsCustomInternalServerErrorException_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new InternalServerErrorException(message)));
-
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof InternalServerErrorException &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
     void addChallengeToFavorites_WhenUserServiceReturnsAnyException_ReturnsError() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -919,27 +928,6 @@ class ChallengeServiceImplTest {
 
         verify(challengeRepository, times(1)).findByUuid(challengeUuid);
         verify(userService, times(1)).addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
-    void addChallengeToSolved_WhenUserServiceReturnsAnyException_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new Exception(message)));
-
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof Exception &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
     }
 
     @Test
@@ -997,33 +985,6 @@ class ChallengeServiceImplTest {
     }
 
     @Test
-    void addChallengeToSolved_WhenAdded_IncreasesTimesSolvedAndReturnsSolvedDTO() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        int initialTimesSolved = 20;
-
-        challenge.setTimesSolved(initialTimesSolved);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
-        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
-
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(solvedDto -> {
-                    return solvedDto.getTimesSolved() == initialTimesSolved + 1 &&
-                    solvedDto.isSolved();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(initialTimesSolved + 1, challenge.getTimesSolved());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(1)).save(challenge);
-    }
-
-    @Test
     void addChallengeToFavorites_WhenAddedAndInitialTimesFavoriteIsNull_IncreasesTimesFavoriteAndReturnsFavoriteDTO() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -1072,32 +1033,6 @@ class ChallengeServiceImplTest {
 
         verify(challengeRepository, times(1)).findByUuid(challengeUuid);
         verify(userService, times(1)).addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(1)).save(challenge);
-    }
-
-    @Test
-    void addChallengeToSolved_WhenAddedAndInitialTimesSolvedIsNull_IncreasesTimesSolvedAndReturnsSolvedDTO() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-
-        challenge.setTimesSolved(null);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
-        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
-
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(solvedDto -> {
-                    return solvedDto.getTimesSolved() == 1 &&
-                            solvedDto.isSolved();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(1, challenge.getTimesSolved());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
         verify(challengeRepository, times(1)).save(challenge);
     }
 
@@ -1153,32 +1088,6 @@ class ChallengeServiceImplTest {
         verify(challengeRepository, times(0)).save(any());
     }
 
-    @Test
-    void addChallengeToSolved_WhenNotAdded_NotIncreaseTimesSolvedAndReturnsSolvedDTO() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        int initialTimesSolved = 20;
-
-        challenge.setTimesSolved(initialTimesSolved);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
-
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(solvedDto -> {
-                    return solvedDto.getTimesSolved() == initialTimesSolved &&
-                            solvedDto.isSolved();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(initialTimesSolved, challenge.getTimesSolved());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(0)).save(any());
-    }
-
     @ParameterizedTest
     @MethodSource
     void addChallengeToFavorites_WhenNotAddedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToOneAndReturnsFavoriteDTO(Integer timesFavorite) {
@@ -1230,33 +1139,6 @@ class ChallengeServiceImplTest {
 
         verify(challengeRepository, times(1)).findByUuid(challengeUuid);
         verify(userService, times(1)).addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(1)).save(challenge);
-    }
-
-    @ParameterizedTest
-    @MethodSource
-    void addChallengeToSolved_WhenNotAddedAndTimesSolvedIsNullOrZero_SetTimesSolvedToOneAndReturnsSolvedDTO(Integer timesSolved) {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-
-        challenge.setTimesSolved(timesSolved);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
-        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
-
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(solvedDto -> {
-                    return solvedDto.getTimesSolved() == 1 &&
-                            solvedDto.isSolved();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(1, challenge.getTimesSolved());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
         verify(challengeRepository, times(1)).save(challenge);
     }
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -552,6 +553,15 @@ class ChallengeServiceImplTest {
     }
 
     @Test
+    void addChallengeToSolved_WhenChallengeUuidNotValid_ReturnsError() {
+        StepVerifier.create(challengeService.addChallengeToSolved("InvalidUuid", UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
     void addChallengeToFavorites_WhenUserUuidNotValid_ReturnsError() {
         StepVerifier.create(challengeService.addChallengeToFavorites(UUID.randomUUID().toString(), "InvalidUuid"))
                 .expectErrorMatches(error ->
@@ -563,6 +573,15 @@ class ChallengeServiceImplTest {
     @Test
     void addChallengeToBookmarks_WhenUserUuidNotValid_ReturnsError() {
         StepVerifier.create(challengeService.addChallengeToBookmarks(UUID.randomUUID().toString(), "InvalidUuid"))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void addChallengeToSolved_WhenUserUuidNotValid_ReturnsError() {
+        StepVerifier.create(challengeService.addChallengeToSolved(UUID.randomUUID().toString(), "InvalidUuid"))
                 .expectErrorMatches(error ->
                         error instanceof BadUUIDException &&
                                 error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
@@ -588,6 +607,15 @@ class ChallengeServiceImplTest {
     }
 
     @Test
+    void addChallengeToSolved_WhenChallengeUuidIsNull_ReturnsError() {
+        StepVerifier.create(challengeService.addChallengeToSolved(null, UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
     void addChallengeToFavorites_WhenUserUuidIsNull_ReturnsError() {
         StepVerifier.create(challengeService.addChallengeToFavorites(UUID.randomUUID().toString(), null))
                 .expectErrorMatches(error ->
@@ -599,6 +627,15 @@ class ChallengeServiceImplTest {
     @Test
     void addChallengeToBookmarks_WhenUserUuidIsNull_ReturnsError() {
         StepVerifier.create(challengeService.addChallengeToBookmarks(UUID.randomUUID().toString(), null))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void addChallengeToSolved_WhenUserUuidIsNull_ReturnsError() {
+        StepVerifier.create(challengeService.addChallengeToSolved(UUID.randomUUID().toString(), null))
                 .expectErrorMatches(error ->
                         error instanceof BadUUIDException &&
                                 error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
@@ -629,6 +666,22 @@ class ChallengeServiceImplTest {
         when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.empty());
 
         StepVerifier.create(challengeService.addChallengeToBookmarks(challengeUuid.toString(), UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof ChallengeNotFoundReturn404Exception &&
+                                error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+    }
+
+    @Test
+    void addChallengeToSolved_WhenChallengeNotFound_ReturnsError() {
+        String CHALLENGE_NOT_FOUND_ERROR = "Challenge with id: %s not found";
+        UUID challengeUuid = UUID.randomUUID();
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.empty());
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), UUID.randomUUID().toString()))
                 .expectErrorMatches(error ->
                         error instanceof ChallengeNotFoundReturn404Exception &&
                                 error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
@@ -680,6 +733,27 @@ class ChallengeServiceImplTest {
     }
 
     @Test
+    void addChallengeToSolved_WhenUserNotFound_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new UserNotFoundException(message)));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
     void addChallengeToFavorites_WhenUserServiceReturnsCustomBadRequestException_ReturnsError() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -719,6 +793,27 @@ class ChallengeServiceImplTest {
 
         verify(challengeRepository, times(1)).findByUuid(challengeUuid);
         verify(userService, times(1)).addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void addChallengeToSolved_WhenUserServiceReturnsCustomBadRequestException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new BadRequestException(message)));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
     }
 
     @Test
@@ -764,6 +859,27 @@ class ChallengeServiceImplTest {
     }
 
     @Test
+    void addChallengeToSolved_WhenUserServiceReturnsCustomInternalServerErrorException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new InternalServerErrorException(message)));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
     void addChallengeToFavorites_WhenUserServiceReturnsAnyException_ReturnsError() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -803,6 +919,27 @@ class ChallengeServiceImplTest {
 
         verify(challengeRepository, times(1)).findByUuid(challengeUuid);
         verify(userService, times(1)).addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void addChallengeToSolved_WhenUserServiceReturnsAnyException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new Exception(message)));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof Exception &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
     }
 
     @Test
@@ -860,6 +997,33 @@ class ChallengeServiceImplTest {
     }
 
     @Test
+    void addChallengeToSolved_WhenAdded_IncreasesTimesSolvedAndReturnsSolvedDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        int initialTimesSolved = 20;
+
+        challenge.setTimesSolved(initialTimesSolved);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(solvedDto -> {
+                    return solvedDto.getTimesSolved() == initialTimesSolved + 1 &&
+                    solvedDto.isSolved();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(initialTimesSolved + 1, challenge.getTimesSolved());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    @Test
     void addChallengeToFavorites_WhenAddedAndInitialTimesFavoriteIsNull_IncreasesTimesFavoriteAndReturnsFavoriteDTO() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -912,6 +1076,32 @@ class ChallengeServiceImplTest {
     }
 
     @Test
+    void addChallengeToSolved_WhenAddedAndInitialTimesSolvedIsNull_IncreasesTimesSolvedAndReturnsSolvedDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesSolved(null);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(solvedDto -> {
+                    return solvedDto.getTimesSolved() == 1 &&
+                            solvedDto.isSolved();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(1, challenge.getTimesSolved());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    @Test
     void addChallengeToFavorites_WhenNotAdded_NotIncreaseTimesFavoriteAndReturnsFavoriteDTO() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -960,6 +1150,32 @@ class ChallengeServiceImplTest {
 
         verify(challengeRepository, times(1)).findByUuid(challengeUuid);
         verify(userService, times(1)).addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(0)).save(any());
+    }
+
+    @Test
+    void addChallengeToSolved_WhenNotAdded_NotIncreaseTimesSolvedAndReturnsSolvedDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        int initialTimesSolved = 20;
+
+        challenge.setTimesSolved(initialTimesSolved);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(solvedDto -> {
+                    return solvedDto.getTimesSolved() == initialTimesSolved &&
+                            solvedDto.isSolved();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(initialTimesSolved, challenge.getTimesSolved());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
         verify(challengeRepository, times(0)).save(any());
     }
 
@@ -1017,11 +1233,42 @@ class ChallengeServiceImplTest {
         verify(challengeRepository, times(1)).save(challenge);
     }
 
+    @ParameterizedTest
+    @MethodSource
+    void addChallengeToSolved_WhenNotAddedAndTimesSolvedIsNullOrZero_SetTimesSolvedToOneAndReturnsSolvedDTO(Integer timesSolved) {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesSolved(timesSolved);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.addChallengeToSolved(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(solvedDto -> {
+                    return solvedDto.getTimesSolved() == 1 &&
+                            solvedDto.isSolved();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(1, challenge.getTimesSolved());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToSolved(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
     public static Stream<Integer> addChallengeToFavorites_WhenNotAddedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToOneAndReturnsFavoriteDTO() {
         return Stream.of(null, 0);
     }
 
     public static Stream<Integer> addChallengeToBookmarks_WhenNotAddedAndTimesBookmarkIsNullOrZero_SetTimesBookmarkToOneAndReturnsBookmarkDTO() {
+        return Stream.of(null, 0);
+    }
+
+    public static Stream<Integer> addChallengeToSolved_WhenNotAddedAndTimesSolvedIsNullOrZero_SetTimesSolvedToOneAndReturnsSolvedDTO() {
         return Stream.of(null, 0);
     }
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -104,7 +104,7 @@ class ChallengeServiceImplTest {
 
         challengeDocument = new ChallengeDocument(challengeRandomId, title, level, localDateTime, detail,
                 Set.of(languageDocument), List.of(solutionsRandomId), Topic.COMPONENTS,
-                20, 30,tags);
+                20, 30, 40, tags);
 
         challengeDto = getChallengeDtoMocked(challengeRandomId, title, level, creationDate, detail,
                 Set.of(languageDto),
@@ -1320,7 +1320,7 @@ class ChallengeServiceImplTest {
                 Set.of(new LanguageDocument(languageId, "Language Name", "image.png")),
                 List.of(UUID.randomUUID()),
                 Topic.COMPONENTS,
-                0, 0, tags
+                0, 0, 0, tags
         );
 
         when(challengeRepository.findAllByUuidNotNullExcludingTestingValues())
@@ -1374,7 +1374,7 @@ class ChallengeServiceImplTest {
                 Set.of(new LanguageDocument(UUID.randomUUID(), "Other Language", "image.png")),
                 List.of(UUID.randomUUID()),
                 Topic.COMPONENTS,
-                0, 0, tags
+                0, 0, 0, tags
         );
 
         when(challengeRepository.findAllByUuidNotNullExcludingTestingValues())

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ResourceServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ResourceServiceImplTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import static org.mockito.ArgumentMatchers.*;
@@ -415,6 +416,91 @@ class ResourceServiceImplTest {
                         error.getMessage().equals("Conversion DTO to Document null"))
                 .verify();
     }
+
+    // ID CON recursos
+    @Test
+    void getResourcesByChallengeId_WhenResourcesExist_ReturnsFluxOfResources() {
+
+        UUID challengeId = UUID.randomUUID();
+        UUID resourceId1 = UUID.randomUUID();
+        UUID resourceId2 = UUID.randomUUID();
+
+
+        ResourceDocument doc1 = new ResourceDocument(
+                resourceId1, "Resource 1", "Desc 1", "https://example.com/1",
+                Topic.DEBUGGING, ResourceContentType.VIDEO, List.of(challengeId), AssociationType.ALLSAMETOPIC
+        );
+        ResourceDocument doc2 = new ResourceDocument(
+                resourceId2, "Resource 2", "Desc 2", "https://example.com/2",
+                Topic.COMPONENTS, ResourceContentType.BLOG, List.of(challengeId), AssociationType.CHOOSE
+        );
+
+        ResourceDto dto1 = new ResourceDto();
+        dto1.setResourceId(resourceId1);
+        dto1.setTitle("Resource 1");
+
+
+        ResourceDto dto2 = new ResourceDto();
+        dto2.setResourceId(resourceId2);
+        dto2.setTitle("Resource 2");
+
+
+        when(resourceRepository.findByChallengeIdsContaining(challengeId))
+                .thenReturn(Flux.just(doc1, doc2));
+        when(resourceConverter.convertDocumentToDto(doc1, ResourceDto.class)).thenReturn(dto1);
+        when(resourceConverter.convertDocumentToDto(doc2, ResourceDto.class)).thenReturn(dto2);
+
+
+        StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
+                .expectNext(dto1)
+                .expectNext(dto2)
+                .verifyComplete();
+    }
+
+    // Valido SIN recursos
+    @Test
+    void getResourcesByChallengeId_WhenNoResourcesExist_ReturnsEmptyFlux() {
+
+        UUID challengeId = UUID.randomUUID();
+        when(resourceRepository.findByChallengeIdsContaining(challengeId))
+                .thenReturn(Flux.empty());
+
+
+        StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
+                .expectNextCount(0)
+                .verifyComplete();
+    }
+
+    //ID Nulo
+    @Test
+    void getResourcesByChallengeId_WhenIdIsNull_ThrowsIllegalArgumentException() {
+
+        StepVerifier.create(resourceService.getResourcesByChallengeId(null))
+                .expectErrorMatches(ex ->
+                        ex instanceof IllegalArgumentException &&
+                                ex.getMessage().equals("Challenge ID cannot be null")
+                )
+                .verify();
+    }
+
+    //Error en el repo
+    @Test
+    void getResourcesByChallengeId_WhenRepositoryFails_PropagatesError() {
+
+        UUID challengeId = UUID.randomUUID();
+        when(resourceRepository.findByChallengeIdsContaining(challengeId))
+                .thenReturn(Flux.error(new RuntimeException("DB Connection Failed")));
+
+
+        StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
+                .expectErrorMatches(ex ->
+                        ex instanceof RuntimeException &&
+                                ex.getMessage().equals("Server error while fetching resources")
+                )
+                .verify();
+    }
+
+
 
 
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ResourceServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ResourceServiceImplTest.java
@@ -460,18 +460,16 @@ class ResourceServiceImplTest {
                 .verifyComplete();
     }
 
-    // Valido SIN recursos
     @Test
-    void getResourcesByChallengeId_WhenNoResourcesExist_ReturnsEmptyFlux() {
+    void getResourcesByChallengeId_WhenNoResourcesExist_ThrowsResourceNotFoundException() {
 
         UUID challengeId = UUID.randomUUID();
         when(resourceRepository.findByChallengeIdsContaining(challengeId))
-                .thenReturn(Flux.empty());
-
+                .thenReturn(Flux.empty()); // Simula que no hay recursos
 
         StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
-                .expectNextCount(0)
-                .verifyComplete();
+                .expectError(ResourceNotFoundException.class)
+                .verify();
     }
 
     @Test
@@ -484,7 +482,7 @@ class ResourceServiceImplTest {
                 .verify();
     }
 
-    //Error en el repo
+
     @Test
     void getResourcesByChallengeId_WhenRepositoryFails_ThrowsInternalServerErrorException() {
         UUID challengeId = UUID.randomUUID();

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ResourceServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ResourceServiceImplTest.java
@@ -7,6 +7,9 @@ import com.itachallenge.challenge.dto.ResourceDto;
 import com.itachallenge.challenge.enums.AssociationType;
 import com.itachallenge.challenge.enums.ResourceContentType;
 import com.itachallenge.challenge.enums.Topic;
+import com.itachallenge.challenge.exception.BadRequestException;
+import com.itachallenge.challenge.exception.InternalServerErrorException;
+import com.itachallenge.challenge.exception.ResourceNotFoundException;
 import com.itachallenge.challenge.helper.DocumentToDtoConverter;
 import com.itachallenge.challenge.repository.ResourceRepository;
 import org.junit.jupiter.api.Test;
@@ -471,13 +474,11 @@ class ResourceServiceImplTest {
                 .verifyComplete();
     }
 
-    //ID Nulo
     @Test
-    void getResourcesByChallengeId_WhenIdIsNull_ThrowsIllegalArgumentException() {
-
+    void getResourcesByChallengeId_WhenIdIsNull_ThrowsBadRequestException() {
         StepVerifier.create(resourceService.getResourcesByChallengeId(null))
                 .expectErrorMatches(ex ->
-                        ex instanceof IllegalArgumentException &&
+                        ex instanceof BadRequestException &&
                                 ex.getMessage().equals("Challenge ID cannot be null")
                 )
                 .verify();
@@ -485,17 +486,32 @@ class ResourceServiceImplTest {
 
     //Error en el repo
     @Test
-    void getResourcesByChallengeId_WhenRepositoryFails_PropagatesError() {
-
+    void getResourcesByChallengeId_WhenRepositoryFails_ThrowsInternalServerErrorException() {
         UUID challengeId = UUID.randomUUID();
         when(resourceRepository.findByChallengeIdsContaining(challengeId))
                 .thenReturn(Flux.error(new RuntimeException("DB Connection Failed")));
 
-
         StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
                 .expectErrorMatches(ex ->
-                        ex instanceof RuntimeException &&
-                                ex.getMessage().equals("Server error while fetching resources")
+                        ex instanceof InternalServerErrorException &&
+                                ex.getMessage().equals("Failed to fetch resources for challenge ID: " + challengeId)
+                )
+                .verify();
+
+        verify(resourceRepository, times(1)).findByChallengeIdsContaining(challengeId);
+    }
+
+    @Test
+    void getResourcesByChallengeId_WhenResourceNotFound_PropagatesException() {
+        UUID challengeId = UUID.randomUUID();
+        ResourceNotFoundException ex = new ResourceNotFoundException("Not found");
+        when(resourceRepository.findByChallengeIdsContaining(challengeId))
+                .thenReturn(Flux.error(ex));
+
+        StepVerifier.create(resourceService.getResourcesByChallengeId(challengeId))
+                .expectErrorMatches(thrownEx ->
+                        thrownEx instanceof ResourceNotFoundException &&
+                                thrownEx.getMessage().equals("Not found")
                 )
                 .verify();
     }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/UserServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/UserServiceImplTest.java
@@ -24,8 +24,10 @@ public class UserServiceImplTest {
 
     private static final String FAVORITES_URL = "/itachallenge/api/v1/user/users/%s/favorites/%s";
     private static final String BOOKMARKS_URL = "/itachallenge/api/v1/user/users/%s/bookmarks/%s";
+    private static final String SOLVED_URL = "/itachallenge/api/v1/user/users/%s/solved/%s";
     public static final String X_FAVORITE_MESSAGE = "X-Favorite-Message";
     public static final String X_BOOKMARK_MESSAGE = "X-Bookmark-Message";
+    public static final String X_SOLVED_MESSAGE = "X-Solved-Message";
 
     @BeforeEach
     void setUp() throws IOException {
@@ -91,6 +93,29 @@ public class UserServiceImplTest {
     }
 
     @Test
+    void addChallengeToSolved_AddedToUser_ReturnsTrue() throws InterruptedException {
+        String userId = "someId";
+        String challengeId = "anotherId";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("true")
+                .setResponseCode(201)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = userService.addChallengeToSolved(userId, challengeId);
+
+        StepVerifier.create(result)
+                .expectNext(true)
+                .verifyComplete();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(SOLVED_URL, userId, challengeId),
+                request.getRequestUrl().encodedPath());
+    }
+
+    @Test
     void addChallengeToFavorites_NotAddedToUser_ReturnsFalse() throws InterruptedException {
         String userId = "someId";
         String challengeId = "anotherId";
@@ -135,6 +160,29 @@ public class UserServiceImplTest {
                 String.format(BOOKMARKS_URL, userId, challengeId),
                 request.getRequestUrl().encodedPath());
         assertEquals("POST", request.getMethod());
+    }
+
+    @Test
+    void addChallengeToSolved_NotAddedToUser_ReturnsFalse() throws InterruptedException {
+        String userId = "someId";
+        String challengeId = "anotherId";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = userService.addChallengeToSolved(userId, challengeId);
+
+        StepVerifier.create(result)
+                .expectNext(false)
+                .verifyComplete();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(SOLVED_URL, userId, challengeId),
+                request.getRequestUrl().encodedPath());
     }
 
     @Test
@@ -195,6 +243,34 @@ public class UserServiceImplTest {
     }
 
     @Test
+    void addChallengeToSolved_BadRequest_ReturnsError() throws InterruptedException {
+        String userId = "someId";
+        String challengeId = "anotherId";
+        String someErrorMessage = "Some error message";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(400)
+                .addHeader(X_SOLVED_MESSAGE, someErrorMessage)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = userService.addChallengeToSolved(userId, challengeId);
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadRequestException.class, throwable);
+                    assertTrue(throwable.getMessage().contains(someErrorMessage));
+                })
+                .verify();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(SOLVED_URL, userId, challengeId),
+                request.getRequestUrl().encodedPath());
+    }
+
+    @Test
     void addChallengeToFavorites_UserNotFound_ReturnsError() throws InterruptedException {
         String userId = "someId";
         String challengeId = "anotherId";
@@ -245,6 +321,32 @@ public class UserServiceImplTest {
                 String.format(BOOKMARKS_URL, userId, challengeId),
                 request.getRequestUrl().encodedPath());
         assertEquals("POST", request.getMethod());
+    }
+
+    @Test
+    void addChallengeToSolved_UserNotFound_ReturnsError() throws InterruptedException {
+        String userId = "someId";
+        String challengeId = "anotherId";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(404)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = userService.addChallengeToSolved(userId, challengeId);
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(UserNotFoundException.class, throwable);
+                    assertTrue(throwable.getMessage().contains("User not found"));
+                })
+                .verify();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(SOLVED_URL, userId, challengeId),
+                request.getRequestUrl().encodedPath());
     }
 
     @Test
@@ -302,6 +404,34 @@ public class UserServiceImplTest {
                 String.format(BOOKMARKS_URL, userId, challengeId),
                 request.getRequestUrl().encodedPath());
         assertEquals("POST", request.getMethod());
+    }
+
+    @Test
+    void addChallengeToSolved_500_ReturnsError() throws InterruptedException {
+        String userId = "someId";
+        String challengeId = "anotherId";
+        String someErrorMessage = "Some error message";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(500)
+                .addHeader(X_SOLVED_MESSAGE, someErrorMessage)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = userService.addChallengeToSolved(userId, challengeId);
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(InternalServerErrorException.class, throwable);
+                    assertTrue(throwable.getMessage().contains(someErrorMessage));
+                })
+                .verify();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(SOLVED_URL, userId, challengeId),
+                request.getRequestUrl().encodedPath());
     }
 
     @Test

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -370,4 +370,32 @@ public class UserController {
                     return ResponseEntity.ok().body(favorites);
                 });
     }
+
+    @Operation(
+            summary = "Gets challenges marked as bookmarks by a user",
+            description = "Returns a set of challenge IDs that the specified user has marked as bookmarked",
+            parameters = {
+                    @Parameter(
+                            name = "userId",
+                            description = "UUID of the user",
+                            required = true,
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Set of bookmarked challengeIds by user"),
+                    @ApiResponse(responseCode = "404", description = "User not found"),
+                    @ApiResponse(responseCode = "400", description = "The provided IDs are not valid."),
+                    @ApiResponse(responseCode = "500", description = "Unexpected error")
+            }
+    )
+
+    @GetMapping("/users/{userId}/bookmarks")
+    public Mono<ResponseEntity<Set<UUID>>> getUserBookmarks(@PathVariable String userId) {
+        return userService.getUserBookmarks(userId)
+                .map(bookmarks -> {
+                    log.info("Retrieved {} bookmarked challenges for user {}", bookmarks.size(), userId);
+                    return ResponseEntity.ok().body(bookmarks);
+                });
+    }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/ChallengeStatus.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/ChallengeStatus.java
@@ -13,8 +13,13 @@ public enum ChallengeStatus {ENDED("ENDED"),
     }
 
     public static ChallengeStatus determineChallengeStatus(String status){
-        return status != null  && status.equalsIgnoreCase(ChallengeStatus.ENDED.getValue()) ?
-                ChallengeStatus.ENDED : null;
+        ChallengeStatus output = null;
+        if(status != null  && status.equalsIgnoreCase(ChallengeStatus.ENDED.getValue())){
+            output = ChallengeStatus.ENDED;
+        } else if (status != null && status.equalsIgnoreCase(ChallengeStatus.IN_PROGRESS.getValue())) {
+            output = ChallengeStatus.IN_PROGRESS;
+        }
+        return output;
     }
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/ChallengeStatus.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/ChallengeStatus.java
@@ -2,6 +2,8 @@ package com.itachallenge.user.document.enums;
 
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
 public enum ChallengeStatus {ENDED("ENDED"),
     IN_PROGRESS("IN_PROGRESS");
@@ -12,12 +14,13 @@ public enum ChallengeStatus {ENDED("ENDED"),
         this.value = value;
     }
 
-    public static ChallengeStatus determineChallengeStatus(String status){
+    public static ChallengeStatus challengeStatusFromString(String status) {
         ChallengeStatus output = null;
-        if(status != null  && status.equalsIgnoreCase(ChallengeStatus.ENDED.getValue())){
-            output = ChallengeStatus.ENDED;
-        } else if (status != null && status.equalsIgnoreCase(ChallengeStatus.IN_PROGRESS.getValue())) {
-            output = ChallengeStatus.IN_PROGRESS;
+        if (status != null) {
+            output = Arrays.stream(ChallengeStatus.values())
+                    .filter(s -> status.equalsIgnoreCase(s.getValue()))
+                    .findFirst()
+                    .orElse(null);
         }
         return output;
     }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/ChallengeStatus.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/ChallengeStatus.java
@@ -3,7 +3,8 @@ package com.itachallenge.user.document.enums;
 import lombok.Getter;
 
 @Getter
-public enum ChallengeStatus {ENDED("ENDED");
+public enum ChallengeStatus {ENDED("ENDED"),
+    IN_PROGRESS("IN_PROGRESS");
 
     private final String value;
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
@@ -18,4 +18,6 @@ public interface UserService {
     Mono<Set<UUID>> getUserFavorites(String userId);
 
     Mono<Boolean> deleteChallengeFromBookmarks(String userId, String challengeId);
+
+    Mono<Set<UUID>> getUserBookmarks(String userId);
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -159,4 +159,14 @@ public class UserServiceImpl implements UserService {
                 );
     }
 
+    @Override
+    public Mono<Set<UUID>> getUserBookmarks(String userId) {
+        return parseAndValidateUUID(userId)
+                .flatMap(userUuid ->
+                        userRepository.findById(userUuid)
+                                .switchIfEmpty(Mono.error(new NotFoundException("User not found with id: " + userId)))
+                                .map(user -> Optional.ofNullable(user.getBookmarkChallenges()).orElseGet(HashSet::new))
+                );
+    }
+
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -37,7 +36,7 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
                 .solutionText(userSolutionDto.getSolutionText())
                 .build();
 
-        challengeStatus = ChallengeStatus.determineChallengeStatus(status);
+        challengeStatus = ChallengeStatus.challengeStatusFromString(status);
 
         if (challengeStatus == null) {
             log.error("PUT operation failed due to invalid challenge status parameter");

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -498,4 +498,75 @@ class UserControllerTest {
         verify(userService, times(1)).getUserFavorites(userId.toString());
     }
 
+    @Test
+    @DisplayName("GET /users/{userId}/bookmarks returns bookmarked challenges")
+    void getUserBookmarks_returnsBookmarks() {
+        UUID userId = UUID.randomUUID();
+        Set<UUID> expectedBookmarks = Set.of(UUID.randomUUID(), UUID.randomUUID());
+
+        when(userService.getUserBookmarks(userId.toString())).thenReturn(Mono.just(expectedBookmarks));
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(UUID.class)
+                .hasSize(expectedBookmarks.size())
+                .contains(expectedBookmarks.toArray(new UUID[0]));
+
+        verify(userService, times(1)).getUserBookmarks(userId.toString());
+    }
+
+    @Test
+    @DisplayName("GET /users/{userId}/bookmarks returns 404 if user not found")
+    void getUserBookmarks_returns404IfUserNotFound() {
+        UUID userId = UUID.randomUUID();
+
+        when(userService.getUserBookmarks(userId.toString()))
+                .thenReturn(Mono.error(new NotFoundException("User not found")));
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(String.class).isEqualTo("User not found");
+
+        verify(userService, times(1)).getUserBookmarks(userId.toString());
+    }
+
+    @Test
+    @DisplayName("GET /users/{userId}/bookmarks returns 400 if UUID is invalid")
+    void getUserBookmarks_returns400IfInvalidUUID() {
+        String invalidUserId = "invalid-uuid";
+
+        when(userService.getUserBookmarks(invalidUserId))
+                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", invalidUserId)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+
+        verify(userService, times(1)).getUserBookmarks(invalidUserId);
+    }
+
+    @Test
+    @DisplayName("GET /users/{userId}/bookmarks returns 500 if there is an internal error")
+    void getUserBookmarks_returns500IfUnexpectedError() {
+        UUID userId = UUID.randomUUID();
+
+        when(userService.getUserBookmarks(userId.toString()))
+                .thenReturn(Mono.error(new RuntimeException("Unexpected error")));
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+
+        verify(userService, times(1)).getUserBookmarks(userId.toString());
+    }
+
+
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -727,4 +727,69 @@ class UserServiceImplTest {
                 .verify();
     }
 
+    @Test
+    @DisplayName("getUserBookmarks returns bookmarked challenges when the user exists and has challenges")
+    void getUserBookmarks_WhenUserExistsWithBookmarks_ReturnsSet() {
+        UUID userId = UUID.randomUUID();
+        UUID challengeId1 = UUID.randomUUID();
+        UUID challengeId2 = UUID.randomUUID();
+
+        Set<UUID> bookmarks = Set.of(challengeId1, challengeId2);
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+        user.setBookmarkChallenges(bookmarks);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+
+        userService.getUserBookmarks(userId.toString())
+                .as(StepVerifier::create)
+                .expectNextMatches(result -> result.size() == 2 && result.contains(challengeId1))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getUserBookmarks returns an empty set when the user has no challenges marked.")
+    void getUserBookmarks_WhenUserHasNoBookmarks_ReturnsEmptySet() {
+        UUID userId = UUID.randomUUID();
+
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+        user.setFavoriteChallenges(null); // explícitely null
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+
+        userService.getUserBookmarks(userId.toString())
+                .as(StepVerifier::create)
+                .expectNextMatches(Set::isEmpty)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getUserBookmarks returns NotFoundException error when the user does not exist")
+    void getUserBookmarks_WhenUserNotFound_ReturnsError() {
+        UUID userId = UUID.randomUUID();
+
+        when(userRepository.findById(userId)).thenReturn(Mono.empty());
+
+        userService.getUserBookmarks(userId.toString())
+                .as(StepVerifier::create)
+                .expectErrorMatches(error ->
+                        error instanceof NotFoundException &&
+                                error.getMessage().equals("User not found with id: " + userId))
+                .verify();
+    }
+
+    @Test
+    @DisplayName("getUserBookmarks throws BadUUIDException when the UUID format is invalid")
+    void getUserBookmarks_WhenInvalidUUID_ReturnsBadUUIDException() {
+        String invalidUUID = "invalid-uuid";
+
+        userService.getUserBookmarks(invalidUUID)
+                .as(StepVerifier::create)
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format"))
+                .verify();
+    }
+
 }


### PR DESCRIPTION
 **Implement GET Endpoint for Challenge Resources**
Overview:
This PR implements the endpoint GET /itachallenge/api/v1/resource?challengeId={id} that allows students to view all learning resources associated with a specific challenge.
This completes feature #279: "Como alumno, puedo ver los recursos de un reto".

 **Technical Implementation** 
Endpoint Details:
Path: GET /itachallenge/api/v1/resource

Query Parameter:

challengeId (required, UUID): ID of the challenge whose resources are being requested.

🔸 **Responses**
200 OK: Returns an array of ResourceDto objects.

400 Bad Request: Returned when challengeId is missing or invalid.

500 Internal Server Error: For unexpected failures.

🔗 **Resource–Challenge Relationship**
Resources are associated with challenges in two ways:

Direct Association: Each resource contains a challengeIds array field with UUIDs of related challenges.

Repository Query: The method findByChallengeIdsContaining() efficiently fetches resources from MongoDB where the given challengeId appears in their challengeIds array.

🔄 **Flow Summary**
📍 Controller
Validates request parameters.

Logs the operation.

Delegates processing to the service layer.

Returns a reactive Flux<ResourceDto>.

🧠 Service Layer
Performs null validation.

Queries MongoDB via reactive repository.

Maps documents to DTOs.

Handles errors and logs them.

Maintains a fully reactive pipeline.

Tras el turbo commit con las revisiones aplicadas:


Fix in the Global Exception Handler: The handling of ResourceNotFoundException was modified. The previous exception returned a 200 status code with the error message, which was incorrect. Now, it returns a 404 (HttpStatus.NOT_FOUND) status code with the corresponding error message.

Controllers: The resource controller now correctly handles the ResourceNotFoundException to return a 404 when no resources are found for a challengeId.

Tests: The tests were adjusted to correctly validate responses with 404 status codes when resources are not found, as well as ensuring proper error propagation.

Updated the controller to work with @PathVariable

Updated the route "/challenge/{challengeId}"