### PR TITLE
feature/334-Logout-endpoint-response-should-manage-expired-token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+* Issue #864: Added JWT authentication to logout endpoint in User microservice.
 * PR #872: Added error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags
 * PR #866: Added tag validation in the addChallenge endpoint.
 * Issue #852: Added GET endpoint for retrieving resources from a challenge

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -145,8 +145,11 @@ public class AuthController {
 
     @PostMapping("/logout")
     public Mono<ResponseEntity<Map<String, String>>> logout(@RequestHeader(value = "Authorization", required = false) String authHeader) {
-        if (authHeader == null || !authHeader.startsWith("Bearer "))
-            log.warn("Logout attempt without token");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")){
+            log.warn("Logged out without token");
+        }else{
+                log.info("Successfully logged out with token
+        }
         
         return Mono.just(ResponseEntity.ok(Map.of(MESSAGE_KEY, "Logout successful")));
     }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -29,6 +29,7 @@ public class AuthController {
     private static final String KEY_USERNAME = "username";
     public static final String X_GITHUB_USERNAME = "X-Github-Username";
     public static final String X_AUTHENTICATION_STATUS = "X-Authentication-Status";
+    private static final String MESSAGE_KEY = "message";
 
     private final IAuthService authService;
 
@@ -99,7 +100,7 @@ public class AuthController {
                 .switchIfEmpty(Mono.defer(() -> {
                     response.put(KEY_USERNAME, null);
                     response.put(KEY_IS_VALID, false);
-                    response.put("message", "User does not exist in the database");
+                    response.put(MESSAGE_KEY, "User does not exist in the database");
                     return Mono.just(ResponseEntity.status(HttpStatus.FORBIDDEN)
                             .header("X-Validation-Status", "Forbidden")
                             .header(X_GITHUB_USERNAME, githubUsername)
@@ -119,7 +120,7 @@ public class AuthController {
                     }
                     response.put(KEY_USERNAME, null);
                     response.put(KEY_IS_VALID, false);
-                    response.put("message", message);
+                    response.put(MESSAGE_KEY, message);
                     return Mono.just(ResponseEntity.status(status)
                             .header("X-Validation-Status", "Forbidden")
                             .header(X_GITHUB_USERNAME, githubUsername)
@@ -150,7 +151,7 @@ public class AuthController {
             String jwt = authHeader.replace("Bearer ", "");
             log.info("Logout attempt for token: {}", jwt);
         }
-        return Mono.just(ResponseEntity.ok(Map.of("message", "Logout successful")));
+        return Mono.just(ResponseEntity.ok(Map.of(MESSAGE_KEY, "Logout successful")));
     }
 
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -145,12 +145,13 @@ public class AuthController {
 
     @PostMapping("/logout")
     public Mono<ResponseEntity<Map<String, String>>> logout(@RequestHeader(value = "Authorization", required = false) String authHeader) {
-        if (authHeader == null || !authHeader.startsWith("Bearer ")){
-            log.warn("Logged out without token");
-        }else{
-                log.info("Successfully logged out with token");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.warn("Logout attempt without or malformed token");
+            return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of(MESSAGE_KEY, "Authorization header is missing or malformed")));
         }
-        
+
+        log.info("Logout attempt with token");
         return Mono.just(ResponseEntity.ok(Map.of(MESSAGE_KEY, "Logout successful")));
     }
 

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -145,12 +145,9 @@ public class AuthController {
 
     @PostMapping("/logout")
     public Mono<ResponseEntity<Map<String, String>>> logout(@RequestHeader(value = "Authorization", required = false) String authHeader) {
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+        if (authHeader == null || !authHeader.startsWith("Bearer "))
             log.warn("Logout attempt without token");
-        } else {
-            String jwt = authHeader.replace("Bearer ", "");
-            log.info("Logout attempt for token: {}", jwt);
-        }
+        
         return Mono.just(ResponseEntity.ok(Map.of(MESSAGE_KEY, "Logout successful")));
     }
 

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -13,6 +13,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 
 import reactor.core.publisher.Mono;
 
@@ -144,16 +147,31 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public Mono<ResponseEntity<Map<String, String>>> logout(@RequestHeader(value = "Authorization", required = false) String authHeader) {
+    public Mono<ResponseEntity<Map<String, String>>> logout(
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             log.warn("Logout attempt without or malformed token");
             return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of(MESSAGE_KEY, "Authorization header is missing or malformed")));
+                    .body(Map.of("message", "Authorization header is missing or malformed")));
         }
+        String token = authHeader.replace("Bearer ", "").trim();
+        try {
+            jwtService.validateToken(token);
 
-        log.info("Logout attempt with token");
-        return Mono.just(ResponseEntity.ok(Map.of(MESSAGE_KEY, "Logout successful")));
+            log.info("Logout attempt with valid token");
+            return Mono.just(ResponseEntity.ok(Map.of("message", "Logout successful")));
+
+        } catch (ExpiredJwtException e) {
+            log.info("Logout with expired token (accepted): {}", e.getMessage());
+            return Mono.just(ResponseEntity.ok(Map.of("message", "Logout successful")));
+
+        } catch (JwtException e) {
+            log.warn("Logout attempt with invalid JWT: {}", e.getMessage());
+            return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("message", "Invalid or tampered token")));
+        }
     }
+
 
 }
 

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -149,29 +149,23 @@ public class AuthController {
     @PostMapping("/logout")
     public Mono<ResponseEntity<Map<String, String>>> logout(
             @RequestHeader(value = "Authorization", required = false) String authHeader) {
+
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             log.warn("Logout attempt without or malformed token");
             return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("message", "Authorization header is missing or malformed")));
         }
