### PR TITLE
Feature/354 addChallenge add tags validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+* PR #866: Added tag validation in the addChallenge endpoint.
 * Issue #852: Added GET endpoint for retrieving resources from a challenge
 * Issue #849: Added GET endpoint to retrieve all User's bookmarked challenges.
 * Issue #843: Added DELETE endpoint in the Challenge Microservice to unbookmark a challenge.

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -248,18 +248,24 @@ public class ChallengeServiceImpl implements IChallengeService {
                             .idLanguage(existingLanguage.getIdLanguage())
                             .build();
                     return solutionRepository.save(solution)
-                            .flatMap(savedSolution -> {
-                                ChallengeDocument challenge = buildChallengeDocument(
-                                        challengeCreateDto,
-                                        existingLanguage,
-                                        savedSolution.getUuid(),
-                                        topic,
-                                        challengeCreateDto.getTags());
-                                return challengeRepository.save(challenge)
-                                        .map(savedChallenge -> challengeConverter.convertDocumentToDto(challenge,
-                                                ChallengeDto.class));
-                            });
-                });
+                            .flatMap(savedSolution -> tagService.getValidatedTags(challengeCreateDto.getTags())
+                                    .flatMap(allTagsValid -> {
+                                        if (!allTagsValid) {
+                                            return Mono.error(new TagNotFoundException(
+                                                    "One or more tags are invalid"));
+                                        }
+                                        ChallengeDocument challenge = buildChallengeDocument(
+                                                challengeCreateDto,
+                                                existingLanguage,
+                                                savedSolution.getUuid(),
+                                                topic,
+                                                challengeCreateDto.getTags());
+                                        return challengeRepository.save(challenge);
+                                    })
+                            );
+                })
+                .map(savedChallenge ->
+                        challengeConverter.convertDocumentToDto(savedChallenge, ChallengeDto.class));
     }
 
     private ChallengeDocument buildChallengeDocument(ChallengeCreateDto dto, LanguageDocument language, UUID solutionId, Topic topic, List<UUID> tags) {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -563,6 +563,32 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
         verify(challengeRepository, never()).save(any(ChallengeDocument.class));
         verify(tagService, times(1)).getValidatedTags(eq(formData.getTags()));
     }
+    
+    @Test
+    void addChallenge_test_emptyTags() {
+        formData.setTags(Collections.emptyList());
+        when(ILanguageService.findFirstByLanguageName(eq(languageName)))
+                .thenReturn(Mono.just(languageDocument));
+        when(solutionRepository.save(any(SolutionDocument.class)))
+                .thenReturn(Mono.just(solutionDocument));
+        when(tagService.getValidatedTags(eq(Collections.emptyList())))
+                .thenReturn(Mono.just(true));
+        when(challengeRepository.save(any(ChallengeDocument.class)))
+                .thenReturn(Mono.just(challengeDocument));
+        when(challengeConverter.convertDocumentToDto(any(ChallengeDocument.class), eq(ChallengeDto.class)))
+                .thenReturn(challengeDto);
+        
+        StepVerifier.create(challengeService.addChallenge(formData))
+                .expectNext(challengeDto)
+                .verifyComplete();
+                
+        verify(ILanguageService, times(1)).findFirstByLanguageName(eq(languageName));
+        verify(solutionRepository, times(1)).save(any(SolutionDocument.class));
+        verify(tagService, times(1)).getValidatedTags(eq(Collections.emptyList()));
+        verify(challengeRepository, times(1)).save(any(ChallengeDocument.class));
+        verify(challengeConverter, times(1))
+                .convertDocumentToDto(any(ChallengeDocument.class), eq(ChallengeDto.class));
+    }
 
     @Test
     void deleteChallengeById_NotFound() {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -543,8 +543,26 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
         when(challengeDocMocked.getTags()).thenReturn(tags);
         return challengeDocMocked;
     }
-
-
+    
+    @Test
+    void addChallenge_test_invalidTags() {
+        when(ILanguageService.findFirstByLanguageName(eq(languageName)))
+                .thenReturn(Mono.just(languageDocument));
+        when(solutionRepository.save(any(SolutionDocument.class)))
+                .thenReturn(Mono.just(solutionDocument));
+                when(tagService.getValidatedTags(eq(formData.getTags())))
+                .thenReturn(Mono.just(false));
+        
+        StepVerifier.create(challengeService.addChallenge(formData))
+                .expectErrorMatches(throwable ->
+                        throwable instanceof TagNotFoundException
+                                && throwable.getMessage().equals("One or more tags are invalid")
+                )
+                .verify();
+        
+        verify(challengeRepository, never()).save(any(ChallengeDocument.class));
+        verify(tagService, times(1)).getValidatedTags(eq(formData.getTags()));
+    }
 
     @Test
     void deleteChallengeById_NotFound() {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -499,6 +499,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     void addChallenge_test_success() {
         when(ILanguageService.findFirstByLanguageName(eq(languageName))).thenReturn(Mono.just(languageDocument)); // Valid language
         when(solutionRepository.save(any(SolutionDocument.class))).thenReturn(Mono.just(solutionDocument));
+        when(tagService.getValidatedTags(eq(formData.getTags()))).thenReturn(Mono.just(true));
         when(challengeRepository.save(any(ChallengeDocument.class))).thenReturn(Mono.just(challengeDocument));
         when(challengeConverter.convertDocumentToDto(any(ChallengeDocument.class), eq(ChallengeDto.class))).thenReturn(challengeDto);
 
@@ -509,6 +510,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         verify(ILanguageService, times(1)).findFirstByLanguageName(eq(languageName));
         verify(solutionRepository, times(1)).save(any(SolutionDocument.class));
+        verify(tagService, times(1)).getValidatedTags(eq(formData.getTags()));
         verify(challengeRepository, times(1)).save(any(ChallengeDocument.class));
         verify(challengeConverter, times(1)).convertDocumentToDto(any(ChallengeDocument.class), eq(ChallengeDto.class));
     }


### PR DESCRIPTION
Implement tag validation in addChallenge endpoint
User Story: #322 [https://tree.taiga.io/project/luisvi-ita-challenges/us/322](url)

Summary
This PR adds validation of tags in the addChallenge endpoint, mirroring the existing logic in updateChallenge. If any of the supplied tags are invalid, the endpoint now returns a TagNotFoundException.

Changes

ChallengeServiceImpl.addChallenge(...)

After saving the SolutionDocument, calls tagService.getValidatedTags(...)

Throws TagNotFoundException if validation fails

Unit tests

Modified addChallenge_test_success() to mock tagService.getValidatedTags(...) returning true and verify it’s invoked

Added addChallenge_test_invalidTags() to cover the failure path when getValidatedTags(...) returns false