### PR TITLE
Feature/349 Creation method connect micro.user with micro.challenge

### DIFF
--- a/itachallenge-user/build.gradle
+++ b/itachallenge-user/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation group: 'io.projectreactor', name: 'reactor-test', version: '3.1.0.RELEASE'
     testImplementation group: 'org.testcontainers', name: 'mongodb', version: '1.17.6'
     testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.17.6'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/ChallengeNotFoundException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/ChallengeNotFoundException.java
@@ -1,0 +1,9 @@
+package com.itachallenge.user.exception;
+
+public class ChallengeNotFoundException extends RuntimeException {
+
+    public ChallengeNotFoundException(String message) {
+        super(message);
+    }
+    
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/InternalServerErrorException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/InternalServerErrorException.java
@@ -1,0 +1,9 @@
+package com.itachallenge.user.exception;
+
+public class InternalServerErrorException extends RuntimeException {
+
+    public InternalServerErrorException(String message) {
+        super(message);
+    }
+    
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -71,4 +71,14 @@ public class UserGlobalExceptionHandler {
     public ResponseEntity<String> handleUnmodifiableSolutionException(UnmodificableSolutionException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
+
+    @ExceptionHandler(InternalServerErrorException.class)
+    public ResponseEntity<String> handleInternalServerErrorException(InternalServerErrorException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+    }
+    
+    @ExceptionHandler(ChallengeNotFoundException.class)
+    public ResponseEntity<String> handleChallengeNotFoundException(ChallengeNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/ChallengeServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/ChallengeServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.stereotype.Service;
 
 import com.itachallenge.user.document.enums.ChallengeStatus;
 import com.itachallenge.user.exception.BadRequestException;
@@ -15,6 +16,7 @@ import com.itachallenge.user.exception.InternalServerErrorException;
 
 import reactor.core.publisher.Mono;
 
+@Service
 public class ChallengeServiceImpl implements IChallengeService {
 
     private static final Logger log = LoggerFactory.getLogger(ChallengeServiceImpl.class);

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/ChallengeServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/ChallengeServiceImpl.java
@@ -1,0 +1,72 @@
+package com.itachallenge.user.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.itachallenge.user.document.enums.ChallengeStatus;
+import com.itachallenge.user.exception.BadRequestException;
+import com.itachallenge.user.exception.ChallengeNotFoundException;
+import com.itachallenge.user.exception.InternalServerErrorException;
+
+import reactor.core.publisher.Mono;
+
+public class ChallengeServiceImpl implements IChallengeService {
+
+    private static final Logger log = LoggerFactory.getLogger(ChallengeServiceImpl.class);
+
+    private final WebClient.Builder webClientBuilder;
+
+    private final String challengeServiceUrl;
+    private static final String X_SOLVED_MESSAGE = "X-Solved-Message";
+
+    public ChallengeServiceImpl(
+        WebClient.Builder webClientBuilder, @Value("${challenge.service.url}") String challengeServiceUrl) {
+        this.webClientBuilder = webClientBuilder;
+        this.challengeServiceUrl = challengeServiceUrl;
+    }
+
+    @Override
+    public Mono<Boolean> addChallengeToSolved(String challengeId) {
+        return callEndpoint(challengeId, ChallengeStatus.ENDED, X_SOLVED_MESSAGE, HttpMethod.POST);
+    }
+
+    private Mono<Boolean> callEndpoint(String challengeId, ChallengeStatus type, String errorHeader, HttpMethod method) {
+        String url = buildUrl(challengeId, type.toString().toLowerCase());
+        log.debug("Calling {} endpoint with method={} and URL={}", type.name().toLowerCase(), method, url);
+
+        return webClientBuilder.build()
+                .method(method)
+                .uri(url)
+                .retrieve()
+                .onStatus(HttpStatus.NOT_FOUND::equals, response -> {
+                    log.info("Challenge not found with id: {}", challengeId);
+                    return Mono.error(new ChallengeNotFoundException("Challenge not found"));
+                })
+                .onStatus(HttpStatus.BAD_REQUEST::equals, response -> {
+                    String errorMessage = response.headers().header(errorHeader).stream()
+                            .findFirst().orElse("Unknown error");
+                    log.warn("ChallengeService returned 400: {}", errorMessage);
+                    return Mono.error(new BadRequestException(errorMessage));
+                })
+                .onStatus(HttpStatus.INTERNAL_SERVER_ERROR::equals, response -> {
+                    String errorMessage = response.headers().header(errorHeader).stream()
+                            .findFirst().orElse("Unknown error");
+                    log.warn("ChallengeService returned 500: {}", errorMessage);
+                    return Mono.error(new InternalServerErrorException(errorMessage));
+                })
+                .bodyToMono(Boolean.class);
+    }
+
+    private String buildUrl(String challengeId, String type){
+        return UriComponentsBuilder.fromHttpUrl(challengeServiceUrl)
+                .path("/itachallenge/api/v1/challenge/challenges/{type}/{challengeId}")
+                .buildAndExpand(type, challengeId)
+                .toUriString();
+    }
+    
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/IChallengeService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/IChallengeService.java
@@ -1,0 +1,9 @@
+package com.itachallenge.user.service;
+
+import reactor.core.publisher.Mono;
+
+public interface IChallengeService {
+    
+    Mono<Boolean> addChallengeToSolved(String challengeId);
+
+}

--- a/itachallenge-user/src/main/resources/application.yml
+++ b/itachallenge-user/src/main/resources/application.yml
@@ -56,3 +56,9 @@ logging:
 
 validation:
   mongodb_pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+
+
+challenge:
+  service:
+    url: http://apisix-gateway:9080 # IN PRODUCTION
+    #url: http://172.17.0.2:8764 # LOCAL IP

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/ChallengeServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/ChallengeServiceImplTest.java
@@ -1,0 +1,166 @@
+package com.itachallenge.user.service;
+
+import com.itachallenge.user.exception.BadRequestException;
+import com.itachallenge.user.exception.ChallengeNotFoundException;
+import com.itachallenge.user.exception.InternalServerErrorException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ChallengeServiceImplTest {
+
+    private MockWebServer mockWebServer;
+    private ChallengeServiceImpl challengeService;
+
+    private static final String SOLVED_URL = "/itachallenge/api/v1/challenge/challenges/ended/%s";
+    public static final String X_SOLVED_MESSAGE = "X-Solved-Message";
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        challengeService = new ChallengeServiceImpl(
+                WebClient.builder(),
+                mockWebServer.url("").toString()
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.close();
+    }
+
+    @Test
+    void addChallengeToSolved_AddedToUser_ReturnsTrue() throws InterruptedException {
+        String challengeId = "someId";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("true")
+                .setResponseCode(201)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = challengeService.addChallengeToSolved(challengeId);
+
+        StepVerifier.create(result)
+                .expectNext(true)
+                .verifyComplete();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(SOLVED_URL, challengeId),
+                request.getRequestUrl().encodedPath());
+    }
+
+    @Test
+    void addChallengeToSolved_NotAddedToUser_ReturnsFalse() throws InterruptedException {
+        String challengeId = "someId";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = challengeService.addChallengeToSolved(challengeId);
+
+        StepVerifier.create(result)
+                .expectNext(false)
+                .verifyComplete();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(SOLVED_URL, challengeId),
+                request.getRequestUrl().encodedPath());
+    }
+
+    @Test
+    void addChallengeToSolved_BadRequest_ReturnsError() throws InterruptedException {
+        String challengeId = "someId";
+        String someErrorMessage = "Some error message";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(400)
+                .addHeader(X_SOLVED_MESSAGE, someErrorMessage)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = challengeService.addChallengeToSolved(challengeId);
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadRequestException.class, throwable);
+                    assertTrue(throwable.getMessage().contains(someErrorMessage));
+                })
+                .verify();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(SOLVED_URL, challengeId),
+                request.getRequestUrl().encodedPath());
+    }
+
+    @Test
+    void addChallengeToSolved_ChallengeNotFound_ReturnsError() throws InterruptedException {
+        String challengeId = "someId";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(404)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = challengeService.addChallengeToSolved(challengeId);
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(ChallengeNotFoundException.class, throwable);
+                    assertTrue(throwable.getMessage().contains("Challenge not found"));
+                })
+                .verify();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(SOLVED_URL, challengeId),
+                request.getRequestUrl().encodedPath());
+    }
+
+    @Test
+    void addChallengeToSolved_InternalServerError_ReturnsError() throws InterruptedException {
+        String challengeId = "someId";
+        String someErrorMessage = "Some error message";
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("false")
+                .setResponseCode(500)
+                .addHeader(X_SOLVED_MESSAGE, someErrorMessage)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<Boolean> result = challengeService.addChallengeToSolved(challengeId);
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(InternalServerErrorException.class, throwable);
+                    assertTrue(throwable.getMessage().contains(someErrorMessage));
+                })
+                .verify();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request.getRequestUrl());
+        assertEquals(
+                String.format(SOLVED_URL, challengeId),
+                request.getRequestUrl().encodedPath());
+    }
+}


### PR DESCRIPTION
This PR contains the necessary changes to enable communication between the user microservice and the challenge microservice, with the goal of incrementing the field `timesSolved`

Changes:

- **NEW** `ChallengeServiceImpl.java` : This class is responsible for sending a request to an endpoint of the challenge micro, so that the challenge micro handles only the part it is responsible. In this case, incrementing the value of the field `timesSolved`

- **NEW** `IChallengeService.java` : This is the interface for `ChallengeServiceImpl.java`

- **NEW** `ChallengeNotFoundException.java` and `InternalServerErrorException.java` 

- **UPDATED** `UserGlobalHandlerException.java` : Added the previously mentioned exceptions

- **UPDATED** `gradle.build` : Added the library okhttp3 for the testing for `ChallengeServiceImpl.java`

- **NEW** `ChallengeServiceImplTest.java` : This is the test of the `ChallengeServiceImpl.java`, checks for the exceptions

NOTE : The okhttp3 library is already used in the challenge microservice.