### PR TITLE
Feature/383 adapt the micro.challenge to support dual frontend calls

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeSolvedController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeSolvedController.java
@@ -46,7 +46,7 @@ public class ChallengeSolvedController {
             @RequestHeader(name = "Authorization", required = false) String authHeader) {
         return Mono.fromCallable(() -> jwtService.getUserUuIdFromAuthenticationHeader(authHeader))
                 .onErrorMap(JwtException.class, e -> new BadRequestException(e.getMessage()))
-                .flatMap(userId -> challengeService.addChallengeToSolved(challengeId, userId))
+                .flatMap(userId -> challengeService.addChallengeToSolved(challengeId))
                 .doOnError(error -> log.error("Error adding challenge to solved: {}", error.getMessage()))
                 .map(ResponseEntity::ok);
     }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -495,32 +495,23 @@ public class ChallengeServiceImpl implements IChallengeService {
     }
 
     @Override
-    public Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId) {
+    public Mono<SolvedDto> addChallengeToSolved(String challengeId) {
         Mono<UUID> challengeIdMono = validateUUID(challengeId);
-        Mono<UUID> userIdMono = validateUUID(userId);
 
-        return Mono.zip(challengeIdMono, userIdMono)
-                .flatMap(uuidTuple -> {
-                    UUID challengeUuid = uuidTuple.getT1();
-                    UUID userUuid = uuidTuple.getT2();
-
-                    return challengeRepository.findByUuid(challengeUuid)
+        return challengeIdMono
+                .flatMap(challengeUuid -> 
+                    challengeRepository.findByUuid(challengeUuid)
                             .switchIfEmpty(Mono.error(new ChallengeNotFoundException(
                                     String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid))))
                             .flatMap(challenge -> {
-                                log.info("It should be connected to user service using the fields {} and {}", challengeUuid, userUuid);
-
-                                //The part of the user service is not implemented yet, it should be connected to the user service in the future.
-
                                 if (Optional.ofNullable(challenge.getTimesSolved()).orElse(0) == 0) {
                                     challenge.increaseTimesSolved();
                                     return challengeRepository.save(challenge);
                                 }
-
                                 return Mono.just(challenge);
                             })
-                            .map(updatedChallenge -> new SolvedDto(true, updatedChallenge.getTimesSolved()));
-                });
+                            .map(updatedChallenge -> new SolvedDto(true, updatedChallenge.getTimesSolved()))
+                );
     }
 
     private SolutionDocument buildSolutionDocument(LanguageDocument language, ChallengeCreateDto challengeCreateDto){

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -45,5 +45,5 @@ public interface IChallengeService {
 
     Mono<ChallengeDto> updateChallenge(String challengeId, ChallengeCreateDto challengeCreateDto);
 
-    Mono<SolvedDto> addChallengeToSolved(String challengeId, String userId);
+    Mono<SolvedDto> addChallengeToSolved(String challengeId);
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeSolvedControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeSolvedControllerTest.java
@@ -42,7 +42,7 @@ class ChallengeSolvedControllerTest {
         SolvedDto solvedDto = new SolvedDto();
 
         when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-        when(challengeService.addChallengeToSolved(challengeId, userId)).thenReturn(Mono.just(solvedDto));
+        when(challengeService.addChallengeToSolved(challengeId)).thenReturn(Mono.just(solvedDto));
 
         Mono<ResponseEntity<SolvedDto>> result = challengeSolvedController.addChallengeToSolved(challengeId, authHeader);
 
@@ -54,7 +54,7 @@ class ChallengeSolvedControllerTest {
                 .verifyComplete();
 
         verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
-        verify(challengeService, times(1)).addChallengeToSolved(challengeId, userId);
+        verify(challengeService, times(1)).addChallengeToSolved(challengeId);
     }
 
     @Test
@@ -82,7 +82,7 @@ class ChallengeSolvedControllerTest {
         String userId = "user123";
 
         when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-        when(challengeService.addChallengeToSolved(challengeId, userId)).thenReturn(Mono.error(new RuntimeException("Service error")));
+        when(challengeService.addChallengeToSolved(challengeId)).thenReturn(Mono.error(new RuntimeException("Service error")));
 
         Mono<ResponseEntity<SolvedDto>> result = challengeSolvedController.addChallengeToSolved(challengeId, authHeader);
 
@@ -92,6 +92,6 @@ class ChallengeSolvedControllerTest {
                 .verify();
 
         verify(jwtService, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
-        verify(challengeService, times(1)).addChallengeToSolved(challengeId, userId);
+        verify(challengeService, times(1)).addChallengeToSolved(challengeId);
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -323,7 +323,7 @@ class ChallengeServiceImplTest {
 @Test
 void addChallengeToSolved_WhenChallengeTimesSolvedIsNull_IncreasesTimesSolvedAndReturnsSolvedDTO() {
         UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
+
         ChallengeDocument challenge = new ChallengeDocument();
 
         challenge.setTimesSolved(null);
@@ -331,7 +331,7 @@ void addChallengeToSolved_WhenChallengeTimesSolvedIsNull_IncreasesTimesSolvedAnd
         when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
         when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
 
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString()))
                         .expectNextMatches(solvedDto -> {
                                 return solvedDto.getTimesSolved() == 1 &&
                                                 solvedDto.isSolved();
@@ -347,7 +347,7 @@ void addChallengeToSolved_WhenChallengeTimesSolvedIsNull_IncreasesTimesSolvedAnd
 @Test
 void addChallengeToSolved_WhenChallengeTimesSolvedIsZero_IncreasesTimesSolvedAndReturnsSolvedDTO() {
         UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
+
         ChallengeDocument challenge = new ChallengeDocument();
 
         challenge.setTimesSolved(0);
@@ -355,7 +355,7 @@ void addChallengeToSolved_WhenChallengeTimesSolvedIsZero_IncreasesTimesSolvedAnd
         when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
         when(challengeRepository.save(challenge)).thenReturn(Mono.just(challenge));
 
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString()))
                         .expectNextMatches(solvedDto -> {
                                 return solvedDto.getTimesSolved() == 1 &&
                                                 solvedDto.isSolved();
@@ -371,7 +371,7 @@ void addChallengeToSolved_WhenChallengeTimesSolvedIsZero_IncreasesTimesSolvedAnd
 @Test
 void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedAndReturnsSolvedDTO() {
         UUID challengeUuid = UUID.randomUUID();
-        UUID userUuid = UUID.randomUUID();
+
         ChallengeDocument challenge = new ChallengeDocument();
         int initialTimesSolved = 5;
 
@@ -379,7 +379,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.just(challenge));
 
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), userUuid.toString()))
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString()))
                         .expectNextMatches(solvedDto -> {
                                 return solvedDto.getTimesSolved() == initialTimesSolved &&
                                                 solvedDto.isSolved();
@@ -677,7 +677,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
     @Test
     void addChallengeToSolved_WhenChallengeUuidNotValid_ReturnsError() {
-        StepVerifier.create(challengeService.addChallengeToSolved("InvalidUuid", UUID.randomUUID().toString()))
+        StepVerifier.create(challengeService.addChallengeToSolved("InvalidUuid"))
                 .expectErrorMatches(error ->
                         error instanceof BadUUIDException &&
                                 error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
@@ -704,7 +704,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
     @Test
     void addChallengeToSolved_WhenUserUuidNotValid_ReturnsError() {
-        StepVerifier.create(challengeService.addChallengeToSolved(UUID.randomUUID().toString(), "InvalidUuid"))
+        StepVerifier.create(challengeService.addChallengeToSolved("InvalidUuid"))
                 .expectErrorMatches(error ->
                         error instanceof BadUUIDException &&
                                 error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
@@ -731,7 +731,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
     @Test
     void addChallengeToSolved_WhenChallengeUuidIsNull_ReturnsError() {
-        StepVerifier.create(challengeService.addChallengeToSolved(null, UUID.randomUUID().toString()))
+        StepVerifier.create(challengeService.addChallengeToSolved(null))
                 .expectErrorMatches(error ->
                         error instanceof BadUUIDException &&
                                 error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
@@ -750,15 +750,6 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
     @Test
     void addChallengeToBookmarks_WhenUserUuidIsNull_ReturnsError() {
         StepVerifier.create(challengeService.addChallengeToBookmarks(UUID.randomUUID().toString(), null))
-                .expectErrorMatches(error ->
-                        error instanceof BadUUIDException &&
-                                error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
-                .verify();
-    }
-
-    @Test
-    void addChallengeToSolved_WhenUserUuidIsNull_ReturnsError() {
-        StepVerifier.create(challengeService.addChallengeToSolved(UUID.randomUUID().toString(), null))
                 .expectErrorMatches(error ->
                         error instanceof BadUUIDException &&
                                 error.getMessage().equals("Invalid ID format. Please indicate the correct format."))
@@ -804,7 +795,7 @@ void addChallengeToSolved_WhenChallengeAlreadySolved_DoesNotIncreaseTimesSolvedA
 
         when(challengeRepository.findByUuid(challengeUuid)).thenReturn(Mono.empty());
 
-        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString(), UUID.randomUUID().toString()))
+        StepVerifier.create(challengeService.addChallengeToSolved(challengeUuid.toString()))
                 .expectErrorMatches(error ->
                         error instanceof ChallengeNotFoundException &&
                                 error.getMessage().equals(String.format(CHALLENGE_NOT_FOUND_ERROR, challengeUuid.toString())))


### PR DESCRIPTION
This pull request includes the necessary changes to adapt the EndPoint to be called and only update the `timesSolved` value by the `ChallengeId`

**Changes:**
-  `ChallengeSolvedController`: The endpoint doesn't require the value userId anymore.
-  `ChallengeSolvedControllerTest`: The test has been updated to match with the changes made in `ChallengeSolvedController`
-  `ChallengeServiceImpl`: The field `userId` has been removed.
-  `IChallengeService`
-  `ChallengeServiceImplTest`: The test has been updated to match with the changes made in `ChallengeServiceImpl`
 
All the modifications has made to remove the `useId` from the logic, because is not needed.