### PR TITLE
feature 366: Update service layer with ChallengeNotFoundException

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -355,7 +355,7 @@ public class ChallengeServiceImpl implements IChallengeService {
                     UUID userUuid = Uuidtuple.getT2();
 
                     return challengeRepository.findByUuid(challengeUuid)
-                            .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundException(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
                             .flatMap(challenge -> userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())
                                     .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
                                     .flatMap(isAddedToUsersFavorites -> {
@@ -381,7 +381,7 @@ public class ChallengeServiceImpl implements IChallengeService {
                     UUID userUuid = Uuidtuple.getT2();
 
                     return challengeRepository.findByUuid(challengeUuid)
-                            .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundException(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
                             .flatMap(challenge -> userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())
                                     .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
                                     .flatMap(isRemovedFromUsersFavorites -> {
@@ -404,7 +404,7 @@ public class ChallengeServiceImpl implements IChallengeService {
                 .switchIfEmpty(Mono.error(new LanguageNotFoundException("Language " + codingLanguage + " is not valid")))
                 .flatMap(newLanguage -> validateUUID(String.valueOf(challengeId))
                         .flatMap(validId -> challengeRepository.findByUuid(validId)
-                                .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(
+                                .switchIfEmpty(Mono.error(new ChallengeNotFoundException(
                                         String.format(CHALLENGE_NOT_FOUND_ERROR, validId))))
                                 .flatMap(challengeDocument -> {
                                     log.info("Challenge found for challengeId: {}", validId);
@@ -447,7 +447,7 @@ public class ChallengeServiceImpl implements IChallengeService {
                     UUID userUuid = Uuidtuple.getT2();
 
                     return challengeRepository.findByUuid(challengeUuid)
-                            .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundException(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
                             .flatMap(challenge -> userService.addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString())
                                     .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
                                     .flatMap(isAddedToUsersBookmarks -> {
@@ -473,7 +473,7 @@ public class ChallengeServiceImpl implements IChallengeService {
                     UUID userUuid = Uuidtuple.getT2();
 
                     return challengeRepository.findByUuid(challengeUuid)
-                            .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundException(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
                             .flatMap(challenge -> userService.removeChallengeFromBookmarks(userUuid.toString(), challengeUuid.toString())
                                     .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
                                     .flatMap(isRemovedFromUsersBookmarks -> {
@@ -499,7 +499,7 @@ public class ChallengeServiceImpl implements IChallengeService {
                     UUID userUuid = uuidTuple.getT2();
 
                     return challengeRepository.findByUuid(challengeUuid)
-                            .switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundException(
                                     String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
                             .flatMap(challenge -> {
                                 log.info("It should be connected to user service using the fields {} and {}", challengeUuid, userUuid);

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -728,7 +728,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         StepVerifier.create(challengeService.addChallengeToFavorites(challengeUuid.toString(), UUID.randomUUID().toString()))
                 .expectErrorMatches(error ->
-                        error instanceof ChallengeNotFoundReturn404Exception &&
+                        error instanceof ChallengeNotFoundException &&
                                 error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
                 .verify();
 
@@ -744,7 +744,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         StepVerifier.create(challengeService.addChallengeToBookmarks(challengeUuid.toString(), UUID.randomUUID().toString()))
                 .expectErrorMatches(error ->
-                        error instanceof ChallengeNotFoundReturn404Exception &&
+                        error instanceof ChallengeNotFoundException &&
                                 error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
                 .verify();
 
@@ -760,7 +760,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), UUID.randomUUID().toString()))
                 .expectErrorMatches(error ->
-                        error instanceof ChallengeNotFoundReturn404Exception &&
+                        error instanceof ChallengeNotFoundException &&
                                 error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
                 .verify();
 
@@ -1204,7 +1204,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), UUID.randomUUID().toString()))
                 .expectErrorMatches(error ->
-                        error instanceof ChallengeNotFoundReturn404Exception &&
+                        error instanceof ChallengeNotFoundException &&
                                 error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
                 .verify();
 
@@ -1645,7 +1645,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         StepVerifier.create(challengeService.removeChallengeFromBookmarks(challengeUuid.toString(), UUID.randomUUID().toString()))
                 .expectErrorMatches(error ->
-                        error instanceof ChallengeNotFoundReturn404Exception &&
+                        error instanceof ChallengeNotFoundException &&
                                 error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
                 .verify();
 
@@ -1934,7 +1934,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         StepVerifier.create(challengeService.updateChallenge(challengeId, formData))
                 .expectErrorMatches(error ->
-                        error instanceof ChallengeNotFoundReturn404Exception &&
+                        error instanceof ChallengeNotFoundException &&
                                 error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeId)))
                 .verify();
 


### PR DESCRIPTION
### Update service layer with ChallengeNotFoundException

User Story: #365 [https://tree.taiga.io/project/luisvi-ita-challenges/us/365](url)

#### Summary

Replace all internal service-level references to the deprecated ChallengeNotFoundReturn404Exception with the unified ChallengeNotFoundException.

#### Changes

ChallengeServiceImpl.java:

Updated to replace:
`.switchIfEmpty(Mono.error(new ChallengeNotFoundReturn404Exception(...)))`
with:
`.switchIfEmpty(Mono.error(new ChallengeNotFoundException(...)))`

In the following methods:
- addChallengeToFavorites
- removeChallengeFromFavorites
- updateChallenge
- addChallengeToBookmarks
- removeChallengeFromBookmarks
- addChallengeToSolved

ChallengeServiceImplTest.java:

Replaced all assertions that expected ChallengeNotFoundReturn404Exception with ChallengeNotFoundException in the following test:
- addChallengeToFavorites_WhenChallengeNotFound_ReturnsError
- addChallengeToBookmarks_WhenChallengeNotFound_ReturnsError
- addChallengeToSolved_WhenChallengeNotFound_ReturnsError
- removeChallengeFromFavorites_WhenChallengeNotFound_ReturnsError
- removeChallengeFromBookmarks_WhenChallengeNotFound_ReturnsError
- updateChallengeWhenChallengeDoesNotExist_returnsError_test