### PR TITLE
PR 1/4 - Add IFavoriteService interface (325)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IFavoriteService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IFavoriteService.java
@@ -1,0 +1,11 @@
+package com.itachallenge.challenge.service;
+
+import com.itachallenge.challenge.dto.FavoriteDto;
+import reactor.core.publisher.Mono;
+
+public interface IFavoriteService {
+
+    Mono<FavoriteDto> addChallengeToFavorites(String challengeId, String userId);
+
+    Mono<FavoriteDto> removeChallengeFromFavorites(String challengeId, String userId);
+}


### PR DESCRIPTION
This PR introduces the `IFavoriteService` interface as the first step in refactoring `ChallengeController` by isolating favorite-related logic into its own service layer, in line with the goal of improving separation of responsibilities (Story `325`).

- Added `IFavoriteService` interface in the service package.
- Declared:
  - `addChallengeToFavorites(String challengeId, String userId)`
  - `removeChallengeFromFavorites(String challengeId, String userId)` 