### PR TITLE
Feature/277 creation method endpoint solved controller

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeSolvedController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeSolvedController.java
@@ -1,0 +1,53 @@
+package com.itachallenge.challenge.controller;
+
+import com.itachallenge.challenge.dto.SolvedDto;
+import com.itachallenge.challenge.exception.BadRequestException;
+import com.itachallenge.challenge.exception.JwtException;
+import com.itachallenge.challenge.service.IChallengeService;
+import com.itachallenge.challenge.service.IJwtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@Validated
+@RequestMapping(value = "/itachallenge/api/v1/challenge")
+@RequiredArgsConstructor
+public class ChallengeSolvedController {
+
+    private static final Logger log = LoggerFactory.getLogger(ChallengeSolvedController.class);
+
+    private IChallengeService challengeService;
+    private IJwtService jwtService;
+
+    @PostMapping("/challenges/{challengeId}/solved")
+    @Operation(
+            operationId = "Add a challenge to User's solved challenges.",
+            summary = "Add a challenge to solved challenges.",
+            description = "The ID Challenge sent through the URI is added to the user's solved challenges. User Id is determined from the headers.",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = SolvedDto.class), mediaType = "application/json")}),
+                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
+                    @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error")
+            }
+    )
+    public Mono<ResponseEntity<SolvedDto>> addChallengeToSolved(
+            @PathVariable String challengeId,
+            @RequestHeader(name = "Authorization", required = false) String authHeader) {
+        return Mono.fromCallable(() -> jwtService.getUserUuIdFromAuthenticationHeader(authHeader))
+                .onErrorMap(JwtException.class, e -> new BadRequestException(e.getMessage()))
+                .flatMap(userId -> challengeService.addChallengeToSolved(challengeId, userId))
+                .doOnError(error -> log.error("Error adding challenge to solved: {}", error.getMessage()))
+                .map(ResponseEntity::ok);
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeSolvedControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeSolvedControllerTest.java
@@ -1,0 +1,97 @@
+package com.itachallenge.challenge.controller;
+
+import com.itachallenge.challenge.dto.SolvedDto;
+import com.itachallenge.challenge.exception.BadRequestException;
+import com.itachallenge.challenge.exception.JwtException;
+import com.itachallenge.challenge.service.IChallengeService;
+import com.itachallenge.challenge.service.IJwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+
+class ChallengeSolvedControllerTest {
+
+    @Mock
+    private IChallengeService challengeService;
+
+    @Mock
+    private IJwtService jwtService;
+
+    @InjectMocks
+    private ChallengeSolvedController challengeSolvedController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void addChallengeToSolved_Success() {
+        String challengeId = "123";
+        String authHeader = "Bearer validToken";
+        String userId = "user123";
+        SolvedDto solvedDto = new SolvedDto();
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+        when(challengeService.addChallengeToSolved(challengeId, userId)).thenReturn(Mono.just(solvedDto));
+
+        Mono<ResponseEntity<SolvedDto>> result = challengeSolvedController.addChallengeToSolved(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(200, response.getStatusCodeValue());
+                    assertEquals(solvedDto, response.getBody());
+                })
+                .verifyComplete();
+
+        verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
+        verify(challengeService, times(1)).addChallengeToSolved(challengeId, userId);
+    }
+
+    @Test
+    void addChallengeToSolved_InvalidAuthHeader() {
+        String challengeId = "123";
+        String authHeader = "invalidToken";
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenThrow(new JwtException("Invalid token"));
+
+        Mono<ResponseEntity<SolvedDto>> result = challengeSolvedController.addChallengeToSolved(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof BadRequestException &&
+                        throwable.getMessage().equals("Invalid token"))
+                .verify();
+
+        verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
+        verifyNoInteractions(challengeService);
+    }
+
+    @Test
+    void addChallengeToSolved_ServiceError() {
+        String challengeId = "123";
+        String authHeader = "Bearer validToken";
+        String userId = "user123";
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+        when(challengeService.addChallengeToSolved(challengeId, userId)).thenReturn(Mono.error(new RuntimeException("Service error")));
+
+        Mono<ResponseEntity<SolvedDto>> result = challengeSolvedController.addChallengeToSolved(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof RuntimeException &&
+                        throwable.getMessage().equals("Service error"))
+                .verify();
+
+        verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
+        verify(challengeService, times(1)).addChallengeToSolved(challengeId, userId);
+    }
+}


### PR DESCRIPTION
A new controller has been added '`ChallengeSolvedController.java`' in this PR for the solvedCounter feature.

The `addChallengeToSolved` method is a Spring WebFlux POST endpoint that marks a challenge as solved for a user. It extracts the `challengeId` from the URI and the user ID from the `Authorization` header using `jwtService`. Errors like invalid headers or missing challenges are handled and logged.
