### PR TITLE
feat(user): Hardcode getAllSolutionsByUser endpoint response for frontend (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Issue #871  Secured POST endpoint addChallenge for creating a challenge in the Challenge Microservice.
+* PR #884: Added a hardcoded GET endpoint to return all of a user’s challenge solutions.
 * Issue #864: Added JWT authentication to logout endpoint in User microservice.
 * PR #872: Added error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags
 * PR #866: Added tag validation in the addChallenge endpoint.

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Set;
@@ -397,5 +398,32 @@ public class UserController {
                     log.info("Retrieved {} bookmarked challenges for user {}", bookmarks.size(), userId);
                     return ResponseEntity.ok().body(bookmarks);
                 });
+    }
+    
+    @Operation(
+            summary = "Retrieve all solutions for a user.",
+            parameters = {
+                    @Parameter(
+                            name = "userId",
+                            in = ParameterIn.PATH,
+                            required = true,
+                            description = "User UUID")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Solutions found"),
+                    @ApiResponse(responseCode = "404", description = "Solutions not found"),
+                    @ApiResponse(responseCode = "400", description = "Invalid UUID"),
+                    @ApiResponse(responseCode = "500", description = "Unexpected error")
+            }
+    )
+    @GetMapping(
+            path = "/users/{userId}/solutions"
+    )
+    public Mono<ResponseEntity<Flux<UserSolutionResponseDto>>> getAllSolutions(
+            @PathVariable String userId
+    ) {
+        return Mono.just(ResponseEntity.ok()
+                .body(userSolutionService.getAllSolutionsByUser(userId))
+        );
     }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -419,7 +419,7 @@ public class UserController {
     @GetMapping(
             path = "/users/{userId}/solutions"
     )
-    public Mono<ResponseEntity<Flux<UserSolutionResponseDto>>> getAllSolutions(
+    public Mono<ResponseEntity<Flux<UserSolutionResponseDto>>> getAllSolutionsByUser(
             @PathVariable String userId
     ) {
         return Mono.just(ResponseEntity.ok()

--- a/itachallenge-user/src/main/java/com/itachallenge/user/repository/IUserSolutionRepository.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/repository/IUserSolutionRepository.java
@@ -3,7 +3,6 @@ package com.itachallenge.user.repository;
 import com.itachallenge.user.document.UserSolutionDocument;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
@@ -12,6 +11,5 @@ import java.util.UUID;
 public interface IUserSolutionRepository extends ReactiveMongoRepository<UserSolutionDocument, UUID> {
 
     Mono<UserSolutionDocument> findByUserIdAndChallengeIdAndLanguageId(UUID userId, UUID challengeId, UUID languageId);
-    Flux<UserSolutionDocument> findAllByUserId(UUID userId);
 }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/repository/IUserSolutionRepository.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/repository/IUserSolutionRepository.java
@@ -3,6 +3,7 @@ package com.itachallenge.user.repository;
 import com.itachallenge.user.document.UserSolutionDocument;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
@@ -11,5 +12,6 @@ import java.util.UUID;
 public interface IUserSolutionRepository extends ReactiveMongoRepository<UserSolutionDocument, UUID> {
 
     Mono<UserSolutionDocument> findByUserIdAndChallengeIdAndLanguageId(UUID userId, UUID challengeId, UUID languageId);
+    Flux<UserSolutionDocument> findAllByUserId(UUID userId);
 }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/IUserSolutionService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/IUserSolutionService.java
@@ -2,8 +2,10 @@ package com.itachallenge.user.service;
 
 import com.itachallenge.user.dto.UserSolutionRequestDto;
 import com.itachallenge.user.dto.UserSolutionResponseDto;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface IUserSolutionService {
     Mono<UserSolutionResponseDto> addSolution(UserSolutionRequestDto userSolutionDto);
+    Flux<UserSolutionResponseDto> getAllSolutionsByUser(String userId);
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -9,6 +9,7 @@ import com.itachallenge.user.repository.IUserSolutionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
@@ -77,7 +78,27 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
                     return userSolutionRepository.save(userSolutionDocument);
                 }));
     }
-
+    
+    @Override
+    public Flux<UserSolutionResponseDto> getAllSolutionsByUser(String userId) {
+        UserSolutionResponseDto sol1 = UserSolutionResponseDto.builder()
+                .userId("1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d")
+                .challengeId("d43a1a4d-ee8f-432d-8f9c-68eda2547dae")
+                .languageId("409c9fe8-74de-4db3-81a1-a55280cf92ef")
+                .solutionText("This is the submitted solution")
+                .build();
+        
+        UserSolutionResponseDto sol2 = UserSolutionResponseDto.builder()
+                .userId("1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d")
+                .challengeId("b5c06903-f27b-4057-8220-ad9d957cdce4")
+                .languageId("09fabe32-7362-4bfb-ac05-b7bf854c6e0f")
+                .solutionText("This is the submitted solution")
+                .build();
+        
+        return Flux.just(sol1, sol2);
+    }
+    
+    
 }
 
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -81,6 +81,7 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
     
     @Override
     public Flux<UserSolutionResponseDto> getAllSolutionsByUser(String userId) {
+        // TODO: Replace this mock logic with an actual MongoDB query that fetches the user's solutions.
         UserSolutionResponseDto sol1 = UserSolutionResponseDto.builder()
                 .userId("1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d")
                 .challengeId("d43a1a4d-ee8f-432d-8f9c-68eda2547dae")

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -2,25 +2,25 @@ package com.itachallenge.user.controller;
 
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
+import com.itachallenge.user.dto.UserSolutionResponseDto;
 import com.itachallenge.user.exception.BadUUIDException;
 import com.itachallenge.user.exception.NotFoundException;
 import com.itachallenge.user.service.IUserSolutionService;
 import com.itachallenge.user.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.service.UserService;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Set;
 import java.util.UUID;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 class UserControllerTest {
@@ -567,6 +567,103 @@ class UserControllerTest {
 
         verify(userService, times(1)).getUserBookmarks(userId.toString());
     }
-
-
+    
+    @Test
+    @DisplayName("GET /users/{userId}/solutions returns solutions")
+    void getAllSolutions_returnsSolutions() {
+        String userId = UUID.randomUUID().toString();
+        
+        UserSolutionResponseDto sol1 = UserSolutionResponseDto.builder()
+                .userId(userId)
+                .challengeId("d43a1a4d-ee8f-432d-8f9c-68eda2547dae")
+                .languageId("409c9fe8-74de-4db3-81a1-a55280cf92ef")
+                .solutionText("This is the submitted solution")
+                .build();
+        
+        UserSolutionResponseDto sol2 = UserSolutionResponseDto.builder()
+                .userId(userId)
+                .challengeId("b5c06903-f27b-4057-8220-ad9d957cdce4")
+                .languageId("09fabe32-7362-4bfb-ac05-b7bf854c6e0f")
+                .solutionText("This is the submitted solution")
+                .build();
+        
+        when(userSolutionService.getAllSolutionsByUser(userId))
+                .thenReturn(Flux.just(sol1, sol2));
+        
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(UserSolutionResponseDto.class)
+                .hasSize(2)
+                .value(list -> {
+                    
+                    Assertions.assertEquals(sol1.getUserId(), list.get(0).getUserId());
+                    Assertions.assertEquals(sol1.getChallengeId(), list.get(0).getChallengeId());
+                    Assertions.assertEquals(sol1.getLanguageId(), list.get(0).getLanguageId());
+                    Assertions.assertEquals(sol1.getSolutionText(), list.get(0).getSolutionText());
+                    
+                    Assertions.assertEquals(sol2.getUserId(), list.get(1).getUserId());
+                    Assertions.assertEquals(sol2.getChallengeId(), list.get(1).getChallengeId());
+                    Assertions.assertEquals(sol2.getLanguageId(), list.get(1).getLanguageId());
+                    Assertions.assertEquals(sol2.getSolutionText(), list.get(1).getSolutionText());
+                });
+        
+        verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
+    }
+    
+    @Test
+    @DisplayName("GET /users/{userId}/solutions returns 404 if no solutions found")
+    void getAllSolutions_returns404IfNotFound() {
+        String userId = UUID.randomUUID().toString();
+        
+        // Simulamos que el servicio lanza NotFoundException
+        when(userSolutionService.getAllSolutionsByUser(userId))
+                .thenReturn(Flux.error(new NotFoundException("Solutions not found")));
+        
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(String.class)
+                .isEqualTo("Solutions not found");
+        
+        verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
+    }
+    
+    @Test
+    @DisplayName("GET /users/{userId}/solutions returns 400 if UUID is invalid")
+    void getAllSolutions_returns400IfInvalidUUID() {
+        String badUserId = "not-a-uuid";
+        
+        when(userSolutionService.getAllSolutionsByUser(badUserId))
+                .thenReturn(Flux.error(new BadUUIDException("Bad UUID")));
+        
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/user/users/{userId}/solutions", badUserId)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(String.class)
+                .isEqualTo("The provided IDs are not valid.");
+        
+        verify(userSolutionService, times(1)).getAllSolutionsByUser(badUserId);
+    }
+    
+    @Test
+    @DisplayName("GET /users/{userId}/solutions returns 500 on unexpected error")
+    void getAllSolutions_returns500IfUnexpectedError() {
+        String userId = UUID.randomUUID().toString();
+        
+        when(userSolutionService.getAllSolutionsByUser(userId))
+                .thenReturn(Flux.error(new RuntimeException("Boom")));
+        
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                .expectBody(String.class)
+                .isEqualTo("Unexpected error happened.");
+        
+        verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
+    }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWeb
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.mockito.InjectMocks;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -170,6 +171,30 @@ class UserSolutionServiceImplTest {
         verifyNoInteractions(userSolutionRepository);
 
     }
+    
+    @DisplayName("UserSolutionServiceImplTest - getAllSolutionsByUser")
+    @Test
+    void getAllSolutionsByUser_returnsTwoStaticSolutions_test() {
+        String anyUserId = "cualquier-uuid";
+        
+        Flux<UserSolutionResponseDto> resultFlux = userSolutionService.getAllSolutionsByUser(anyUserId);
+        
+        StepVerifier.create(resultFlux)
+                .expectNextMatches(dto ->
+                        dto.getUserId().equals("1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d")
+                                && dto.getChallengeId().equals("d43a1a4d-ee8f-432d-8f9c-68eda2547dae")
+                                && dto.getLanguageId().equals("409c9fe8-74de-4db3-81a1-a55280cf92ef")
+                                && dto.getSolutionText().equals("This is the submitted solution")
+                )
+                .expectNextMatches(dto ->
+                        dto.getUserId().equals("1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d")
+                                && dto.getChallengeId().equals("b5c06903-f27b-4057-8220-ad9d957cdce4")
+                                && dto.getLanguageId().equals("09fabe32-7362-4bfb-ac05-b7bf854c6e0f")
+                                && dto.getSolutionText().equals("This is the submitted solution")
+                )
+                .verifyComplete();
+    }
+    
 }
 
 


### PR DESCRIPTION
This change introduces a new controller action that exposes a reactive endpoint at GET /users/{userId}/solutions. Instead of querying the database, it returns a fixed list of two UserSolutionResponseDto objects. The primary goal is to allow Front-end teams to integrate against this contract and iterate on UI workflows while backend persistence is still under construction.

Originally it was implemented by filtering by challengeId, but in a meeting we held with the Frontend team, it was suggested that it would be preferable to return an array of all a user’s solutions, and that’s what was agreed upon.

From the Frontend team, it was requested to do it this way mainly for two reasons:

Fewer backend calls: we avoid making a request for each challengeId.

Flexibility: if tomorrow we want to display an overall list of progress or statistics, we already have all the data available.

That said, if in the future we find that this approach hurts performance (for example, if the payload becomes too large), we can create a dedicated endpoint—/users/{userId}/challenges/{challengeId}/solution—to fetch only a single challenge’s solution. For now, given the expected data volume, we believe this gives us faster development and better maintainability.