### PR TITLE
feat(auth): allow user role change at runtime (#404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- POST endpoint in Auth microservice to allow user role change at runtime (PR #882)
 - Hardcoded GET endpoint to return all of a user’s challenge solutions (PR #884)
 - JWT authentication to logout endpoint in User microservice (PR #864)
 - Error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags (PR #872)

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.itachallenge.auth.controller;
 
-
 import com.itachallenge.auth.dto.SwitchRoleRequest;
 import com.itachallenge.auth.exception.CustomBadRequestException;
 import com.itachallenge.auth.exception.CustomInternalServerErrorException;
@@ -18,9 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 
 import reactor.core.publisher.Mono;
 
@@ -39,7 +35,6 @@ public class AuthController {
     public static final String X_AUTHENTICATION_STATUS = "X-Authentication-Status";
     private static final String MESSAGE_KEY = "message";
     private static final String LOGOUT_SUCCESS = "Logout successful";
-    private static final String BEARER_KEY = "Bearer ";
 
     private final IAuthService authService;
 
@@ -182,18 +177,9 @@ public class AuthController {
             @RequestHeader(value = "Authorization", required = false) String authHeader,
             @RequestBody SwitchRoleRequest request) {
 
-        String token = extractBearerToken(authHeader);
+        String token = jwtService.extractBearerToken(authHeader);
         String newToken = jwtService.switchRole(token, request.getNewRole());
         log.info("Switch-role successful for token");
         return Mono.just(ResponseEntity.ok(Map.of("token", newToken)));
     }
-
-
-    private String extractBearerToken(String authHeader) {
-        if (authHeader == null || !authHeader.startsWith(BEARER_KEY)) {
-            throw new JwtException("Authorization header is missing or malformed");
-        }
-        return authHeader.replace(BEARER_KEY, "").trim();
-    }
-
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -6,6 +6,10 @@ import com.itachallenge.auth.exception.CustomInternalServerErrorException;
 import com.itachallenge.auth.service.IAuthService;
 import com.itachallenge.auth.service.IJwtService;
 import com.itachallenge.auth.service.IUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,6 +21,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
@@ -34,6 +39,7 @@ public class AuthController {
     public static final String X_AUTHENTICATION_STATUS = "X-Authentication-Status";
     private static final String MESSAGE_KEY = "message";
     private static final String LOGOUT_SUCCESS = "Logout successful";
+    private static final String BEARER_KEY = "Bearer ";
 
     private final IAuthService authService;
 
@@ -160,5 +166,40 @@ public class AuthController {
         jwtService.validateToken(token);
         return Mono.just(ResponseEntity.ok(Map.of(MESSAGE_KEY, "Logout successful")));
     }
-}
 
+    @PostMapping("/switch-role")
+    @Operation(
+            summary = "Temporarily switch the user's role and return a new token.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Token generated successfully or expired.",
+                            content = @Content(schema = @Schema(implementation = Map.class))),
+                    @ApiResponse(responseCode = "401", description = "Missing or malformed Authorization header or invalid token."),
+                    @ApiResponse(responseCode = "500", description = "Unexpected error occurred.")
+            }
+    )
+    public Mono<ResponseEntity<Map<String, String>>> switchRole(
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
+
+        if (authHeader == null || !authHeader.startsWith(BEARER_KEY)) {
+            log.warn("Switch-role attempt without token or malformed header");
+            return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of(MESSAGE_KEY, "Authorization header is missing or malformed")));
+        }
+
+        String token = authHeader.replace(BEARER_KEY, "").trim();
+
+        try {
+            String newToken = jwtService.switchRole(token);
+            log.info("Switch-role successful for token");
+            return Mono.just(ResponseEntity.ok(Map.of("token", newToken)));
+        } catch (ResponseStatusException e) {
+            log.info("Switch-role ended with status {}: {}", e.getStatusCode(), e.getReason());
+            return Mono.just(ResponseEntity.status(e.getStatusCode())
+                    .body(Map.of(MESSAGE_KEY, e.getReason())));
+        } catch (JwtException e) {
+            log.warn("Switch-role failed due to invalid token: {}", e.getMessage());
+            return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of(MESSAGE_KEY, e.getMessage())));
+        }
+    }
+}

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.itachallenge.auth.controller;
 
 
+import com.itachallenge.auth.dto.SwitchRoleRequest;
 import com.itachallenge.auth.exception.CustomBadRequestException;
 import com.itachallenge.auth.exception.CustomInternalServerErrorException;
 import com.itachallenge.auth.service.IAuthService;
@@ -21,7 +22,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 
-import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
@@ -173,33 +173,27 @@ public class AuthController {
             responses = {
                     @ApiResponse(responseCode = "200", description = "Token generated successfully or expired.",
                             content = @Content(schema = @Schema(implementation = Map.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid role requested."),
                     @ApiResponse(responseCode = "401", description = "Missing or malformed Authorization header or invalid token."),
                     @ApiResponse(responseCode = "500", description = "Unexpected error occurred.")
             }
     )
     public Mono<ResponseEntity<Map<String, String>>> switchRole(
-            @RequestHeader(value = "Authorization", required = false) String authHeader) {
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @RequestBody SwitchRoleRequest request) {
 
-        if (authHeader == null || !authHeader.startsWith(BEARER_KEY)) {
-            log.warn("Switch-role attempt without token or malformed header");
-            return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of(MESSAGE_KEY, "Authorization header is missing or malformed")));
-        }
-
-        String token = authHeader.replace(BEARER_KEY, "").trim();
-
-        try {
-            String newToken = jwtService.switchRole(token);
-            log.info("Switch-role successful for token");
-            return Mono.just(ResponseEntity.ok(Map.of("token", newToken)));
-        } catch (ResponseStatusException e) {
-            log.info("Switch-role ended with status {}: {}", e.getStatusCode(), e.getReason());
-            return Mono.just(ResponseEntity.status(e.getStatusCode())
-                    .body(Map.of(MESSAGE_KEY, e.getReason())));
-        } catch (JwtException e) {
-            log.warn("Switch-role failed due to invalid token: {}", e.getMessage());
-            return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of(MESSAGE_KEY, e.getMessage())));
-        }
+        String token = extractBearerToken(authHeader);
+        String newToken = jwtService.switchRole(token, request.getNewRole());
+        log.info("Switch-role successful for token");
+        return Mono.just(ResponseEntity.ok(Map.of("token", newToken)));
     }
