### PR TITLE
Feature 370: Remove ChallengeNotFoundReturn404Exception

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/ChallengeNotFoundReturn404Exception.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/ChallengeNotFoundReturn404Exception.java
@@ -1,8 +1,0 @@
-package com.itachallenge.challenge.exception;
-
-public class ChallengeNotFoundReturn404Exception extends RuntimeException {
-
-    public ChallengeNotFoundReturn404Exception(String message) {
-        super(message);
-    }
-}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/GlobalExceptionHandler.java
@@ -57,11 +57,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new MessageDto(ex.getMessage()));
     }
 
-    @ExceptionHandler(ChallengeNotFoundReturn404Exception.class)
-    public ResponseEntity<MessageDto> handleChallengeNotFoundReturn404Exception(ChallengeNotFoundReturn404Exception ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new MessageDto(ex.getMessage()));
-    }
-
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<MessageDto> handleResourceNotFoundException(ResourceNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new MessageDto(ex.getMessage()));

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -507,7 +507,7 @@ class ChallengeControllerTest {
 
         String errorMessage = "ErrorMessage";
 
-        when(challengeService.addChallengeToFavorites(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundReturn404Exception(errorMessage)));
+        when(challengeService.addChallengeToFavorites(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundException(errorMessage)));
         when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
 
         webTestClient.post()
@@ -529,7 +529,7 @@ class ChallengeControllerTest {
 
         String errorMessage = "ErrorMessage";
 
-        when(challengeService.addChallengeToBookmarks(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundReturn404Exception(errorMessage)));
+        when(challengeService.addChallengeToBookmarks(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundException(errorMessage)));
         when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
 
         webTestClient.post()
@@ -725,7 +725,7 @@ class ChallengeControllerTest {
 
         String errorMessage = "ErrorMessage";
 
-        when(challengeService.removeChallengeFromFavorites(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundReturn404Exception(errorMessage)));
+        when(challengeService.removeChallengeFromFavorites(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundException(errorMessage)));
         when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
 
         webTestClient.delete()
@@ -971,7 +971,7 @@ class ChallengeControllerTest {
 
         String errorMessage = "ErrorMessage";
 
-        when(challengeService.removeChallengeFromBookmarks(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundReturn404Exception(errorMessage)));
+        when(challengeService.removeChallengeFromBookmarks(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundException(errorMessage)));
         when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
 
         webTestClient.delete()

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/exception/GlobalExceptionHandlerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/exception/GlobalExceptionHandlerTest.java
@@ -164,20 +164,6 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
-    void testHandleChallengeNotFoundReturn404Exception() {
-        // Arrange
-        ChallengeNotFoundReturn404Exception challengeNotFoundException = new ChallengeNotFoundReturn404Exception("Challenge not found");
-
-        // Act
-        ResponseEntity<MessageDto> responseEntity = globalExceptionHandler.handleChallengeNotFoundReturn404Exception(challengeNotFoundException);
-
-        // Assert
-        assertEquals(NOT_FOUND_REQUEST, responseEntity.getStatusCode());
-        String responseBody = Objects.requireNonNull(responseEntity.getBody()).getMessage();
-        Assertions.assertTrue(responseBody.contains("Challenge not found"));
-    }
-
-    @Test
     void testHandleResourceNotFoundException() {
         // Testgi
         ResourceNotFoundException resourceNotFoundException = new ResourceNotFoundException("Resource not found");


### PR DESCRIPTION
### Remove ChallengeNotFoundReturn404Exception
User Story: #365 [https://tree.taiga.io/project/luisvi-ita-challenges/us/365](url)
#### Summary

This PR removes the redundant custom exception ChallengeNotFoundReturn404Exception and unifies its behavior under the already existing ChallengeNotFoundException.

#### Changes

ChallengeNotFoundReturn404Exception.java:
- Deleted class.

GlobalExceptionHandler.java:
- Refactored to remove the handler for ChallengeNotFoundReturn404Exception.

#### Updated tests

Replaced usage of ChallengeNotFoundReturn404Exception with ChallengeNotFoundException in:

- ChallengeControllerTest.java

- GlobalExceptionHandlerTest.java

Removed the corresponding test method testHandleChallengeNotFoundReturn404Exception