+
         String token = authHeader.replace("Bearer ", "").trim();
-        try {
-            jwtService.validateToken(token);
 
-            log.info("Logout attempt with valid token");
-            return Mono.just(ResponseEntity.ok(Map.of("message", "Logout successful")));
-
-        } catch (ExpiredJwtException e) {
-            log.info("Logout with expired token (accepted): {}", e.getMessage());
-            return Mono.just(ResponseEntity.ok(Map.of("message", "Logout successful")));
-
-        } catch (JwtException e) {
-            log.warn("Logout attempt with invalid JWT: {}", e.getMessage());
+        if (!jwtService.validateToken(token)) {
+            log.warn("Logout attempt with invalid or expired token");
             return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("message", "Invalid or tampered token")));
         }
+
+        log.info("Logout attempt with valid token");
+        return Mono.just(ResponseEntity.ok(Map.of("message", "Logout successful")));
     }
-
-
 }
 

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -143,21 +143,14 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public Mono<ResponseEntity<Map<String, String>>> logout(@RequestHeader (value = "Authorization", required = false) String authHeader){
-        if(authHeader == null || !authHeader.startsWith("Bearer ")){
-            return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("message", "Unauthorized: No token provided")));
-        }
-        String jwt = authHeader.replace("Bearer ", "");
-
-        if (jwtService.validateToken(jwt)) {
-            log.info("Logout successful for token: {}", jwt);
-            return Mono.just(ResponseEntity.ok(Map.of("message", "Logout successful")));
+    public Mono<ResponseEntity<Map<String, String>>> logout(@RequestHeader(value = "Authorization", required = false) String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.warn("Logout attempt without token");
         } else {
-            log.warn("Invalid or expired token during logout");
-            return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("message", "Invalid or expired token")));
+            String jwt = authHeader.replace("Bearer ", "");
+            log.info("Logout attempt for token: {}", jwt);
         }
