### PR TITLE
PR 2/4 feat(service): implement FavoriteService interface (#352)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -56,6 +56,8 @@ public class ChallengeServiceImpl implements IChallengeService {
     private IUserService userService;
     @Autowired
     private ITagService tagService;
+    @Autowired
+    private IFavoriteService favoriteService;
 
     @Cacheable(value = "challenges", key = "#id", unless = "#result==null")
     public Mono<ChallengeDto> getChallengeById(String id) {
@@ -351,55 +353,12 @@ public class ChallengeServiceImpl implements IChallengeService {
 
     @Override
     public Mono<FavoriteDto> addChallengeToFavorites(String challengeId, String userId) {
-
-        Mono<UUID> challengeIdMono = validateUUID(String.valueOf(challengeId));
-        Mono<UUID> userIdMono = validateUUID(String.valueOf(userId));
-
-        return Mono.zip(challengeIdMono, userIdMono)
-                .flatMap(Uuidtuple -> {
-                    UUID challengeUuid = Uuidtuple.getT1();
-                    UUID userUuid = Uuidtuple.getT2();
-
-                    return challengeRepository.findByUuid(challengeUuid)
-                            .switchIfEmpty(Mono.error(new ChallengeNotFoundException(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
-                            .flatMap(challenge -> userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())
-                                    .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
-                                    .flatMap(isAddedToUsersFavorites -> {
-                                        if (Boolean.TRUE.equals(isAddedToUsersFavorites) ||
-                                                Optional.ofNullable(challenge.getTimesFavorite()).orElse(0) == 0) {
-                                            challenge.increaseTimesFavorite();
-                                            return challengeRepository.save(challenge);
-                                        }
-                                        return Mono.just(challenge);
-                                    })
-                                    .map(savedChallenge -> new FavoriteDto(true, savedChallenge.getTimesFavorite())));
-                });
+        return favoriteService.addChallengeToFavorites(challengeId, userId);
     }
 
     @Override
     public Mono<FavoriteDto> removeChallengeFromFavorites(String challengeId, String userId) {
-        Mono<UUID> challengeIdMono = validateUUID(String.valueOf(challengeId));
-        Mono<UUID> languageIdMono = validateUUID(String.valueOf(userId));
-
-        return Mono.zip(challengeIdMono, languageIdMono)
-                .flatMap(Uuidtuple -> {
-                    UUID challengeUuid = Uuidtuple.getT1();
-                    UUID userUuid = Uuidtuple.getT2();
-
-                    return challengeRepository.findByUuid(challengeUuid)
-                            .switchIfEmpty(Mono.error(new ChallengeNotFoundException(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
-                            .flatMap(challenge -> userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())
-                                    .onErrorResume(throwable -> Mono.error(new InternalServerErrorException(throwable.getMessage())))
-                                    .flatMap(isRemovedFromUsersFavorites -> {
-                                        if (Boolean.TRUE.equals(isRemovedFromUsersFavorites) ||
-                                                Optional.ofNullable(challenge.getTimesFavorite()).orElse(0) == 0) {
-                                            challenge.decreaseTimesFavorite();
-                                            return challengeRepository.save(challenge);
-                                        }
-                                        return Mono.just(challenge);
-                                    })
-                                    .map(savedChallenge -> new FavoriteDto(false, savedChallenge.getTimesFavorite())));
-                });
+        return favoriteService.removeChallengeFromFavorites(challengeId, userId);
     }
 
     @Override

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/FavoriteServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/FavoriteServiceImpl.java
@@ -1,0 +1,93 @@
+package com.itachallenge.challenge.service;
+
+import com.itachallenge.challenge.document.ChallengeDocument;
+import com.itachallenge.challenge.dto.FavoriteDto;
+import com.itachallenge.challenge.exception.BadUUIDException;
+import com.itachallenge.challenge.exception.ChallengeNotFoundException;
+import com.itachallenge.challenge.exception.InternalServerErrorException;
+import com.itachallenge.challenge.repository.ChallengeRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteServiceImpl implements IFavoriteService {
+
+    private static final Logger log = LoggerFactory.getLogger(FavoriteServiceImpl.class);
+    private static final Pattern UUID_FORM = Pattern.compile(
+            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", Pattern.CASE_INSENSITIVE);
+    private static final String CHALLENGE_NOT_FOUND_ERROR = "Challenge with id: %s not found";
+
+    private final ChallengeRepository challengeRepository;
+    private final IUserService userService;
+
+    @Override
+    public Mono<FavoriteDto> addChallengeToFavorites(String challengeId, String userId) {
+        Mono<UUID> challengeIdMono = validateUUID(challengeId);
+        Mono<UUID> userIdMono = validateUUID(userId);
+
+        return Mono.zip(challengeIdMono, userIdMono)
+                .flatMap(tuple -> {
+                    UUID challengeUuid = tuple.getT1();
+                    UUID userUuid = tuple.getT2();
+
+                    return challengeRepository.findByUuid(challengeUuid)
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundException(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                            .flatMap(challenge -> userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())
+                                    .onErrorResume(e -> Mono.error(new InternalServerErrorException(e.getMessage())))
+                                    .flatMap(added -> {
+                                        if (Boolean.TRUE.equals(added) ||
+                                                Optional.ofNullable(challenge.getTimesFavorite()).orElse(0) == 0) {
+                                            challenge.increaseTimesFavorite();
+                                            return challengeRepository.save(challenge);
+                                        }
+                                        return Mono.just(challenge);
+                                    })
+                                    .map(saved -> new FavoriteDto(true, saved.getTimesFavorite())));
+                });
+    }
+
+    @Override
+    public Mono<FavoriteDto> removeChallengeFromFavorites(String challengeId, String userId) {
+        Mono<UUID> challengeIdMono = validateUUID(challengeId);
+        Mono<UUID> userIdMono = validateUUID(userId);
+
+        return Mono.zip(challengeIdMono, userIdMono)
+                .flatMap(tuple -> {
+                    UUID challengeUuid = tuple.getT1();
+                    UUID userUuid = tuple.getT2();
+
+                    return challengeRepository.findByUuid(challengeUuid)
+                            .switchIfEmpty(Mono.error(new ChallengeNotFoundException(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
+                            .flatMap(challenge -> userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())
+                                    .onErrorResume(e -> Mono.error(new InternalServerErrorException(e.getMessage())))
+                                    .flatMap(removed -> {
+                                        if (Boolean.TRUE.equals(removed) ||
+                                                Optional.ofNullable(challenge.getTimesFavorite()).orElse(0) == 0) {
+                                            challenge.decreaseTimesFavorite();
+                                            return challengeRepository.save(challenge);
+                                        }
+                                        return Mono.just(challenge);
+                                    })
+                                    .map(saved -> new FavoriteDto(false, saved.getTimesFavorite())));
+                });
+    }
+
+    private Mono<UUID> validateUUID(String id) {
+        boolean validUUID = id != null && UUID_FORM.matcher(id).matches();
+
+        if (!validUUID) {
+            log.warn("Invalid ID format.");
+            return Mono.error(new BadUUIDException("Invalid ID format. Please indicate the correct format."));
+        }
+
+        return Mono.just(UUID.fromString(id));
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -658,15 +658,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     }
 
     @Test
-    void addChallengeToFavorites_WhenChallengeUuidNotValid_ReturnsError() {
-        StepVerifier.create(challengeService.addChallengeToFavorites("InvalidUuid", UUID.randomUUID().toString()))
-                .expectErrorMatches(error ->
-                        error instanceof BadUUIDException &&
-                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
-                .verify();
-    }
-
-    @Test
     void addChallengeToBookmarks_WhenChallengeUuidNotValid_ReturnsError() {
         StepVerifier.create(challengeService.addChallengeToBookmarks("InvalidUuid", UUID.randomUUID().toString()))
                 .expectErrorMatches(error ->
@@ -678,15 +669,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     @Test
     void addChallengeToSolved_WhenChallengeUuidNotValid_ReturnsError() {
         StepVerifier.create(challengeService.addChallengeToSolved("InvalidUuid", UUID.randomUUID().toString()))
-                .expectErrorMatches(error ->
-                        error instanceof BadUUIDException &&
-                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
-                .verify();
-    }
-
-    @Test
-    void addChallengeToFavorites_WhenUserUuidNotValid_ReturnsError() {
-        StepVerifier.create(challengeService.addChallengeToFavorites(UUID.randomUUID().toString(), "InvalidUuid"))
                 .expectErrorMatches(error ->
                         error instanceof BadUUIDException &&
                                 error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
@@ -712,15 +694,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     }
 
     @Test
-    void addChallengeToFavorites_WhenChallengeUuidIsNull_ReturnsError() {
-        StepVerifier.create(challengeService.addChallengeToFavorites(null, UUID.randomUUID().toString()))
-                .expectErrorMatches(error ->
-                        error instanceof BadUUIDException &&
-                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
-                .verify();
-    }
-
-    @Test
     void addChallengeToBookmarks_WhenChallengeUuidIsNull_ReturnsError() {
         StepVerifier.create(challengeService.addChallengeToBookmarks(null, UUID.randomUUID().toString()))
                 .expectErrorMatches(error ->
@@ -732,15 +705,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     @Test
     void addChallengeToSolved_WhenChallengeUuidIsNull_ReturnsError() {
         StepVerifier.create(challengeService.addChallengeToSolved(null, UUID.randomUUID().toString()))
-                .expectErrorMatches(error ->
-                        error instanceof BadUUIDException &&
-                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
-                .verify();
-    }
-
-    @Test
-    void addChallengeToFavorites_WhenUserUuidIsNull_ReturnsError() {
-        StepVerifier.create(challengeService.addChallengeToFavorites(UUID.randomUUID().toString(), null))
                 .expectErrorMatches(error ->
                         error instanceof BadUUIDException &&
                                 error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
@@ -763,22 +727,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
                         error instanceof BadUUIDException &&
                                 error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
                 .verify();
-    }
-
-    @Test
-    void addChallengeToFavorites_WhenChallengeNotFound_ReturnsError() {
-        String CHALLENGE_NOT_FOUND_ERROR = "Challenge with id: %s not found";
-        UUID challengeUuid = UUID.randomUUID();
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.empty());
-
-        StepVerifier.create(challengeService.addChallengeToFavorites(challengeUuid.toString(), UUID.randomUUID().toString()))
-                .expectErrorMatches(error ->
-                        error instanceof ChallengeNotFoundException &&
-                                error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
     }
 
     @Test
@@ -814,27 +762,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     }
 
     @Test
-    void addChallengeToFavorites_WhenUserNotFound_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new UserNotFoundException(message)));
-
-        StepVerifier.create(challengeService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof InternalServerErrorException &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
     void addChallengeToBookmarks_WhenUserNotFound_ReturnsError() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -853,27 +780,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         verify(challengeRepository, times(1)).findByUuid(challengeUuid);
         verify(userService, times(1)).addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
-    void addChallengeToFavorites_WhenUserServiceReturnsCustomBadRequestException_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new BadRequestException(message)));
-
-        StepVerifier.create(challengeService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof InternalServerErrorException &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
     }
 
     @Test
@@ -898,27 +804,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     }
 
     @Test
-    void addChallengeToFavorites_WhenUserServiceReturnsCustomInternalServerErrorException_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new InternalServerErrorException(message)));
-
-        StepVerifier.create(challengeService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof InternalServerErrorException &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
     void addChallengeToBookmarks_WhenUserServiceReturnsCustomInternalServerErrorException_ReturnsError() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -940,27 +825,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     }
 
     @Test
-    void addChallengeToFavorites_WhenUserServiceReturnsAnyException_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new Exception(message)));
-
-        StepVerifier.create(challengeService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof Exception &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
     void addChallengeToBookmarks_WhenUserServiceReturnsAnyException_ReturnsError() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -979,33 +843,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         verify(challengeRepository, times(1)).findByUuid(challengeUuid);
         verify(userService, times(1)).addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
-    void addChallengeToFavorites_WhenAdded_IncreasesTimesFavoriteAndReturnsFavoriteDTO() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        int initialTimesFavorite = 20;
-
-        challenge.setTimesFavorite(initialTimesFavorite);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
-        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
-
-        StepVerifier.create(challengeService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(favoriteDto -> {
-                        return favoriteDto.getTimesFavorited() == initialTimesFavorite + 1 &&
-                                favoriteDto.isFavorite();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(initialTimesFavorite + 1, challenge.getTimesFavorite());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(1)).save(challenge);
     }
 
     @Test
@@ -1036,32 +873,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     }
 
     @Test
-    void addChallengeToFavorites_WhenAddedAndInitialTimesFavoriteIsNull_IncreasesTimesFavoriteAndReturnsFavoriteDTO() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-
-        challenge.setTimesFavorite(null);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
-        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
-
-        StepVerifier.create(challengeService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(favoriteDto -> {
-                    return favoriteDto.getTimesFavorited() == 1 &&
-                            favoriteDto.isFavorite();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(1, challenge.getTimesFavorite());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(1)).save(challenge);
-    }
-
-    @Test
     void addChallengeToBookmarks_WhenAddedAndInitialTimesFavoriteIsNull_IncreasesTimesBookmarkAndReturnsBookmarkDTO() {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -1085,32 +896,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
         verify(challengeRepository, times(1)).findByUuid(challengeUuid);
         verify(userService, times(1)).addChallengeToBookmarks(userUuid.toString(), challengeUuid.toString());
         verify(challengeRepository, times(1)).save(challenge);
-    }
-
-    @Test
-    void addChallengeToFavorites_WhenNotAdded_NotIncreaseTimesFavoriteAndReturnsFavoriteDTO() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        int initialTimesFavorite = 20;
-
-        challenge.setTimesFavorite(initialTimesFavorite);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
-
-        StepVerifier.create(challengeService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(favoriteDto -> {
-                    return favoriteDto.getTimesFavorited() == initialTimesFavorite &&
-                            favoriteDto.isFavorite();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(initialTimesFavorite, challenge.getTimesFavorite());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(0)).save(any());
     }
 
     @Test
@@ -1141,33 +926,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
     @ParameterizedTest
     @MethodSource
-    void addChallengeToFavorites_WhenNotAddedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToOneAndReturnsFavoriteDTO(Integer timesFavorite) {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-
-        challenge.setTimesFavorite(timesFavorite);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
-        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
-
-        StepVerifier.create(challengeService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(favoriteDto -> {
-                    return favoriteDto.getTimesFavorited() == 1 &&
-                            favoriteDto.isFavorite();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(1, challenge.getTimesFavorite());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(1)).save(challenge);
-    }
-
-    @ParameterizedTest
-    @MethodSource
     void addChallengeToBookmarks_WhenNotAddedAndTimesBookmarkIsNullOrZero_SetTimesBookmarkToOneAndReturnsBookmarkDTO(Integer timesBookmark) {
         UUID challengeUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
@@ -1193,284 +951,12 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
         verify(challengeRepository, times(1)).save(challenge);
     }
 
-    public static Stream<Integer> addChallengeToFavorites_WhenNotAddedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToOneAndReturnsFavoriteDTO() {
-        return Stream.of(null, 0);
-    }
-
     public static Stream<Integer> addChallengeToBookmarks_WhenNotAddedAndTimesBookmarkIsNullOrZero_SetTimesBookmarkToOneAndReturnsBookmarkDTO() {
         return Stream.of(null, 0);
     }
 
     public static Stream<Integer> addChallengeToSolved_WhenNotAddedAndTimesSolvedIsNullOrZero_SetTimesSolvedToOneAndReturnsSolvedDTO() {
         return Stream.of(null, 0);
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenChallengeUuidNotValid_ReturnsError() {
-        StepVerifier.create(challengeService.removeChallengeFromFavorites("InvalidUuid", UUID.randomUUID().toString()))
-                .expectErrorMatches(error ->
-                        error instanceof BadUUIDException &&
-                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
-                .verify();
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenUserUuidNotValid_ReturnsError() {
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(UUID.randomUUID().toString(), "InvalidUuid"))
-                .expectErrorMatches(error ->
-                        error instanceof BadUUIDException &&
-                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
-                .verify();
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenChallengeUuidIsNull_ReturnsError() {
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(null, UUID.randomUUID().toString()))
-                .expectErrorMatches(error ->
-                        error instanceof BadUUIDException &&
-                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
-                .verify();
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenUserUuidIsNull_ReturnsError() {
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(UUID.randomUUID().toString(), null))
-                .expectErrorMatches(error ->
-                        error instanceof BadUUIDException &&
-                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
-                .verify();
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenChallengeNotFound_ReturnsError() {
-        String CHALLENGE_NOT_FOUND_ERROR = "Challenge with id: %s not found";
-        UUID challengeUuid = UUID.randomUUID();
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.empty());
-
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), UUID.randomUUID().toString()))
-                .expectErrorMatches(error ->
-                        error instanceof ChallengeNotFoundException &&
-                                error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenUserNotFound_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new UserNotFoundException(message)));
-
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof InternalServerErrorException &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenUserServiceReturnsCustomBadRequestException_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new BadRequestException(message)));
-
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof InternalServerErrorException &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenUserServiceReturnsCustomInternalServerErrorException_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new InternalServerErrorException(message)));
-
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof InternalServerErrorException &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenUserServiceReturnsAnyException_ReturnsError() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        String message = "Some error message";
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-
-        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new Exception(message)));
-
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectErrorMatches(error ->
-                        error instanceof Exception &&
-                                error.getMessage().equals(message))
-                .verify();
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenRemoved_DecreasesTimesFavoriteAndReturnsFavoriteDTO() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        int initialTimesFavorite = 20;
-
-        challenge.setTimesFavorite(initialTimesFavorite);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
-        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
-
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(favoriteDto -> {
-                    return favoriteDto.getTimesFavorited() == initialTimesFavorite - 1 &&
-                            !favoriteDto.isFavorite();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(initialTimesFavorite - 1, challenge.getTimesFavorite());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(1)).save(challenge);
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenRemovedAndInitialTimesFavoriteIsNull_SetsTimesFavoriteToZeroAndReturnsFavoriteDTO() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-
-        challenge.setTimesFavorite(null);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
-        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
-
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(favoriteDto -> {
-                    return favoriteDto.getTimesFavorited() == 0 &&
-                            !favoriteDto.isFavorite();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(0, challenge.getTimesFavorite());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(1)).save(challenge);
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenRemovedAndInitialTimesFavoriteIsZero_SetsTimesFavoriteToZeroAndReturnsFavoriteDTO() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-
-        challenge.setTimesFavorite(0);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
-        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
-
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(favoriteDto -> {
-                    return favoriteDto.getTimesFavorited() == 0 &&
-                            !favoriteDto.isFavorite();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(0, challenge.getTimesFavorite());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(1)).save(challenge);
-    }
-
-    @Test
-    void removeChallengeFromFavorites_WhenNotRemoved_NotChangeTimesFavoriteAndReturnsFavoriteDTO() {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-        int initialTimesFavorite = 20;
-
-        challenge.setTimesFavorite(initialTimesFavorite);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
-
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(favoriteDto -> {
-                    return favoriteDto.getTimesFavorited() == initialTimesFavorite &&
-                            !favoriteDto.isFavorite();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(initialTimesFavorite, challenge.getTimesFavorite());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(0)).save(any());
-    }
-
-    @ParameterizedTest
-    @MethodSource
-    void removeChallengeFromFavorites_WhenNotRemovedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToZeroAndReturnsFavoriteDTO(Integer timesFavorite) {
-        UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
-        ChallengeDocument challenge = new ChallengeDocument();
-
-        challenge.setTimesFavorite(timesFavorite);
-
-        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
-        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
-        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
-
-        StepVerifier.create(challengeService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
-                .expectNextMatches(favoriteDto -> {
-                    return favoriteDto.getTimesFavorited() == 0 &&
-                            !favoriteDto.isFavorite();
-                })
-                .verifyComplete();
-
-        Assertions.assertEquals(0, challenge.getTimesFavorite());
-
-        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
-        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
-        verify(challengeRepository, times(1)).save(challenge);
     }
 
     @Test
@@ -1639,11 +1125,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
                     assertEquals(0, genericResultDto.getCount());
                     return true;
                 });
-    }
-
-
-    public static Stream<Integer> removeChallengeFromFavorites_WhenNotRemovedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToZeroAndReturnsFavoriteDTO() {
-        return Stream.of(null, 0);
     }
 
     @Test

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/FavoriteServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/FavoriteServiceImplTest.java
@@ -1,0 +1,562 @@
+package com.itachallenge.challenge.service;
+
+import com.itachallenge.challenge.document.ChallengeDocument;
+import com.itachallenge.challenge.dto.FavoriteDto;
+import com.itachallenge.challenge.exception.*;
+import com.itachallenge.challenge.repository.ChallengeRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FavoriteServiceImplTest {
+
+    @Mock
+    private ChallengeRepository challengeRepository;
+
+    @Mock
+    private IUserService userService;
+
+    @InjectMocks
+    private FavoriteServiceImpl favoriteService;
+
+    private UUID challengeId;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        challengeId = UUID.randomUUID();
+        userId = UUID.randomUUID();
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenChallengeUuidNotValid_ReturnsError() {
+        StepVerifier.create(favoriteService.addChallengeToFavorites("InvalidUuid", UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenUserUuidNotValid_ReturnsError() {
+        StepVerifier.create(favoriteService.addChallengeToFavorites(UUID.randomUUID().toString(), "InvalidUuid"))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenChallengeUuidIsNull_ReturnsError() {
+        StepVerifier.create(favoriteService.addChallengeToFavorites(null, UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenUserUuidIsNull_ReturnsError() {
+        StepVerifier.create(favoriteService.addChallengeToFavorites(UUID.randomUUID().toString(), null))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenChallengeNotFound_ReturnsError() {
+        String CHALLENGE_NOT_FOUND_ERROR = "Challenge with id: %s not found";
+        UUID challengeUuid = UUID.randomUUID();
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.empty());
+
+        StepVerifier.create(favoriteService.addChallengeToFavorites(challengeUuid.toString(), UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof ChallengeNotFoundException &&
+                                error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenUserNotFound_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new UserNotFoundException(message)));
+
+        StepVerifier.create(favoriteService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenUserServiceReturnsCustomBadRequestException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new BadRequestException(message)));
+
+        StepVerifier.create(favoriteService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenUserServiceReturnsCustomInternalServerErrorException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new InternalServerErrorException(message)));
+
+        StepVerifier.create(favoriteService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenUserServiceReturnsAnyException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new Exception(message)));
+
+        StepVerifier.create(favoriteService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof Exception &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenAdded_IncreasesTimesFavoriteAndReturnsFavoriteDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        int initialTimesFavorite = 20;
+
+        challenge.setTimesFavorite(initialTimesFavorite);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(favoriteService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesFavorited() == initialTimesFavorite + 1 &&
+                            favoriteDto.isFavorite();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(initialTimesFavorite + 1, challenge.getTimesFavorite());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenAddedAndInitialTimesFavoriteIsNull_IncreasesTimesFavoriteAndReturnsFavoriteDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesFavorite(null);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(favoriteService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesFavorited() == 1 &&
+                            favoriteDto.isFavorite();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(1, challenge.getTimesFavorite());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    @Test
+    void addChallengeToFavorites_WhenNotAdded_NotIncreaseTimesFavoriteAndReturnsFavoriteDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        int initialTimesFavorite = 20;
+
+        challenge.setTimesFavorite(initialTimesFavorite);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
+
+        StepVerifier.create(favoriteService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesFavorited() == initialTimesFavorite &&
+                            favoriteDto.isFavorite();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(initialTimesFavorite, challenge.getTimesFavorite());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(0)).save(any());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void addChallengeToFavorites_WhenNotAddedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToOneAndReturnsFavoriteDTO(Integer timesFavorite) {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesFavorite(timesFavorite);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.addChallengeToFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(favoriteService.addChallengeToFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesFavorited() == 1 &&
+                            favoriteDto.isFavorite();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(1, challenge.getTimesFavorite());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).addChallengeToFavorites(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    public static Stream<Integer> addChallengeToFavorites_WhenNotAddedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToOneAndReturnsFavoriteDTO() {
+        return Stream.of(null, 0);
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenChallengeUuidNotValid_ReturnsError() {
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites("InvalidUuid", UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenUserUuidNotValid_ReturnsError() {
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(UUID.randomUUID().toString(), "InvalidUuid"))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenChallengeUuidIsNull_ReturnsError() {
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(null, UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenUserUuidIsNull_ReturnsError() {
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(UUID.randomUUID().toString(), null))
+                .expectErrorMatches(error ->
+                        error instanceof BadUUIDException &&
+                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
+                .verify();
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenChallengeNotFound_ReturnsError() {
+        String CHALLENGE_NOT_FOUND_ERROR = "Challenge with id: %s not found";
+        UUID challengeUuid = UUID.randomUUID();
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.empty());
+
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(challengeUuid.toString(), UUID.randomUUID().toString()))
+                .expectErrorMatches(error ->
+                        error instanceof ChallengeNotFoundException &&
+                                error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenUserNotFound_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new UserNotFoundException(message)));
+
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenUserServiceReturnsCustomBadRequestException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new BadRequestException(message)));
+
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenUserServiceReturnsCustomInternalServerErrorException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new InternalServerErrorException(message)));
+
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof InternalServerErrorException &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenUserServiceReturnsAnyException_ReturnsError() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        String message = "Some error message";
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+
+        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.error(new Exception(message)));
+
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectErrorMatches(error ->
+                        error instanceof Exception &&
+                                error.getMessage().equals(message))
+                .verify();
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenRemoved_DecreasesTimesFavoriteAndReturnsFavoriteDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        int initialTimesFavorite = 20;
+
+        challenge.setTimesFavorite(initialTimesFavorite);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesFavorited() == initialTimesFavorite - 1 &&
+                            !favoriteDto.isFavorite();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(initialTimesFavorite - 1, challenge.getTimesFavorite());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenRemovedAndInitialTimesFavoriteIsNull_SetsTimesFavoriteToZeroAndReturnsFavoriteDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesFavorite(null);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesFavorited() == 0 &&
+                            !favoriteDto.isFavorite();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(0, challenge.getTimesFavorite());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenRemovedAndInitialTimesFavoriteIsZero_SetsTimesFavoriteToZeroAndReturnsFavoriteDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesFavorite(0);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(true));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesFavorited() == 0 &&
+                            !favoriteDto.isFavorite();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(0, challenge.getTimesFavorite());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    @Test
+    void removeChallengeFromFavorites_WhenNotRemoved_NotChangeTimesFavoriteAndReturnsFavoriteDTO() {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+        int initialTimesFavorite = 20;
+
+        challenge.setTimesFavorite(initialTimesFavorite);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
+
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesFavorited() == initialTimesFavorite &&
+                            !favoriteDto.isFavorite();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(initialTimesFavorite, challenge.getTimesFavorite());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(0)).save(any());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void removeChallengeFromFavorites_WhenNotRemovedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToZeroAndReturnsFavoriteDTO(Integer timesFavorite) {
+        UUID challengeUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        ChallengeDocument challenge = new ChallengeDocument();
+
+        challenge.setTimesFavorite(timesFavorite);
+
+        when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
+        when(userService.removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString())).thenReturn(Mono.just(false));
+        when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
+
+        StepVerifier.create(favoriteService.removeChallengeFromFavorites(challengeUuid.toString(), userUuid.toString()))
+                .expectNextMatches(favoriteDto -> {
+                    return favoriteDto.getTimesFavorited() == 0 &&
+                            !favoriteDto.isFavorite();
+                })
+                .verifyComplete();
+
+        Assertions.assertEquals(0, challenge.getTimesFavorite());
+
+        verify(challengeRepository, times(1)).findByUuid(challengeUuid);
+        verify(userService, times(1)).removeChallengeFromFavorites(userUuid.toString(), challengeUuid.toString());
+        verify(challengeRepository, times(1)).save(challenge);
+    }
+
+    public static Stream<Integer> removeChallengeFromFavorites_WhenNotRemovedAndTimesFavoriteIsNullOrZero_SetTimesFavoriteToZeroAndReturnsFavoriteDTO() {
+        return Stream.of(null, 0);
+    }
+}


### PR DESCRIPTION
This PR implements the `FavoriteServiceImpl` class as the second step in refactoring `ChallengeController` by moving favorite-related business logic out of `ChallengeServiceImpl` into a dedicated service layer, supporting the goal of improving separation of responsibilities.

- Added `FavoriteServiceImpl` in the service package.
- Moved logic for:
  - `addChallengeToFavorites(String challengeId, String userId)`
  - `removeChallengeFromFavorites(String challengeId, String userId)`
- Updated `ChallengeServiceImpl` to delegate to `IFavoriteService`.
- Created `FavoriteServiceImplTest` to cover all functional paths.
- Removed favorite-related logic from `ChallengeServiceImplTest`.

Continuation of https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/874