### PR TITLE
Feature 367: Set 404 response in ChallengeNotFoundException

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
@@ -49,7 +49,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ChallengeNotFoundException.class)
     public ResponseEntity<MessageDto> handleChallengeNotFoundException(ChallengeNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.OK).body(new MessageDto(ex.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new MessageDto(ex.getMessage()));
     }
 
     @ExceptionHandler(TagNotFoundException.class)

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -450,7 +450,7 @@ class ChallengeControllerTest {
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/challenge/challenges/" + id)
                 .exchange()
-                .expectStatus().isOk()
+                .expectStatus().isNotFound()
                 .expectBody()
                 .jsonPath("$.message").isEqualTo("Challenge with id: non_existing_id not found");
     }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/exception/GlobalExceptionHandlerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/exception/GlobalExceptionHandlerTest.java
@@ -158,7 +158,7 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<MessageDto> responseEntity = globalExceptionHandler.handleChallengeNotFoundException(challengeNotFoundException);
 
         // Assert
-        assertEquals(OK_REQUEST, responseEntity.getStatusCode());
+        assertEquals(NOT_FOUND_REQUEST, responseEntity.getStatusCode());
         String responseBody = Objects.requireNonNull(responseEntity.getBody()).getMessage();
         Assertions.assertTrue(responseBody.contains("Challenge not found"));
     }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
@@ -4,10 +4,7 @@ import com.itachallenge.challenge.document.*;
 import com.itachallenge.challenge.dto.ChallengeDto;
 import com.itachallenge.challenge.enums.Topic;
 import com.itachallenge.challenge.repository.ChallengeRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
@@ -134,7 +131,8 @@ class ChallengeIntegrationTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ChallengeDto.class)
-                .value(dto -> assertTrue(dto != null));
+                .value(Assertions::assertNotNull);
+
     }
 
     @Test

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
@@ -114,17 +114,19 @@ class ChallengeIntegrationTest {
     }
 
     @Test
-    void shouldReturnOKForUnknownUserId() {
+    void shouldReturnNotFoundForInvalidChallengeId() {
         webTestClient
                 .get()
                 .uri(CHALLENGE_BASE_URL + "/challenges/{challengeId}", UUID_INVALID)
                 .exchange()
                 .expectStatus()
-                .isEqualTo(OK);
+                .isNotFound()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("Challenge with id: " + UUID_INVALID + " not found");
     }
 
     @Test
-    void shouldReturnOk_ValidUserId() {
+    void shouldReturnOkForValidChallengeId() {
         webTestClient
                 .get()
                 .uri(CHALLENGE_BASE_URL + "/challenges/{challengeId}", UUID_VALID)
@@ -132,9 +134,7 @@ class ChallengeIntegrationTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ChallengeDto.class)
-                .value(dto -> {
-                    assert dto != null;
-                });
+                .value(dto -> assertTrue(dto != null));
     }
 
     @Test


### PR DESCRIPTION
### Set 404 response in ChallengeNotFoundException

User Story: #365 [https://tree.taiga.io/project/luisvi-ita-challenges/us/365](url)

#### Summary

Update the annotation of the ChallengeNotFoundException class to return HTTP status 404 Not Found instead of 200 OK when a challenge is not found.

#### Changes

GlobalExceptionHandler.java:
- Changed the response of handleChallengeNotFoundException from HttpStatus.OK to HttpStatus.NOT_FOUND.

ChallengeControllerTest.java:
- Modified the deleteOneChallenge_notFound() test to expect HttpStatus.NOT_FOUND instead of HttpStatus.OK.

GlobalExceptionHandlerTest.java:
- Updated the testHandleChallengeNotFoundException() test to assert HttpStatus.NOT_FOUND in the response instead of HttpStatus.OK.

ChallengeIntegrationTest.java:
- Renamed test method `shouldReturnOKForUnknownUserId()` to `shouldReturnNotFoundForInvalidChallengeId()`. 
- Changed .expectStatus().isEqualTo(OK) to .expectStatus().isNotFound(). Also added .jsonPath("$.message").isEqualTo("Challenge with id: ... not found") to validate the error message.

- Renamed test method `shouldReturnOk_ValidUserId()` to `shouldReturnOkForValidChallengeId()`. 
- Replaced assertTrue(dto != null) with Assertions.assertNotNull(dto).