+        return Mono.just(ResponseEntity.ok(Map.of("message", "Logout successful")));
     }
 
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -148,7 +148,7 @@ public class AuthController {
         if (authHeader == null || !authHeader.startsWith("Bearer ")){
             log.warn("Logged out without token");
         }else{
-                log.info("Successfully logged out with token
+                log.info("Successfully logged out with token");
         }
         
         return Mono.just(ResponseEntity.ok(Map.of(MESSAGE_KEY, "Logout successful")));

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IJwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IJwtService.java
@@ -1,6 +1,8 @@
 package com.itachallenge.auth.service;
+import javax.crypto.SecretKey;
 
 public interface IJwtService {
+    SecretKey getSigningKey();
     String generateToken(String username, String role, String uuid);
     boolean validateToken(String token);
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
@@ -54,7 +54,7 @@ public class JwtService implements IJwtService {
         }
     }
 
-    private SecretKey getSigningKey() {
+    public SecretKey getSigningKey() {
         byte[] keyBytes = Decoders.BASE64.decode(jwtSigningKey);
         return Keys.hmacShaKeyFor(keyBytes);
     }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -210,8 +210,7 @@ class AuthControllerTest {
     @Test
     void logout_ValidToken_ShouldReturn200() {
         String validToken = "valid.jwt.token";
-
-        when(jwtService.validateToken(validToken)).thenReturn(true);
+        doNothing().when(jwtService).validateToken(validToken);
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
@@ -224,11 +223,12 @@ class AuthControllerTest {
                 });
     }
 
+
     @Test
     void logout_ExpiredToken_ShouldReturn200() {
         String expiredToken = "expired.jwt.token";
 
-        Mockito.doThrow(new ExpiredJwtException(null, null, "Token expired"))
+        doThrow(new ExpiredJwtException(null, null, "Token expired"))
                 .when(jwtService).validateToken(expiredToken);
 
         webTestClient.post()
@@ -242,12 +242,13 @@ class AuthControllerTest {
                 });
     }
 
+
     @Test
     void logout_InvalidToken_ShouldReturn401() {
         String invalidToken = "invalid.jwt.token";
 
-        when(jwtService.getSigningKey()).thenReturn(Keys.hmacShaKeyFor("someRandomStringToProtectThisAppFromAttacks".getBytes()));
-        when(jwtService.validateToken(invalidToken)).thenThrow(new JwtException("Invalid token"));
+        doThrow(new JwtException("Invalid token"))
+                .when(jwtService).validateToken(invalidToken);
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
@@ -259,6 +260,7 @@ class AuthControllerTest {
                     assert response.get("message").equals("Invalid or tampered token");
                 });
     }
+
 
     @Test
     void logout_NoToken_ShouldReturn401() {

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -234,14 +234,14 @@ class AuthControllerTest {
     }
 
     @Test
-    void logout_NoToken_ShouldReturn200() {
+    void logout_NoToken_ShouldReturn401() {
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isUnauthorized()
                 .expectBody(Map.class)
                 .value(response -> {
-                    assert response.get("message").equals("Logout successful");
+                    assert response.get("message").equals("Authorization header is missing or malformed");
                 });
     }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -7,6 +7,7 @@ import com.itachallenge.auth.service.IUserService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
@@ -16,6 +17,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.security.Keys;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -207,6 +211,8 @@ class AuthControllerTest {
     void logout_ValidToken_ShouldReturn200() {
         String validToken = "valid.jwt.token";
 
+        when(jwtService.validateToken(validToken)).thenReturn(true);
+
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
                 .header("Authorization", "Bearer " + validToken)
@@ -219,17 +225,38 @@ class AuthControllerTest {
     }
 
     @Test
-    void logout_InvalidToken_ShouldReturn200() {
-        String invalidToken = "invalid.jwt.token";
+    void logout_ExpiredToken_ShouldReturn200() {
+        String expiredToken = "expired.jwt.token";
+
+        Mockito.doThrow(new ExpiredJwtException(null, null, "Token expired"))
+                .when(jwtService).validateToken(expiredToken);
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
-                .header("Authorization", "Bearer " + invalidToken)
+                .header("Authorization", "Bearer " + expiredToken)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(Map.class)
                 .value(response -> {
                     assert response.get("message").equals("Logout successful");
+                });
+    }
+
+    @Test
+    void logout_InvalidToken_ShouldReturn401() {
+        String invalidToken = "invalid.jwt.token";
+
+        when(jwtService.getSigningKey()).thenReturn(Keys.hmacShaKeyFor("someRandomStringToProtectThisAppFromAttacks".getBytes()));
+        when(jwtService.validateToken(invalidToken)).thenThrow(new JwtException("Invalid token"));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/logout")
+                .header("Authorization", "Bearer " + invalidToken)
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .expectBody(Map.class)
+                .value(response -> {
+                    assert response.get("message").equals("Invalid or tampered token");
                 });
     }
 

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -207,8 +207,6 @@ class AuthControllerTest {
     void logout_ValidToken_ShouldReturn200() {
         String validToken = "valid.jwt.token";
 
-        when(jwtService.validateToken(validToken)).thenReturn(true);
-
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
                 .header("Authorization", "Bearer " + validToken)
@@ -221,31 +219,29 @@ class AuthControllerTest {
     }
 
     @Test
-    void logout_InvalidToken_ShouldReturn401() {
+    void logout_InvalidToken_ShouldReturn200() {
         String invalidToken = "invalid.jwt.token";
-
-        when(jwtService.validateToken(invalidToken)).thenReturn(false);
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
                 .header("Authorization", "Bearer " + invalidToken)
                 .exchange()
-                .expectStatus().isUnauthorized()
+                .expectStatus().isOk()
                 .expectBody(Map.class)
                 .value(response -> {
-                    assert response.get("message").equals("Invalid or expired token");
+                    assert response.get("message").equals("Logout successful");
                 });
     }
 
     @Test
-    void logout_NoToken_ShouldReturn401() {
+    void logout_NoToken_ShouldReturn200() {
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
                 .exchange()
-                .expectStatus().isUnauthorized()
+                .expectStatus().isOk()
                 .expectBody(Map.class)
                 .value(response -> {
-                    assert response.get("message").equals("Unauthorized: No token provided");
+                    assert response.get("message").equals("Logout successful");
                 });
     }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -210,7 +210,7 @@ class AuthControllerTest {
     @Test
     void logout_ValidToken_ShouldReturn200() {
         String validToken = "valid.jwt.token";
-        doNothing().when(jwtService).validateToken(validToken);
+        Mockito.when(jwtService.validateToken(validToken)).thenReturn(true);
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
@@ -223,32 +223,10 @@ class AuthControllerTest {
                 });
     }
 
-
-    @Test
-    void logout_ExpiredToken_ShouldReturn200() {
-        String expiredToken = "expired.jwt.token";
-
-        doThrow(new ExpiredJwtException(null, null, "Token expired"))
-                .when(jwtService).validateToken(expiredToken);
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/auth/logout")
-                .header("Authorization", "Bearer " + expiredToken)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(Map.class)
-                .value(response -> {
-                    assert response.get("message").equals("Logout successful");
-                });
-    }
-
-
     @Test
     void logout_InvalidToken_ShouldReturn401() {
         String invalidToken = "invalid.jwt.token";
-
-        doThrow(new JwtException("Invalid token"))
-                .when(jwtService).validateToken(invalidToken);
+        Mockito.when(jwtService.validateToken(invalidToken)).thenReturn(false);
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
@@ -261,9 +239,34 @@ class AuthControllerTest {
                 });
     }
 
+    @Test
+    void logout_EmptyAuthorizationHeader_ShouldReturn401() {
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/logout")
+                .header("Authorization", "")
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .expectBody(Map.class)
+                .value(response -> {
+                    assert response.get("message").equals("Authorization header is missing or malformed");
+                });
+    }
 
     @Test
-    void logout_NoToken_ShouldReturn401() {
+    void logout_MalformedAuthorizationHeader_ShouldReturn401() {
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/logout")
+                .header("Authorization", "Token xyz")
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .expectBody(Map.class)
+                .value(response -> {
+                    assert response.get("message").equals("Authorization header is missing or malformed");
+                });
+    }
+
+    @Test
+    void logout_MissingAuthorizationHeader_ShouldReturn401() {
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/logout")
                 .exchange()

--- a/postman/ITA-Challenges.postman_collection.json
+++ b/postman/ITA-Challenges.postman_collection.json
@@ -1399,6 +1399,35 @@
 					"response": []
 				}
 			]
+		},
+		{
+		  "name": "Auth - Logout",
+		  "request": {
+		    "method": "POST",
+		    "header": [
+		      {
+		        "key": "Authorization",
+		        "value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0VXNlciIsInJvbGUiOiJBRS1JTiIsInV1aWQiOiI0MDc0MzUwMS1lMzViLTRjOTEtYmM5Ni1iMGM5ODM0ODhlN2MiLCJpYXQiOjE3NDE2MTM2MTIsImV4cCI6MTc0MTY0OTYxMn0=.S__qcscgi4JPuz27k5sNuSVIQbmJVB0htFR7vFnH-RI",
+		        "type": "text"
+		      }
+		    ],
+		    "url": {
+		      "raw": "http://{{ip}}:{{auth_port}}/itachallenge/api/v1/auth/logout",
+		      "protocol": "http",
+		      "host": [
+		        "{{ip}}"
+		      ],
+		      "port": "{{auth_port}}",
+		      "path": [
+		        "itachallenge",
+		        "api",
+		        "v1",
+		        "auth",
+		        "logout"
+		      ]
+		    }
+		  },
+		  "response": []
 		}
 	]
 }


### PR DESCRIPTION
1. -Endpoint /logout:

- Modificado para devolver siempre un estado 200 OK con el mensaje "Logout successful", independientemente de si el token JWT es válido, inválido, expirado o ausente.
- Eliminada la validación estricta del token para mejorar la experiencia del usuario.
- Añadidos logs para registrar intentos de logout con tokens inválidos o ausentes.

2. Pruebas actualizadas en AuthControllerTest:

- Se añadieron pruebas para validar el nuevo comportamiento del endpoint /logout.
- Se eliminaron las pruebas que esperaban una respuesta 401 para el endpoint /logout
