### PR TITLE
Feat/280 Finished endpoint for getting resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+* Issue #852: Added GET endpoint for retrieving resources from a challenge
 * Issue #849: Added GET endpoint to retrieve all User's bookmarked challenges.
 * Issue #843: Added DELETE endpoint in the Challenge Microservice to unbookmark a challenge.
 * Issue #829: Added bookmark POST endpoint in the Challenge Microservice to bookmark a challenge.

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ResourceController.java
@@ -5,13 +5,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 @RestController
 @Validated
@@ -40,6 +44,19 @@ public class ResourceController {
         log.info("Creating a new resource {}", resourceDto);
         return resourceService.createResource(resourceDto)
                 .map(createdResource -> ResponseEntity.ok().body(createdResource));
+    }
+
+
+    @GetMapping("/challenge/{challengeId}")
+    @Operation(summary = "Get resources by challenge ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Resources found"),
+            @ApiResponse(responseCode = "400", description = "Invalid challenge ID"),
+            @ApiResponse(responseCode = "404", description = "No resources found"),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error")
+    })
+    public Flux<ResourceDto> getResourcesByChallengeId(@PathVariable UUID challengeId) {
+        return resourceService.getResourcesByChallengeId(challengeId);
     }
 }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
@@ -64,7 +64,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<MessageDto> handleResourceNotFoundException(ResourceNotFoundException ex) {
-        return ResponseEntity.ok().body(new MessageDto(ex.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new MessageDto(ex.getMessage()));
     }
 
     @ExceptionHandler(LanguageNotFoundException.class)

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ResourceControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ResourceControllerTest.java
@@ -4,6 +4,7 @@ import com.itachallenge.challenge.dto.ResourceDto;
 import com.itachallenge.challenge.enums.AssociationType;
 import com.itachallenge.challenge.enums.ResourceContentType;
 import com.itachallenge.challenge.enums.Topic;
+import com.itachallenge.challenge.exception.ResourceNotFoundException;
 import com.itachallenge.challenge.service.IResourceService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import static org.junit.Assert.*;
@@ -105,6 +107,68 @@ class ResourceControllerTest {
                 .expectStatus().isBadRequest();
 
         verify(resourceService, never()).createResource(any(ResourceDto.class));
+    }
+
+    @Test
+    void getResourcesByChallengeId_ValidId_ReturnsResources() {
+
+        UUID challengeId = UUID.randomUUID();
+        ResourceDto mockResource = ResourceDto.builder()
+                .resourceId(UUID.randomUUID())
+                .title("Test Resource")
+                .description("Test Description")
+                .url("http://test.com")
+                .topic(Topic.COMPONENTS)
+                .contentType(ResourceContentType.VIDEO)
+                .challengeIds(List.of(challengeId))
+                .associationType(AssociationType.ALLSAMETOPIC)
+                .build();
+
+        when(resourceService.getResourcesByChallengeId(challengeId))
+                .thenReturn(Flux.just(mockResource));
+
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/resource/challenge/" + challengeId) // Ruta completa
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(ResourceDto.class)
+                .hasSize(1)
+                .contains(mockResource);
+
+        verify(resourceService, times(1)).getResourcesByChallengeId(challengeId);
+    }
+
+    @Test
+    void getResourcesByChallengeId_InvalidId_ReturnsBadRequest() {
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/resource/challenge/null") // Ruta completa con ID inválido
+                .exchange()
+                .expectStatus().isBadRequest();
+
+
+        verify(resourceService, never()).getResourcesByChallengeId(any());
+    }
+
+    @Test
+    void getResourcesByChallengeId_NoResources_ReturnsNotFoundWithMessage() {
+
+        UUID challengeId = UUID.randomUUID();
+        String errorMessage = "No resources found for challenge ID: " + challengeId;
+
+        when(resourceService.getResourcesByChallengeId(challengeId))
+                .thenReturn(Flux.error(new ResourceNotFoundException(errorMessage)));
+
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/resource/challenge/" + challengeId)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo(errorMessage);
+
+        verify(resourceService, times(1)).getResourcesByChallengeId(challengeId);
     }
 
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/exception/GlobalExceptionHandlerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/exception/GlobalExceptionHandlerTest.java
@@ -179,13 +179,10 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void testHandleResourceNotFoundException() {
-        // Arrange
+
         ResourceNotFoundException resourceNotFoundException = new ResourceNotFoundException("Resource not found");
 
-        // Act
         ResponseEntity<MessageDto> responseEntity = globalExceptionHandler.handleResourceNotFoundException(resourceNotFoundException);
-
-        // Assert
 
         assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
         String responseBody = Objects.requireNonNull(responseEntity.getBody()).getMessage();

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/exception/GlobalExceptionHandlerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/exception/GlobalExceptionHandlerTest.java
@@ -186,7 +186,8 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<MessageDto> responseEntity = globalExceptionHandler.handleResourceNotFoundException(resourceNotFoundException);
 
         // Assert
-                    assertEquals(OK_REQUEST, responseEntity.getStatusCode());
+
+        assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
         String responseBody = Objects.requireNonNull(responseEntity.getBody()).getMessage();
         Assertions.assertTrue(responseBody.contains("Resource not found"));
     }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/exception/GlobalExceptionHandlerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/exception/GlobalExceptionHandlerTest.java
@@ -179,7 +179,7 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void testHandleResourceNotFoundException() {
-
+        // Testgi
         ResourceNotFoundException resourceNotFoundException = new ResourceNotFoundException("Resource not found");
 
         ResponseEntity<MessageDto> responseEntity = globalExceptionHandler.handleResourceNotFoundException(resourceNotFoundException);


### PR DESCRIPTION
Tras los cambios aplicados en develop tuve problemas en la PR, esta nueva PR comprende todos los cambios ya revisados sin problemas de commits ajenos.

Implement GET Endpoint for Challenge Resources
Overview:
This PR implements the endpoint GET /itachallenge/api/v1/resource?challengeId={id} that allows students to view all learning resources associated with a specific challenge.
This completes feature #279: "Como alumno, puedo ver los recursos de un reto".

Technical Implementation
Endpoint Details:
Path: GET /itachallenge/api/v1/resource

Query Parameter:

challengeId (required, UUID): ID of the challenge whose resources are being requested.

🔸 Responses
200 OK: Returns an array of ResourceDto objects.

400 Bad Request: Returned when challengeId is missing or invalid.

500 Internal Server Error: For unexpected failures.

🔗 Resource–Challenge Relationship
Resources are associated with challenges in two ways:

Direct Association: Each resource contains a challengeIds array field with UUIDs of related challenges.

Repository Query: The method findByChallengeIdsContaining() efficiently fetches resources from MongoDB where the given challengeId appears in their challengeIds array.

🔄 Flow Summary
📍 Controller
Validates request parameters.

Logs the operation.

Delegates processing to the service layer.

Returns a reactive Flux.

🧠 Service Layer
Performs null validation.

Queries MongoDB via reactive repository.

Maps documents to DTOs.

Handles errors and logs them.

Maintains a fully reactive pipeline.

Tras el turbo commit con las revisiones aplicadas:

Fix in the Global Exception Handler: The handling of ResourceNotFoundException was modified. The previous exception returned a 200 status code with the error message, which was incorrect. Now, it returns a 404 (HttpStatus.NOT_FOUND) status code with the corresponding error message.

Controllers: The resource controller now correctly handles the ResourceNotFoundException to return a 404 when no resources are found for a challengeId.

Tests: The tests were adjusted to correctly validate responses with 404 status codes when resources are not found, as well as ensuring proper error propagation.

Updated the controller to work with @PathVariable

Updated the route "/challenge/{challengeId}"