+
+
+    private String extractBearerToken(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith(BEARER_KEY)) {
+            throw new JwtException("Authorization header is missing or malformed");
+        }
+        return authHeader.replace(BEARER_KEY, "").trim();
+    }
+
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/dto/SwitchRoleRequest.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/dto/SwitchRoleRequest.java
@@ -1,8 +1,23 @@
 package com.itachallenge.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Payload to request a temporary role switch.")
 public class SwitchRoleRequest {
 
+    @Schema(
+            description = "The new role to switch to. Allowed values: ADMIN, USER.",
+            example = "ADMIN",
+            required = true
+    )
     private String newRole;
+
+    public SwitchRoleRequest() {
+    }
+
+    public SwitchRoleRequest(String newRole) {
+        this.newRole = newRole;
+    }
 
     public String getNewRole() {
         return newRole;

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/dto/SwitchRoleRequest.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/dto/SwitchRoleRequest.java
@@ -1,0 +1,14 @@
+package com.itachallenge.auth.dto;
+
+public class SwitchRoleRequest {
+
+    private String newRole;
+
+    public String getNewRole() {
+        return newRole;
+    }
+
+    public void setNewRole(String newRole) {
+        this.newRole = newRole;
+    }
+}

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/enums/UserRole.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/enums/UserRole.java
@@ -18,27 +18,11 @@ public enum UserRole {
     }
 
     public static void validateRoleChange(String currentRoleStr, String requestedRoleStr) {
-        if (currentRoleStr == null || currentRoleStr.isBlank()) {
-            throw new InvalidRoleChangeRequestException("Current role must be provided.");
-        }
+        validateNotBlank(currentRoleStr, "Current role must be provided.");
+        validateNotBlank(requestedRoleStr, "New role must be provided.");
 
-        if (requestedRoleStr == null || requestedRoleStr.isBlank()) {
-            throw new InvalidRoleChangeRequestException("New role must be provided.");
-        }
-
-        Optional<UserRole> currentOpt = fromString(currentRoleStr);
-        Optional<UserRole> requestedOpt = fromString(requestedRoleStr);
-
-        if (currentOpt.isEmpty()) {
-            throw new InvalidRoleChangeRequestException("Current role is not allowed.");
-        }
-
-        if (requestedOpt.isEmpty()) {
-            throw new InvalidRoleChangeRequestException("Requested role change is not allowed.");
-        }
-
-        UserRole current = currentOpt.get();
-        UserRole requested = requestedOpt.get();
+        UserRole current = parseRole(currentRoleStr, "Current role is not allowed.");
+        UserRole requested = parseRole(requestedRoleStr, "Requested role change is not allowed.");
 
         if (current == requested) {
             throw new InvalidRoleChangeRequestException("New role is the same as current role.");
@@ -47,6 +31,17 @@ public enum UserRole {
         if (!current.canSwitchTo(requested)) {
             throw new InvalidRoleChangeRequestException("Requested role change is not allowed.");
         }
+    }
+
+    private static void validateNotBlank(String value, String errorMessage) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidRoleChangeRequestException(errorMessage);
+        }
+    }
+
+    private static UserRole parseRole(String value, String errorMessage) {
+        return fromString(value)
+                .orElseThrow(() -> new InvalidRoleChangeRequestException(errorMessage));
     }
 
     private boolean canSwitchTo(UserRole requestedRole) {

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/enums/UserRole.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/enums/UserRole.java
@@ -1,0 +1,56 @@
+package com.itachallenge.auth.enums;
+
+import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
+
+import java.util.Optional;
+
+public enum UserRole {
+    ADMIN,
+    USER;
+
+    public static Optional<UserRole> fromString(String value) {
+        for (UserRole userRole : values()) {
+            if (userRole.name().equalsIgnoreCase(value)) {
+                return Optional.of(userRole);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static void validateRoleChange(String currentRoleStr, String requestedRoleStr) {
+        if (currentRoleStr == null || currentRoleStr.isBlank()) {
+            throw new InvalidRoleChangeRequestException("Current role must be provided.");
+        }
+
+        if (requestedRoleStr == null || requestedRoleStr.isBlank()) {
+            throw new InvalidRoleChangeRequestException("New role must be provided.");
+        }
+
+        Optional<UserRole> currentOpt = fromString(currentRoleStr);
+        Optional<UserRole> requestedOpt = fromString(requestedRoleStr);
+
+        if (currentOpt.isEmpty()) {
+            throw new InvalidRoleChangeRequestException("Current role is not allowed.");
+        }
+
+        if (requestedOpt.isEmpty()) {
+            throw new InvalidRoleChangeRequestException("Requested role change is not allowed.");
+        }
+
+        UserRole current = currentOpt.get();
+        UserRole requested = requestedOpt.get();
+
+        if (current == requested) {
+            throw new InvalidRoleChangeRequestException("New role is the same as current role.");
+        }
+
+        if (!current.canSwitchTo(requested)) {
+            throw new InvalidRoleChangeRequestException("Requested role change is not allowed.");
+        }
+    }
+
+    private boolean canSwitchTo(UserRole requestedRole) {
+        return (this == ADMIN && requestedRole == USER)
+                || (this == USER && requestedRole == ADMIN);
+    }
+}

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/exception/GlobalExceptionHandler.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/exception/GlobalExceptionHandler.java
@@ -24,4 +24,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(Map.of(MESSAGE_KEY, ex.getMessage()));
     }
+
+    @ExceptionHandler(InvalidRoleChangeRequestException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidRoleChange(InvalidRoleChangeRequestException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of(MESSAGE_KEY, ex.getMessage()));
+    }
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/exception/InvalidRoleChangeRequestException.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/exception/InvalidRoleChangeRequestException.java
@@ -1,0 +1,7 @@
+package com.itachallenge.auth.exception;
+
+public class InvalidRoleChangeRequestException extends RuntimeException {
+    public InvalidRoleChangeRequestException(String message) {
+        super(message);
+    }
+}

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IJwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IJwtService.java
@@ -8,5 +8,5 @@ public interface IJwtService {
     String generateToken(String username, String role, String uuid);
     void validateToken(String token);
     Claims extractAllClaims(String token);
-    String switchRole(String token);
+    String switchRole(String token, String requestedRole);
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IJwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IJwtService.java
@@ -1,8 +1,12 @@
 package com.itachallenge.auth.service;
+import io.jsonwebtoken.Claims;
+
 import javax.crypto.SecretKey;
 
 public interface IJwtService {
     SecretKey getSigningKey();
     String generateToken(String username, String role, String uuid);
     void validateToken(String token);
+    Claims extractAllClaims(String token);
+    String switchRole(String token);
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IJwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IJwtService.java
@@ -9,4 +9,5 @@ public interface IJwtService {
     void validateToken(String token);
     Claims extractAllClaims(String token);
     String switchRole(String token, String requestedRole);
+    String extractBearerToken(String authHeader);
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
@@ -1,16 +1,13 @@
 package com.itachallenge.auth.service;
 
-import com.itachallenge.auth.controller.AuthController;
-import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
+import com.itachallenge.auth.enums.UserRole;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
 
 import javax.crypto.SecretKey;
@@ -86,40 +83,19 @@ public class JwtService implements IJwtService {
     @Override
     public String switchRole(String token, String requestedRole) {
         Claims claims = extractAllClaims(token);
-        String currentRole = claims.get("role", String.class);
 
-        validateRoleChange(currentRole, requestedRole);
+        String currentRole = claims.get("role", String.class);
+        UserRole.validateRoleChange(currentRole, requestedRole);
+
+        UserRole requested = UserRole.fromString(requestedRole).get();
 
         return generateTokenWithTemporaryRole(
                 claims.getSubject(),
-                requestedRole.toUpperCase(),
+                requested.name(),
                 claims.get("uuid", String.class),
                 claims.getIssuedAt(),
                 claims.getExpiration()
         );
-    }
-
-    private void validateRoleChange(String currentRole, String requestedRole) {
-        if (requestedRole == null || requestedRole.isBlank()) {
-            log.warn("Role change failed: requested role is null or blank.");
-            throw new InvalidRoleChangeRequestException("New role must be provided.");
-        }
-
-        if (requestedRole.equalsIgnoreCase(currentRole)) {
-            log.warn("Role change rejected: requested role '{}' is same as current role '{}'.",
-                    requestedRole, currentRole);
-            throw new InvalidRoleChangeRequestException("New role is the same as current role.");
-        }
-
-        boolean isAllowed =
-                ("ADMIN".equalsIgnoreCase(currentRole) && "USER".equalsIgnoreCase(requestedRole)) ||
-                        ("USER".equalsIgnoreCase(currentRole) && "ADMIN".equalsIgnoreCase(requestedRole));
-
-        if (!isAllowed) {
-            log.warn("Role change rejected: requested change from '{}' to '{}' is not allowed.",
-                    currentRole, requestedRole);
-            throw new InvalidRoleChangeRequestException("Requested role change is not allowed.");
-        }
     }
 
     private String generateTokenWithTemporaryRole(String username, String role, String uuid, Date issuedAt, Date expiration) {

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
@@ -97,7 +97,7 @@ public class JwtService implements IJwtService {
 
         return Jwts.builder()
                 .subject(claims.getSubject())
-                .claim("role", requestedRole.toUpperCase()) // seguro: ya validado
+                .claim("role", requestedRole.toUpperCase())
                 .claim("uuid", claims.get("uuid", String.class))
                 .claim("isTemporaryRole", true)
                 .issuedAt(claims.getIssuedAt())

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
@@ -16,6 +16,7 @@ import java.util.Date;
 @Service
 public class JwtService implements IJwtService {
 
+    private static final String BEARER_KEY = "Bearer ";
     private static final Logger log = LoggerFactory.getLogger(JwtService.class);
     private final String jwtSigningKey;
     private final long minutesTillExpiration;
@@ -80,34 +81,29 @@ public class JwtService implements IJwtService {
         }
     }
 
+    public String extractBearerToken(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith(BEARER_KEY)) {
+            throw new JwtException("Authorization header is missing or malformed");
+        }
+        return authHeader.replace(BEARER_KEY, "").trim();
+    }
+
     @Override
     public String switchRole(String token, String requestedRole) {
         Claims claims = extractAllClaims(token);
-
         String currentRole = claims.get("role", String.class);
+
         UserRole.validateRoleChange(currentRole, requestedRole);
 
-        UserRole requested = UserRole.fromString(requestedRole)
-                .orElseThrow(() -> new InvalidRoleChangeRequestException("Requested role is invalid."));
-
-        return generateTokenWithTemporaryRole(
-                claims.getSubject(),
-                requested.name(),
-                claims.get("uuid", String.class),
-                claims.getIssuedAt(),
-                claims.getExpiration()
-        );
-    }
-
-    private String generateTokenWithTemporaryRole(String username, String role, String uuid, Date issuedAt, Date expiration) {
         return Jwts.builder()
-                .subject(username)
-                .claim("role", role)
-                .claim("uuid", uuid)
+                .subject(claims.getSubject())
+                .claim("role", requestedRole.toUpperCase()) // seguro: ya validado
+                .claim("uuid", claims.get("uuid", String.class))
                 .claim("isTemporaryRole", true)
-                .issuedAt(issuedAt)
-                .expiration(expiration)
+                .issuedAt(claims.getIssuedAt())
+                .expiration(claims.getExpiration())
                 .signWith(getSigningKey())
                 .compact();
     }
+
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
@@ -1,6 +1,7 @@
 package com.itachallenge.auth.service;
 
 import com.itachallenge.auth.controller.AuthController;
+import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -75,7 +76,7 @@ public class JwtService implements IJwtService {
             log.info("Token expired at {} for subject {}",
                     e.getClaims().getExpiration(),
                     e.getClaims().getSubject());
-            throw new ResponseStatusException(HttpStatus.OK, "Token is expired.");
+            throw new ExpiredJwtException(e.getHeader(), e.getClaims(), "Token expired ", e);
         } catch (JwtException e) {
             log.warn("Invalid or tampered token: {}", e.getMessage());
             throw new JwtException("Invalid or tampered token: " + e.getMessage(), e);
@@ -83,19 +84,42 @@ public class JwtService implements IJwtService {
     }
 
     @Override
-    public String switchRole(String token) {
+    public String switchRole(String token, String requestedRole) {
         Claims claims = extractAllClaims(token);
-
         String currentRole = claims.get("role", String.class);
-        String newRole = currentRole.equals("ADMIN") ? "USER" : "ADMIN";
 
-        String username = claims.getSubject();
-        String uuid = claims.get("uuid", String.class);
+        validateRoleChange(currentRole, requestedRole);
 
-        Date issuedAt = claims.getIssuedAt();
-        Date expiration = claims.getExpiration();
+        return generateTokenWithTemporaryRole(
+                claims.getSubject(),
+                requestedRole.toUpperCase(),
+                claims.get("uuid", String.class),
+                claims.getIssuedAt(),
+                claims.getExpiration()
+        );
+    }
 
-        return generateTokenWithTemporaryRole(username, newRole, uuid, issuedAt, expiration);
+    private void validateRoleChange(String currentRole, String requestedRole) {
+        if (requestedRole == null || requestedRole.isBlank()) {
+            log.warn("Role change failed: requested role is null or blank.");
+            throw new InvalidRoleChangeRequestException("New role must be provided.");
+        }
+
+        if (requestedRole.equalsIgnoreCase(currentRole)) {
+            log.warn("Role change rejected: requested role '{}' is same as current role '{}'.",
+                    requestedRole, currentRole);
+            throw new InvalidRoleChangeRequestException("New role is the same as current role.");
+        }
+
+        boolean isAllowed =
+                ("ADMIN".equalsIgnoreCase(currentRole) && "USER".equalsIgnoreCase(requestedRole)) ||
+                        ("USER".equalsIgnoreCase(currentRole) && "ADMIN".equalsIgnoreCase(requestedRole));
+
+        if (!isAllowed) {
+            log.warn("Role change rejected: requested change from '{}' to '{}' is not allowed.",
+                    currentRole, requestedRole);
+            throw new InvalidRoleChangeRequestException("Requested role change is not allowed.");
+        }
     }
 
     private String generateTokenWithTemporaryRole(String username, String role, String uuid, Date issuedAt, Date expiration) {

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
@@ -1,16 +1,15 @@
 package com.itachallenge.auth.service;
 
 import com.itachallenge.auth.controller.AuthController;
-import io.jsonwebtoken.JwtBuilder;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import io.jsonwebtoken.ExpiredJwtException;
+import org.springframework.web.server.ResponseStatusException;
 
 
 import javax.crypto.SecretKey;
@@ -64,4 +63,50 @@ public class JwtService implements IJwtService {
         return Keys.hmacShaKeyFor(keyBytes);
     }
 
+    @Override
+    public Claims extractAllClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            log.info("Token expired at {} for subject {}",
+                    e.getClaims().getExpiration(),
+                    e.getClaims().getSubject());
+            throw new ResponseStatusException(HttpStatus.OK, "Token is expired.");
+        } catch (JwtException e) {
+            log.warn("Invalid or tampered token: {}", e.getMessage());
+            throw new JwtException("Invalid or tampered token: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String switchRole(String token) {
+        Claims claims = extractAllClaims(token);
+
+        String currentRole = claims.get("role", String.class);
+        String newRole = currentRole.equals("ADMIN") ? "USER" : "ADMIN";
+
+        String username = claims.getSubject();
+        String uuid = claims.get("uuid", String.class);
+
+        Date issuedAt = claims.getIssuedAt();
+        Date expiration = claims.getExpiration();
+
+        return generateTokenWithTemporaryRole(username, newRole, uuid, issuedAt, expiration);
+    }
+
+    private String generateTokenWithTemporaryRole(String username, String role, String uuid, Date issuedAt, Date expiration) {
+        return Jwts.builder()
+                .subject(username)
+                .claim("role", role)
+                .claim("uuid", uuid)
+                .claim("isTemporaryRole", true)
+                .issuedAt(issuedAt)
+                .expiration(expiration)
+                .signWith(getSigningKey())
+                .compact();
+    }
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/JwtService.java
@@ -1,6 +1,7 @@
 package com.itachallenge.auth.service;
 
 import com.itachallenge.auth.enums.UserRole;
+import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -8,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
 
 import javax.crypto.SecretKey;
 import java.util.Date;
@@ -87,7 +87,8 @@ public class JwtService implements IJwtService {
         String currentRole = claims.get("role", String.class);
         UserRole.validateRoleChange(currentRole, requestedRole);
 
-        UserRole requested = UserRole.fromString(requestedRole).get();
+        UserRole requested = UserRole.fromString(requestedRole)
+                .orElseThrow(() -> new InvalidRoleChangeRequestException("Requested role is invalid."));
 
         return generateTokenWithTemporaryRole(
                 claims.getSubject(),

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -13,9 +13,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -304,5 +306,74 @@ class AuthControllerTest {
                 .value(response -> {
                     assert response.get("message").equals("Authorization header is missing or malformed");
                 });
+    }
+
+    @Test
+    void switchRole_WithValidToken_ShouldReturnNewToken() {
+        String token = "valid.jwt.token";
+        String newToken = "new.jwt.token";
+
+        when(jwtService.switchRole(token)).thenReturn(newToken);
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/switch-role")
+                .header("Authorization", "Bearer " + token)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.token").isEqualTo(newToken);
+    }
+
+    @Test
+    void switchRole_WithExpiredToken_ShouldReturn200WithMessage() {
+        String token = "expired.jwt.token";
+
+        when(jwtService.switchRole(token))
+                .thenThrow(new ResponseStatusException(HttpStatus.OK, "Token is expired."));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/switch-role")
+                .header("Authorization", "Bearer " + token)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("Token is expired.");
+    }
+
+    @Test
+    void switchRole_WithInvalidToken_ShouldReturn401() {
+        String token = "invalid.jwt.token";
+
+        when(jwtService.switchRole(token))
+                .thenThrow(new JwtException("Invalid or tampered token."));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/switch-role")
+                .header("Authorization", "Bearer " + token)
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("Invalid or tampered token.");
+    }
+
+    @Test
+    void switchRole_WithMissingAuthorizationHeader_ShouldReturn401() {
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/switch-role")
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("Authorization header is missing or malformed");
+    }
+
+    @Test
+    void switchRole_WithMalformedAuthorizationHeader_ShouldReturn401() {
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/switch-role")
+                .header("Authorization", "Token not-bearer")
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("Authorization header is missing or malformed");
     }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.itachallenge.auth.controller;
 
 import com.itachallenge.auth.dto.User;
+import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
 import com.itachallenge.auth.service.IAuthService;
 import com.itachallenge.auth.service.IJwtService;
 import com.itachallenge.auth.service.IUserService;
@@ -311,13 +312,15 @@ class AuthControllerTest {
     @Test
     void switchRole_WithValidToken_ShouldReturnNewToken() {
         String token = "valid.jwt.token";
+        String requestedRole = "USER";
         String newToken = "new.jwt.token";
 
-        when(jwtService.switchRole(token)).thenReturn(newToken);
+        when(jwtService.switchRole(token, requestedRole)).thenReturn(newToken);
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/switch-role")
                 .header("Authorization", "Bearer " + token)
+                .bodyValue(Map.of("newRole", requestedRole))
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
@@ -327,13 +330,15 @@ class AuthControllerTest {
     @Test
     void switchRole_WithExpiredToken_ShouldReturn200WithMessage() {
         String token = "expired.jwt.token";
+        String requestedRole = "ADMIN";
 
-        when(jwtService.switchRole(token))
-                .thenThrow(new ResponseStatusException(HttpStatus.OK, "Token is expired."));
+        when(jwtService.switchRole(token, requestedRole))
+                .thenThrow(new ExpiredJwtException(null, null, "Token is expired."));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/switch-role")
                 .header("Authorization", "Bearer " + token)
+                .bodyValue(Map.of("newRole", requestedRole))
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
@@ -343,13 +348,15 @@ class AuthControllerTest {
     @Test
     void switchRole_WithInvalidToken_ShouldReturn401() {
         String token = "invalid.jwt.token";
+        String requestedRole = "USER";
 
-        when(jwtService.switchRole(token))
+        when(jwtService.switchRole(token, requestedRole))
                 .thenThrow(new JwtException("Invalid or tampered token."));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/switch-role")
                 .header("Authorization", "Bearer " + token)
+                .bodyValue(Map.of("newRole", requestedRole))
                 .exchange()
                 .expectStatus().isUnauthorized()
                 .expectBody()
@@ -360,6 +367,7 @@ class AuthControllerTest {
     void switchRole_WithMissingAuthorizationHeader_ShouldReturn401() {
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/switch-role")
+                .bodyValue(Map.of("newRole", "ADMIN"))
                 .exchange()
                 .expectStatus().isUnauthorized()
                 .expectBody()
@@ -371,9 +379,28 @@ class AuthControllerTest {
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/switch-role")
                 .header("Authorization", "Token not-bearer")
+                .bodyValue(Map.of("newRole", "ADMIN"))
                 .exchange()
                 .expectStatus().isUnauthorized()
                 .expectBody()
                 .jsonPath("$.message").isEqualTo("Authorization header is missing or malformed");
+    }
+
+    @Test
+    void switchRole_WithSameRequestedRole_ShouldReturn400() {
+        String token = "valid.jwt.token";
+        String requestedRole = "USER";
+
+        when(jwtService.switchRole(token, requestedRole))
+                .thenThrow(new InvalidRoleChangeRequestException("New role is the same as current role."));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/switch-role")
+                .header("Authorization", "Bearer " + token)
+                .bodyValue(Map.of("newRole", requestedRole))
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("New role is the same as current role.");
     }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.itachallenge.auth.controller;
 
+import com.itachallenge.auth.dto.SwitchRoleRequest;
 import com.itachallenge.auth.dto.User;
 import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
 import com.itachallenge.auth.service.IAuthService;
@@ -310,17 +311,18 @@ class AuthControllerTest {
     }
 
     @Test
-    void switchRole_WithValidToken_ShouldReturnNewToken() {
-        String token = "valid.jwt.token";
-        String requestedRole = "USER";
+    void switchRole_WithValidTokenAndValidRole_ReturnsNewToken() {
+        String originalToken = "valid.jwt.token";
+        String newRole = "ADMIN";
         String newToken = "new.jwt.token";
 
-        when(jwtService.switchRole(token, requestedRole)).thenReturn(newToken);
+        when(jwtService.extractBearerToken("Bearer " + originalToken)).thenReturn(originalToken);
+        when(jwtService.switchRole(originalToken, newRole)).thenReturn(newToken);
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/switch-role")
-                .header("Authorization", "Bearer " + token)
-                .bodyValue(Map.of("newRole", requestedRole))
+                .header("Authorization", "Bearer " + originalToken)
+                .bodyValue(new SwitchRoleRequest(newRole))
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
@@ -328,17 +330,18 @@ class AuthControllerTest {
     }
 
     @Test
-    void switchRole_WithExpiredToken_ShouldReturn200WithMessage() {
-        String token = "expired.jwt.token";
-        String requestedRole = "ADMIN";
+    void switchRole_WithExpiredToken_Returns200WithMessage() {
+        String expiredToken = "expired.jwt.token";
+        String newRole = "ADMIN";
 
-        when(jwtService.switchRole(token, requestedRole))
+        when(jwtService.extractBearerToken("Bearer " + expiredToken)).thenReturn(expiredToken);
+        when(jwtService.switchRole(expiredToken, newRole))
                 .thenThrow(new ExpiredJwtException(null, null, "Token is expired."));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/switch-role")
-                .header("Authorization", "Bearer " + token)
-                .bodyValue(Map.of("newRole", requestedRole))
+                .header("Authorization", "Bearer " + expiredToken)
+                .bodyValue(new SwitchRoleRequest(newRole))
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
@@ -346,61 +349,53 @@ class AuthControllerTest {
     }
 
     @Test
-    void switchRole_WithInvalidToken_ShouldReturn401() {
-        String token = "invalid.jwt.token";
-        String requestedRole = "USER";
+    void switchRole_WithInvalidToken_Returns401() {
+        String invalidToken = "invalid.jwt.token";
+        String newRole = "ADMIN";
 
-        when(jwtService.switchRole(token, requestedRole))
+        when(jwtService.extractBearerToken("Bearer " + invalidToken)).thenReturn(invalidToken);
+        when(jwtService.switchRole(invalidToken, newRole))
                 .thenThrow(new JwtException("Invalid or tampered token."));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/switch-role")
-                .header("Authorization", "Bearer " + token)
-                .bodyValue(Map.of("newRole", requestedRole))
+                .header("Authorization", "Bearer " + invalidToken)
+                .bodyValue(new SwitchRoleRequest(newRole))
                 .exchange()
                 .expectStatus().isUnauthorized()
                 .expectBody()
-                .jsonPath("$.message").isEqualTo("Invalid or tampered token.");
+                .jsonPath("$.message").value(msg -> assertThat(msg).isEqualTo("Invalid or tampered token."));
     }
 
     @Test
-    void switchRole_WithMissingAuthorizationHeader_ShouldReturn401() {
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/auth/switch-role")
-                .bodyValue(Map.of("newRole", "ADMIN"))
-                .exchange()
-                .expectStatus().isUnauthorized()
-                .expectBody()
-                .jsonPath("$.message").isEqualTo("Authorization header is missing or malformed");
-    }
-
-    @Test
-    void switchRole_WithMalformedAuthorizationHeader_ShouldReturn401() {
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/auth/switch-role")
-                .header("Authorization", "Token not-bearer")
-                .bodyValue(Map.of("newRole", "ADMIN"))
-                .exchange()
-                .expectStatus().isUnauthorized()
-                .expectBody()
-                .jsonPath("$.message").isEqualTo("Authorization header is missing or malformed");
-    }
-
-    @Test
-    void switchRole_WithSameRequestedRole_ShouldReturn400() {
+    void switchRole_WithSameRole_Throws400() {
         String token = "valid.jwt.token";
-        String requestedRole = "USER";
 
-        when(jwtService.switchRole(token, requestedRole))
+        when(jwtService.extractBearerToken("Bearer " + token)).thenReturn(token);
+        when(jwtService.switchRole(token, "USER"))
                 .thenThrow(new InvalidRoleChangeRequestException("New role is the same as current role."));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/switch-role")
                 .header("Authorization", "Bearer " + token)
-                .bodyValue(Map.of("newRole", requestedRole))
+                .bodyValue(new SwitchRoleRequest("USER"))
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody()
                 .jsonPath("$.message").isEqualTo("New role is the same as current role.");
+    }
+
+    @Test
+    void switchRole_MissingAuthorizationHeader_Returns401() {
+        when(jwtService.extractBearerToken(null))
+                .thenThrow(new JwtException("Authorization header is missing or malformed"));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/auth/switch-role")
+                .bodyValue(new SwitchRoleRequest("ADMIN"))
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("Authorization header is missing or malformed");
     }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/enums/UserRoleTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/enums/UserRoleTest.java
@@ -106,4 +106,18 @@ class UserRoleTest {
         );
         assertEquals("New role is the same as current role.", ex.getMessage());
     }
+
+    @Test
+    void validateRoleChange_userToAdmin_thenAdminToUserAllowed_butOtherDirectionRejected() {
+        assertDoesNotThrow(() -> UserRole.validateRoleChange("USER", "ADMIN"));
+
+        assertDoesNotThrow(() -> UserRole.validateRoleChange("ADMIN", "USER"));
+
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange("ADMIN", "ADMIN")
+        );
+        assertEquals("New role is the same as current role.", ex.getMessage());
+    }
+
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/enums/UserRoleTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/enums/UserRoleTest.java
@@ -1,0 +1,73 @@
+package com.itachallenge.auth.enums;
+
+import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserRoleTest {
+
+    @Test
+    void validateRoleChange_validChange_ADMIN_to_USER_shouldPass() {
+        assertDoesNotThrow(() -> UserRole.validateRoleChange("ADMIN", "USER"));
+    }
+
+    @Test
+    void validateRoleChange_validChange_USER_to_ADMIN_shouldPass() {
+        assertDoesNotThrow(() -> UserRole.validateRoleChange("user", "admin"));
+    }
+
+    @Test
+    void validateRoleChange_nullRequestedRole_shouldThrow() {
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange("ADMIN", null)
+        );
+        assertEquals("New role must be provided.", ex.getMessage());
+    }
+
+    @Test
+    void validateRoleChange_blankRequestedRole_shouldThrow() {
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange("ADMIN", " ")
+        );
+        assertEquals("New role must be provided.", ex.getMessage());
+    }
+
+    @Test
+    void validateRoleChange_invalidRequestedRole_shouldThrow() {
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange("ADMIN", "GUEST")
+        );
+        assertEquals("Requested role change is not allowed.", ex.getMessage());
+    }
+
+    @Test
+    void validateRoleChange_sameRole_shouldThrow() {
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange("USER", "user")
+        );
+        assertEquals("New role is the same as current role.", ex.getMessage());
+    }
+
+    @Test
+    void validateRoleChange_invalidCurrentRole_shouldThrow() {
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange("GUEST", "ADMIN")
+        );
+        assertEquals("Current role is not allowed.", ex.getMessage());
+    }
+
+    @Test
+    void validateRoleChange_nullCurrentRole_shouldThrow() {
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange(null, "ADMIN")
+        );
+        assertEquals("Current role must be provided.", ex.getMessage());
+    }
+}

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/enums/UserRoleTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/enums/UserRoleTest.java
@@ -70,4 +70,13 @@ class UserRoleTest {
         );
         assertEquals("Current role must be provided.", ex.getMessage());
     }
+
+    @Test
+    void validateRoleChange_invalidRequested_shouldThrow() {
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange("ADMIN", "GUEST")
+        );
+        assertEquals("Requested role change is not allowed.", ex.getMessage());
+    }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/enums/UserRoleTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/enums/UserRoleTest.java
@@ -79,4 +79,31 @@ class UserRoleTest {
         );
         assertEquals("Requested role change is not allowed.", ex.getMessage());
     }
+
+    @Test
+    void validateRoleChange_notAllowedTransition_shouldThrow() {
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange("ADMIN", "GUEST")
+        );
+        assertEquals("Requested role change is not allowed.", ex.getMessage());
+    }
+
+    @Test
+    void validateAdminRoleChange_invalidTransition_shouldThrow() {
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange("ADMIN", "ADMIN")
+        );
+        assertEquals("New role is the same as current role.", ex.getMessage());
+    }
+
+    @Test
+    void validateUserRoleChange_invalidTransition_shouldThrow() {
+        InvalidRoleChangeRequestException ex = assertThrows(
+                InvalidRoleChangeRequestException.class,
+                () -> UserRole.validateRoleChange("USER", "USER")
+        );
+        assertEquals("New role is the same as current role.", ex.getMessage());
+    }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/exception/GlobalExceptionHandlerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/exception/GlobalExceptionHandlerTest.java
@@ -42,4 +42,16 @@ class GlobalExceptionHandlerTest {
         assertNotNull(response.getBody());
         assertEquals(message, response.getBody().get("message"));
     }
+
+    @Test
+    void handleInvalidRoleChange_ShouldReturnBadRequestWithMessage() {
+        String message = "Invalid role.";
+        InvalidRoleChangeRequestException exception = new InvalidRoleChangeRequestException(message);
+
+        ResponseEntity<Map<String, String>> response = handler.handleInvalidRoleChange(exception);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(message, response.getBody().get("message"));
+    }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
@@ -97,37 +97,29 @@ class JwtServiceTest {
     }
 
     @Test
-    void switchRole_ShouldGenerateTemporaryToken_WhenValidRoleChange() {
-        String originalToken = jwtService.generateToken("testUser", "USER", "uuid-001");
-        String newToken = jwtService.switchRole(originalToken, "ADMIN");
+    void extractBearerToken_WithValidHeader_ReturnsToken() {
+        String token = "abc.def.ghi";
+        String header = "Bearer " + token;
 
-        Claims claims = Jwts.parser()
-                .verifyWith(Keys.hmacShaKeyFor(io.jsonwebtoken.io.Decoders.BASE64.decode(jwtSigningKey)))
-                .build()
-                .parseSignedClaims(newToken)
-                .getPayload();
+        String result = jwtService.extractBearerToken(header);
 
-        assertThat(claims.get("role", String.class)).isEqualTo("ADMIN");
-        assertThat(claims.get("isTemporaryRole", Boolean.class)).isTrue();
-        assertThat(claims.get("uuid", String.class)).isEqualTo("uuid-001");
-        assertThat(claims.getSubject()).isEqualTo("testUser");
+        assertThat(result).isEqualTo(token);
     }
 
     @Test
-    void switchRole_WithInvalidRequestedRole_ShouldThrow() {
-        String token = jwtService.generateToken("testUser", "USER", "uuid-002");
-
-        assertThatThrownBy(() -> jwtService.switchRole(token, "MODERATOR"))
-                .isInstanceOf(InvalidRoleChangeRequestException.class)
-                .hasMessageContaining("Requested role change is not allowed.");
+    void extractBearerToken_WithNullHeader_ThrowsJwtException() {
+        assertThatThrownBy(() -> jwtService.extractBearerToken(null))
+                .isInstanceOf(JwtException.class)
+                .hasMessage("Authorization header is missing or malformed");
     }
 
     @Test
-    void switchRole_WithSameRole_ShouldThrow() {
-        String token = jwtService.generateToken("testUser", "USER", "uuid-003");
+    void extractBearerToken_WithMalformedHeader_ThrowsJwtException() {
+        String malformedHeader = "Token abc.def.ghi";
 
-        assertThatThrownBy(() -> jwtService.switchRole(token, "USER"))
-                .isInstanceOf(InvalidRoleChangeRequestException.class)
-                .hasMessageContaining("New role is the same as current role.");
+        assertThatThrownBy(() -> jwtService.extractBearerToken(malformedHeader))
+                .isInstanceOf(JwtException.class)
+                .hasMessage("Authorization header is missing or malformed");
     }
+
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
@@ -1,6 +1,5 @@
 package com.itachallenge.auth.service;
 
-import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -8,7 +7,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Date;
 
@@ -95,49 +93,5 @@ class JwtServiceTest {
         assertThatThrownBy(() -> shortLivedService.validateToken(token))
                 .isInstanceOf(ExpiredJwtException.class)
                 .hasMessageContaining("Token expired but logout successful");
-    }
-
-    @Test
-    void switchRole_ShouldReturnTokenWithUpdatedRole() {
-        String token = jwtService.generateToken("user1", "ADMIN", "uuid-1");
-        String newToken = jwtService.switchRole(token, "USER");
-
-        Claims claims = jwtService.extractAllClaims(newToken);
-        assertThat(claims.get("role", String.class)).isEqualTo("USER");
-        assertThat(claims.get("isTemporaryRole", Boolean.class)).isTrue();
-    }
-
-    @Test
-    void switchRole_WithSameRole_ShouldThrowException() {
-        String token = jwtService.generateToken("user1", "USER", "uuid-1");
-
-        assertThatThrownBy(() -> jwtService.switchRole(token, "USER"))
-                .isInstanceOf(InvalidRoleChangeRequestException.class)
-                .hasMessage("New role is the same as current role.");
-    }
-
-    @Test
-    void switchRole_WithInvalidCurrentRole_ShouldThrowException() {
-        String invalidRoleToken = Jwts.builder()
-                .subject("user2")
-                .claim("role", "GUEST")
-                .claim("uuid", "uuid-2")
-                .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + 600000))
-                .signWith(Keys.hmacShaKeyFor(io.jsonwebtoken.io.Decoders.BASE64.decode(jwtSigningKey)))
-                .compact();
-
-        assertThatThrownBy(() -> jwtService.switchRole(invalidRoleToken, "USER"))
-                .isInstanceOf(InvalidRoleChangeRequestException.class)
-                .hasMessage("Requested role change is not allowed.");
-    }
-
-    @Test
-    void switchRole_WithNullRequestedRole_ShouldThrowException() {
-        String token = jwtService.generateToken("user3", "ADMIN", "uuid-3");
-
-        assertThatThrownBy(() -> jwtService.switchRole(token, null))
-                .isInstanceOf(InvalidRoleChangeRequestException.class)
-                .hasMessage("New role must be provided.");
     }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Date;
 
@@ -94,4 +95,61 @@ class JwtServiceTest {
                 .isInstanceOf(ExpiredJwtException.class)
                 .hasMessageContaining("Token expired but logout successful");
     }
+
+    @Test
+    void switchRole_ShouldChangeRoleFromAdminToUser() {
+        String username = "testUser";
+        String uuid = "uuid-1234";
+        String originalToken = jwtService.generateToken(username, "ADMIN", uuid);
+
+        String switchedToken = jwtService.switchRole(originalToken);
+        Claims claims = jwtService.extractAllClaims(switchedToken);
+
+        assertThat(claims.getSubject()).isEqualTo(username);
+        assertThat(claims.get("role", String.class)).isEqualTo("USER");
+        assertThat(claims.get("uuid", String.class)).isEqualTo(uuid);
+
+        Claims originalClaims = jwtService.extractAllClaims(originalToken);
+        assertThat(claims.getIssuedAt()).isEqualTo(originalClaims.getIssuedAt());
+        assertThat(claims.getExpiration()).isEqualTo(originalClaims.getExpiration());
+    }
+
+    @Test
+    void switchRole_ShouldChangeRoleFromUserToAdmin() {
+        String username = "anotherUser";
+        String uuid = "uuid-5678";
+        String originalToken = jwtService.generateToken(username, "USER", uuid);
+
+        String switchedToken = jwtService.switchRole(originalToken);
+        Claims claims = jwtService.extractAllClaims(switchedToken);
+
+        assertThat(claims.get("role", String.class)).isEqualTo("ADMIN");
+        assertThat(claims.getSubject()).isEqualTo(username);
+        assertThat(claims.get("uuid", String.class)).isEqualTo(uuid);
+    }
+
+    @Test
+    void switchRole_WithInvalidToken_ShouldThrowJwtException() {
+        String invalidToken = "invalid.token.value";
+
+        assertThatThrownBy(() -> jwtService.switchRole(invalidToken))
+                .isInstanceOf(JwtException.class)
+                .hasMessageContaining("Invalid or tampered token");
+    }
+
+    @Test
+    void switchRole_WithExpiredToken_ShouldThrowResponseStatusExceptionWith200() throws InterruptedException {
+        JwtService shortLivedJwtService = new JwtService(jwtSigningKey, 0L);
+        String expiredToken = shortLivedJwtService.generateToken("expiredUser", "USER", "uuid");
+        Thread.sleep(1000); // asegurar que expire
+
+        assertThatThrownBy(() -> shortLivedJwtService.switchRole(expiredToken))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> {
+                    ResponseStatusException ex = (ResponseStatusException) e;
+                    assertThat(ex.getStatusCode().value()).isEqualTo(200);
+                    assertThat(ex.getReason()).isEqualTo("Token is expired.");
+                });
+    }
+
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
@@ -1,5 +1,6 @@
 package com.itachallenge.auth.service;
 
+import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -97,59 +98,46 @@ class JwtServiceTest {
     }
 
     @Test
-    void switchRole_ShouldChangeRoleFromAdminToUser() {
-        String username = "testUser";
-        String uuid = "uuid-1234";
-        String originalToken = jwtService.generateToken(username, "ADMIN", uuid);
+    void switchRole_ShouldReturnTokenWithUpdatedRole() {
+        String token = jwtService.generateToken("user1", "ADMIN", "uuid-1");
+        String newToken = jwtService.switchRole(token, "USER");
 
-        String switchedToken = jwtService.switchRole(originalToken);
-        Claims claims = jwtService.extractAllClaims(switchedToken);
-
-        assertThat(claims.getSubject()).isEqualTo(username);
+        Claims claims = jwtService.extractAllClaims(newToken);
         assertThat(claims.get("role", String.class)).isEqualTo("USER");
-        assertThat(claims.get("uuid", String.class)).isEqualTo(uuid);
-
-        Claims originalClaims = jwtService.extractAllClaims(originalToken);
-        assertThat(claims.getIssuedAt()).isEqualTo(originalClaims.getIssuedAt());
-        assertThat(claims.getExpiration()).isEqualTo(originalClaims.getExpiration());
+        assertThat(claims.get("isTemporaryRole", Boolean.class)).isTrue();
     }
 
     @Test
-    void switchRole_ShouldChangeRoleFromUserToAdmin() {
-        String username = "anotherUser";
-        String uuid = "uuid-5678";
-        String originalToken = jwtService.generateToken(username, "USER", uuid);
+    void switchRole_WithSameRole_ShouldThrowException() {
+        String token = jwtService.generateToken("user1", "USER", "uuid-1");
 
-        String switchedToken = jwtService.switchRole(originalToken);
-        Claims claims = jwtService.extractAllClaims(switchedToken);
-
-        assertThat(claims.get("role", String.class)).isEqualTo("ADMIN");
-        assertThat(claims.getSubject()).isEqualTo(username);
-        assertThat(claims.get("uuid", String.class)).isEqualTo(uuid);
+        assertThatThrownBy(() -> jwtService.switchRole(token, "USER"))
+                .isInstanceOf(InvalidRoleChangeRequestException.class)
+                .hasMessage("New role is the same as current role.");
     }
 
     @Test
-    void switchRole_WithInvalidToken_ShouldThrowJwtException() {
-        String invalidToken = "invalid.token.value";
+    void switchRole_WithInvalidCurrentRole_ShouldThrowException() {
+        String invalidRoleToken = Jwts.builder()
+                .subject("user2")
+                .claim("role", "GUEST")
+                .claim("uuid", "uuid-2")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 600000))
+                .signWith(Keys.hmacShaKeyFor(io.jsonwebtoken.io.Decoders.BASE64.decode(jwtSigningKey)))
+                .compact();
 
-        assertThatThrownBy(() -> jwtService.switchRole(invalidToken))
-                .isInstanceOf(JwtException.class)
-                .hasMessageContaining("Invalid or tampered token");
+        assertThatThrownBy(() -> jwtService.switchRole(invalidRoleToken, "USER"))
+                .isInstanceOf(InvalidRoleChangeRequestException.class)
+                .hasMessage("Requested role change is not allowed.");
     }
 
     @Test
-    void switchRole_WithExpiredToken_ShouldThrowResponseStatusExceptionWith200() throws InterruptedException {
-        JwtService shortLivedJwtService = new JwtService(jwtSigningKey, 0L);
-        String expiredToken = shortLivedJwtService.generateToken("expiredUser", "USER", "uuid");
-        Thread.sleep(1000); // asegurar que expire
+    void switchRole_WithNullRequestedRole_ShouldThrowException() {
+        String token = jwtService.generateToken("user3", "ADMIN", "uuid-3");
 
-        assertThatThrownBy(() -> shortLivedJwtService.switchRole(expiredToken))
-                .isInstanceOf(ResponseStatusException.class)
-                .satisfies(e -> {
-                    ResponseStatusException ex = (ResponseStatusException) e;
-                    assertThat(ex.getStatusCode().value()).isEqualTo(200);
-                    assertThat(ex.getReason()).isEqualTo("Token is expired.");
-                });
+        assertThatThrownBy(() -> jwtService.switchRole(token, null))
+                .isInstanceOf(InvalidRoleChangeRequestException.class)
+                .hasMessage("New role must be provided.");
     }
-
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
@@ -1,5 +1,6 @@
 package com.itachallenge.auth.service;
 
+import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -93,5 +94,40 @@ class JwtServiceTest {
         assertThatThrownBy(() -> shortLivedService.validateToken(token))
                 .isInstanceOf(ExpiredJwtException.class)
                 .hasMessageContaining("Token expired but logout successful");
+    }
+
+    @Test
+    void switchRole_ShouldGenerateTemporaryToken_WhenValidRoleChange() {
+        String originalToken = jwtService.generateToken("testUser", "USER", "uuid-001");
+        String newToken = jwtService.switchRole(originalToken, "ADMIN");
+
+        Claims claims = Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(io.jsonwebtoken.io.Decoders.BASE64.decode(jwtSigningKey)))
+                .build()
+                .parseSignedClaims(newToken)
+                .getPayload();
+
+        assertThat(claims.get("role", String.class)).isEqualTo("ADMIN");
+        assertThat(claims.get("isTemporaryRole", Boolean.class)).isTrue();
+        assertThat(claims.get("uuid", String.class)).isEqualTo("uuid-001");
+        assertThat(claims.getSubject()).isEqualTo("testUser");
+    }
+
+    @Test
+    void switchRole_WithInvalidRequestedRole_ShouldThrow() {
+        String token = jwtService.generateToken("testUser", "USER", "uuid-002");
+
+        assertThatThrownBy(() -> jwtService.switchRole(token, "MODERATOR"))
+                .isInstanceOf(InvalidRoleChangeRequestException.class)
+                .hasMessageContaining("Requested role change is not allowed.");
+    }
+
+    @Test
+    void switchRole_WithSameRole_ShouldThrow() {
+        String token = jwtService.generateToken("testUser", "USER", "uuid-003");
+
+        assertThatThrownBy(() -> jwtService.switchRole(token, "USER"))
+                .isInstanceOf(InvalidRoleChangeRequestException.class)
+                .hasMessageContaining("New role is the same as current role.");
     }
 }

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
@@ -1,6 +1,5 @@
 package com.itachallenge.auth.service;
 
-import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -8,7 +7,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Date;
 

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
@@ -1,5 +1,6 @@
 package com.itachallenge.auth.service;
 
+import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -7,6 +8,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Date;
 

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/JwtServiceTest.java
@@ -122,4 +122,81 @@ class JwtServiceTest {
                 .hasMessage("Authorization header is missing or malformed");
     }
 
+    @Test
+    void extractAllClaims_WithValidToken_ShouldReturnClaims() {
+        String token = jwtService.generateToken("testUser", "USER", "uuid-123");
+        Claims claims = jwtService.extractAllClaims(token);
+
+        assertThat(claims.getSubject()).isEqualTo("testUser");
+        assertThat(claims.get("role", String.class)).isEqualTo("USER");
+        assertThat(claims.get("uuid", String.class)).isEqualTo("uuid-123");
+    }
+
+    @Test
+    void extractAllClaims_WithExpiredToken_ShouldThrowExpiredJwtException() {
+        JwtService shortLivedJwtService = new JwtService(jwtSigningKey, 0L);
+        String token = shortLivedJwtService.generateToken("expiredUser", "USER", "uuid-456");
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ignored) {}
+
+        assertThatThrownBy(() -> shortLivedJwtService.extractAllClaims(token))
+                .isInstanceOf(ExpiredJwtException.class)
+                .hasMessageContaining("Token expired");
+    }
+
+    @Test
+    void extractAllClaims_WithInvalidToken_ShouldThrowJwtException() {
+        String invalidToken = "this.is.not.valid";
+
+        assertThatThrownBy(() -> jwtService.extractAllClaims(invalidToken))
+                .isInstanceOf(JwtException.class)
+                .hasMessageContaining("Invalid or tampered token");
+    }
+
+    @Test
+    void switchRole_WithValidChange_ShouldReturnNewToken() {
+        String originalToken = jwtService.generateToken("testUser", "USER", "uuid-001");
+
+        String switchedToken = jwtService.switchRole(originalToken, "ADMIN");
+
+        Claims claims = Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(io.jsonwebtoken.io.Decoders.BASE64.decode(jwtSigningKey)))
+                .build()
+                .parseSignedClaims(switchedToken)
+                .getPayload();
+
+        assertThat(claims.get("role", String.class)).isEqualTo("ADMIN");
+        assertThat(claims.get("isTemporaryRole", Boolean.class)).isTrue();
+        assertThat(claims.get("uuid", String.class)).isEqualTo("uuid-001");
+        assertThat(claims.getSubject()).isEqualTo("testUser");
+    }
+
+    @Test
+    void switchRole_SameRole_ShouldThrowException() {
+        String token = jwtService.generateToken("testUser", "USER", "uuid-002");
+
+        assertThatThrownBy(() -> jwtService.switchRole(token, "USER"))
+                .isInstanceOf(InvalidRoleChangeRequestException.class)
+                .hasMessage("New role is the same as current role.");
+    }
+
+    @Test
+    void switchRole_InvalidRequestedRole_ShouldThrowException() {
+        String token = jwtService.generateToken("testUser", "USER", "uuid-003");
+
+        assertThatThrownBy(() -> jwtService.switchRole(token, "GUEST"))
+                .isInstanceOf(InvalidRoleChangeRequestException.class)
+                .hasMessage("Requested role change is not allowed.");
+    }
+
+    @Test
+    void switchRole_InvalidToken_ShouldThrowJwtException() {
+        String invalidToken = "not.a.valid.token";
+
+        assertThatThrownBy(() -> jwtService.switchRole(invalidToken, "ADMIN"))
+                .isInstanceOf(JwtException.class)
+                .hasMessageContaining("Invalid or tampered token");
+    }
 }


### PR DESCRIPTION
## Allow user role change at runtime
User Story: #388 [https://tree.taiga.io/project/luisvi-ita-challenges/us/388](url)

### Summary

This update introduces a new feature that allows authenticated users to temporarily switch their role (ADMIN or USER) and receive a new JWT reflecting the new role. All logic is isolated to the auth microservice.

### Changes
SwitchRoleRequest: New User role request DTO.

UserRole: New user role enum (USER, ADMIN). 
-  Validates that the new role:
   - Is not null or blank.
   - Is different from the current role.
   - Is a valid transition between ADMIN and USER.

Since the roles are fixed and limited, using an enum improves cohesion and avoids unnecessary abstraction. Delegating this logic to an external service is not considered necessary for now.
 
AuthController:
- Added POST /switch-role endpoint.
- Tokens generated from a role switch include the claim isTemporaryRole: true.
- Extracted method extractBearerToken(...) improves token extraction clarity.

IJwtService:
- switchRole(String token, String requestedRole).
  - Extracts claims from the token.
 - Returns a new token or throws an appropriate exception based on token state.

- extractAllClaims(String token) 
  - Parses and validates the JWT using the secret signing key.
  - Verifies the token’s signature and integrity.
  - Extracts and returns the payload (claims) if the token is valid.
  - Throws exceptions if the token is:
    - Expired (ExpiredJwtException).
    - Modified or invalid (JwtException).

### Unit Tests Added
UserRoleTest:
- Validates successful role transitions between ADMIN and USER.
- Rejects same-role transitions (e.g., USER to USER)
- Rejects null, blank, or unknown role values.

JwtServiceTest:
- Role switch success case.
- Rejects invalid role switch.

AuthControllerTest:
- Successful switch returns 200.
- Expired token returns 200.
- Bad role requests returns 400.
- Invalid token, malformed or missing headers returns 401.

GlobalExceptionHandlerTest:
- Validates that InvalidRoleChangeRequestException is handled with a 400 response.