### PR TITLE
feat(challenges): Create FavoriteController and refactor ChallengeController (#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-* PR #883: Refactored ChallengeController and created new FavoriteController. Moved all endpoints related to favorites to the new controller.
+* PR #883: Created new FavoriteController and refactored ChallengeController.
 * Issue #864: Added JWT authentication to logout endpoint in User microservice.
 * PR #872: Added error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags
 * PR #866: Added tag validation in the addChallenge endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+* PR #883: Refactored ChallengeController and created new FavoriteController. Moved all endpoints related to favorites to the new controller.
 * Issue #864: Added JWT authentication to logout endpoint in User microservice.
 * PR #872: Added error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags
 * PR #866: Added tag validation in the addChallenge endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-* PR #883: Created new FavoriteController and refactored ChallengeController.
+* PR #886: Created new FavoriteController and refactored ChallengeController.
 * Issue #864: Added JWT authentication to logout endpoint in User microservice.
 * PR #872: Added error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags
 * PR #866: Added tag validation in the addChallenge endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * PR #886: Created new FavoriteController and refactored ChallengeController.
-* PR #884: Added a hardcoded GET endpoint to return all of a user’s challenge solutions.
-* PR #872: Added error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags
 * Issue #871  Secured POST endpoint addChallenge for creating a challenge in the Challenge Microservice.
-* PR #866: Added tag validation in the addChallenge endpoint.
+* PR #884: Added a hardcoded GET endpoint to return all of a user’s challenge solutions.
 * Issue #864: Added JWT authentication to logout endpoint in User microservice.
+* PR #872: Added error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags
+* PR #866: Added tag validation in the addChallenge endpoint.
 * Issue #852: Added GET endpoint for retrieving resources from a challenge
 * Issue #849: Added GET endpoint to retrieve all User's bookmarked challenges.
 * Issue #843: Added DELETE endpoint in the Challenge Microservice to unbookmark a challenge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
 - FavoriteController and extracted endpoints from ChallengeController. (#PR 886)
 - POST endpoint in Auth microservice to allow user role change at runtime (PR #882)
 - Hardcoded GET endpoint to return all of a user’s challenge solutions (PR #884)

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -260,50 +260,6 @@ public class ChallengeController {
                 .map(dto -> ResponseEntity.ok().body(dto));
     }
 
-    @PostMapping("/challenges/{challengeId}/favorites")
-    @Operation(
-            operationId = "Add a challenge to User's favorites.",
-            summary = "Add a challenge to favorites.",
-            description = "The ID Challenge sent through the URI is added to the user's favorites. User Id is determined from the headers.",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = FavoriteDto.class), mediaType = "application/json")}),
-                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
-                    @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
-                    @ApiResponse(responseCode = "500", description = "Internal Server Error")
-            }
-    )
-    public Mono<ResponseEntity<FavoriteDto>> addChallengeToFavorite(
-            @PathVariable String challengeId,
-            @RequestHeader(name = "Authorization", required = false) String authHeader) {
-        return Mono.fromCallable(() -> jwtService.getUserUuIdFromAuthenticationHeader(authHeader))
-                .onErrorMap(JwtException.class, e -> new BadRequestException(e.getMessage()))
-                .flatMap(userId -> challengeService.addChallengeToFavorites(challengeId, userId))
-                .doOnError(error -> log.error("Error adding challenge to favorites: {}", error.getMessage()))
-                .map(ResponseEntity::ok);
-    }
-
-    @DeleteMapping("/challenges/{challengeId}/favorites")
-    @Operation(
-            operationId = "Remove a challenge from the User's favorites.",
-            summary = "Remove a challenge from favorites.",
-            description = "The ID Challenge sent through the URI is removed from the user's favorites. User Id is determined from the headers.",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = FavoriteDto.class), mediaType = "application/json")}),
-                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
-                    @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
-                    @ApiResponse(responseCode = "500", description = "Internal Server Error")
-            }
-    )
-    public Mono<ResponseEntity<FavoriteDto>> removeChallengeFromFavorite(
-            @PathVariable String challengeId,
-            @RequestHeader(name = "Authorization", required = false) String authHeader) {
-        return Mono.fromCallable(() -> jwtService.getUserUuIdFromAuthenticationHeader(authHeader))
-                .onErrorMap(JwtException.class, e -> new BadRequestException(e.getMessage()))
-                .flatMap(userId -> challengeService.removeChallengeFromFavorites(challengeId, userId))
-                .doOnError(error -> log.error("Error removing challenge from favorites: {}", error.getMessage()))
-                .map(ResponseEntity::ok);
-    }
-
     @PostMapping("/challenges/{challengeId}/bookmarks")
     @Operation(
             operationId = "Add a challenge to User's bookmarks.",

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/FavoriteController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/FavoriteController.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,13 +20,16 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/itachallenge/api/v1/challenges/favorites")
 public class FavoriteController {
 
-    @Autowired
-    IFavoriteService favoriteService;
+    private final IFavoriteService favoriteService;
+    private final IJwtService jwtService;
+    private static final Logger log = LoggerFactory.getLogger(FavoriteController.class);
 
-    @Autowired
-    IJwtService jwtService;
+    public FavoriteController(IFavoriteService favoriteService, IJwtService jwtService) {
+        this.favoriteService = favoriteService;
+        this.jwtService = jwtService;
+    }
 
-    @PostMapping("add/{challengeId}")
+    @PostMapping("/{challengeId}/favorites")
     @Operation(
             operationId = "Add a challenge to User's favorites.",
             summary = "Add a challenge to favorites.",
@@ -42,10 +47,11 @@ public class FavoriteController {
         return Mono.fromCallable(() -> jwtService.getUserUuIdFromAuthenticationHeader(authHeader))
                 .onErrorMap(JwtException.class, e -> new BadRequestException(e.getMessage()))
                 .flatMap(userId -> favoriteService.addChallengeToFavorites(challengeId, userId))
+                .doOnError(e -> log.error("Failed to add favorite for challengeId {}: {}", challengeId, e.getMessage()))
                 .map(ResponseEntity::ok);
     }
 
-    @DeleteMapping("remove/{challengeId}")
+    @DeleteMapping("/{challengeId}/favorites")
     @Operation(
             operationId = "Remove a challenge from the User's favorites.",
             summary = "Remove a challenge from favorites.",

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/FavoriteController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/FavoriteController.java
@@ -1,0 +1,68 @@
+package com.itachallenge.challenge.controller;
+
+import com.itachallenge.challenge.dto.FavoriteDto;
+import com.itachallenge.challenge.exception.BadRequestException;
+import com.itachallenge.challenge.exception.JwtException;
+import com.itachallenge.challenge.service.IFavoriteService;
+import com.itachallenge.challenge.service.IJwtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/itachallenge/api/v1/challenges/favorites")
+public class FavoriteController {
+
+    @Autowired
+    IFavoriteService favoriteService;
+
+    @Autowired
+    IJwtService jwtService;
+
+    @PostMapping("/{challengeId}")
+    @Operation(
+            operationId = "Add a challenge to User's favorites.",
+            summary = "Add a challenge to favorites.",
+            description = "The ID Challenge sent through the URI is added to the user's favorites. User Id is determined from the headers.",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = FavoriteDto.class), mediaType = "application/json")}),
+                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
+                    @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error")
+            }
+    )
+    public Mono<ResponseEntity<FavoriteDto>> addFavorite(
+            @PathVariable String challengeId,
+            @RequestHeader(name = "Authorization", required = false) String authHeader) {
+        return Mono.fromCallable(() -> jwtService.getUserUuIdFromAuthenticationHeader(authHeader))
+                .onErrorMap(JwtException.class, e -> new BadRequestException(e.getMessage()))
+                .flatMap(userId -> favoriteService.addChallengeToFavorites(challengeId, userId))
+                .map(ResponseEntity::ok);
+    }
+
+    @DeleteMapping("/{challengeId}")
+    @Operation(
+            operationId = "Remove a challenge from the User's favorites.",
+            summary = "Remove a challenge from favorites.",
+            description = "The ID Challenge sent through the URI is removed from the user's favorites. User Id is determined from the headers.",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = FavoriteDto.class), mediaType = "application/json")}),
+                    @ApiResponse(responseCode = "400", description = "Missing or invalid authorization header."),
+                    @ApiResponse(responseCode = "404", description = "The Challenge with given Id was not found."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error")
+            }
+    )
+    public Mono<ResponseEntity<FavoriteDto>> removeFavorite(
+            @PathVariable String challengeId,
+            @RequestHeader(name = "Authorization", required = false) String authHeader) {
+        return Mono.fromCallable(() -> jwtService.getUserUuIdFromAuthenticationHeader(authHeader))
+                .onErrorMap(JwtException.class, e -> new BadRequestException(e.getMessage()))
+                .flatMap(userId -> favoriteService.removeChallengeFromFavorites(challengeId, userId))
+                .map(ResponseEntity::ok);
+    }
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/FavoriteController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/FavoriteController.java
@@ -24,7 +24,7 @@ public class FavoriteController {
     @Autowired
     IJwtService jwtService;
 
-    @PostMapping("/{challengeId}")
+    @PostMapping("add/{challengeId}")
     @Operation(
             operationId = "Add a challenge to User's favorites.",
             summary = "Add a challenge to favorites.",
@@ -45,7 +45,7 @@ public class FavoriteController {
                 .map(ResponseEntity::ok);
     }
 
-    @DeleteMapping("/{challengeId}")
+    @DeleteMapping("remove/{challengeId}")
     @Operation(
             operationId = "Remove a challenge from the User's favorites.",
             summary = "Remove a challenge from favorites.",

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/FavoriteController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/FavoriteController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
 @RestController
-@RequestMapping("/itachallenge/api/v1/challenges/favorites")
+@RequestMapping("/itachallenge/api/v1/favorite/challenges/")
 public class FavoriteController {
 
     private final IFavoriteService favoriteService;
@@ -29,7 +29,7 @@ public class FavoriteController {
         this.jwtService = jwtService;
     }
 
-    @PostMapping("/{challengeId}/favorites")
+    @PostMapping("/{challengeId}")
     @Operation(
             operationId = "Add a challenge to User's favorites.",
             summary = "Add a challenge to favorites.",
@@ -51,7 +51,7 @@ public class FavoriteController {
                 .map(ResponseEntity::ok);
     }
 
-    @DeleteMapping("/{challengeId}/favorites")
+    @DeleteMapping("/{challengeId}")
     @Operation(
             operationId = "Remove a challenge from the User's favorites.",
             summary = "Remove a challenge from favorites.",

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -56,8 +56,6 @@ public class ChallengeServiceImpl implements IChallengeService {
     private IUserService userService;
     @Autowired
     private ITagService tagService;
-    @Autowired
-    private IFavoriteService favoriteService;
 
     @Cacheable(value = "challenges", key = "#id", unless = "#result==null")
     public Mono<ChallengeDto> getChallengeById(String id) {
@@ -349,16 +347,6 @@ public class ChallengeServiceImpl implements IChallengeService {
                         .total(0)
                         .build()));
 
-    }
-
-    @Override
-    public Mono<FavoriteDto> addChallengeToFavorites(String challengeId, String userId) {
-        return favoriteService.addChallengeToFavorites(challengeId, userId);
-    }
-
-    @Override
-    public Mono<FavoriteDto> removeChallengeFromFavorites(String challengeId, String userId) {
-        return favoriteService.removeChallengeFromFavorites(challengeId, userId);
     }
 
     @Override

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -35,11 +35,7 @@ public interface IChallengeService {
 
     Mono<ChallengeListDto> getChallengesByTopic(Topic topic, int page, int size);
 
-    Mono<FavoriteDto> addChallengeToFavorites(String challengeId, String userId);
-
     Mono<BookmarkDto> addChallengeToBookmarks(String challengeId, String userId);
-
-    Mono<FavoriteDto> removeChallengeFromFavorites(String challengeId, String userId);
 
     Mono<BookmarkDto> removeChallengeFromBookmarks(String challengeId, String userId);
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -456,28 +456,6 @@ class ChallengeControllerTest {
     }
 
     @Test
-    void addChallengeToFavorites_Success_Returns200() {
-        String challengeId = "existing_challengeId";
-        String userId = "existing_userId";
-        String authHeader = "validAuthHeader";
-
-        FavoriteDto expectedResponse = new FavoriteDto(true, 20);
-
-        when(challengeService.addChallengeToFavorites(challengeId, userId)).thenReturn(Mono.just(expectedResponse));
-        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/favorites")
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(FavoriteDto.class)
-                .isEqualTo(expectedResponse);
-
-        verify(challengeService, times(1)).addChallengeToFavorites(challengeId, userId);
-    }
-
-    @Test
     void addChallengeToBookmarks_Success_Returns200() {
         String challengeId = "existing_challengeId";
         String userId = "existing_userId";
@@ -500,28 +478,6 @@ class ChallengeControllerTest {
     }
 
     @Test
-    void addChallengeToFavorites_ChallengeNotFound_Returns404() {
-        String challengeId = "nonExisting_challengeId";
-        String userId = "existing_userId";
-        String authHeader = "validAuthHeader";
-
-        String errorMessage = "ErrorMessage";
-
-        when(challengeService.addChallengeToFavorites(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundException(errorMessage)));
-        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/favorites")
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus().isNotFound()
-                .expectBody(MessageDto.class)
-                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
-
-        verify(challengeService, times(1)).addChallengeToFavorites(challengeId, userId);
-    }
-
-    @Test
     void addChallengeToBookmarks_ChallengeNotFound_Returns404() {
         String challengeId = "nonExisting_challengeId";
         String userId = "existing_userId";
@@ -541,29 +497,6 @@ class ChallengeControllerTest {
                 .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
 
         verify(challengeService, times(1)).addChallengeToBookmarks(challengeId, userId);
-    }
-
-    @Test
-    void addChallengeToFavorites_InternalServerError_Returns500() {
-        String challengeId = "Existing_challengeId";
-        String userId = "existing_userId";
-        String authHeader = "validAuthHeader";
-
-        String errorMessage = "ErrorMessage";
-
-        when(challengeService.addChallengeToFavorites(challengeId, userId)).thenReturn(Mono.error(new InternalServerErrorException(errorMessage)));
-        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/favorites")
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus()
-                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(MessageDto.class)
-                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
-
-        verify(challengeService, times(1)).addChallengeToFavorites(challengeId, userId);
     }
 
     @Test
@@ -590,26 +523,6 @@ class ChallengeControllerTest {
     }
 
     @Test
-    void addChallengeToFavorites_InvalidHeader_Returns400() {
-        String challengeId = "Existing_challengeId";
-        String authHeader = "badHeader";
-        String errorMessage = "ErrorMessage";
-
-        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenThrow(new JwtException(errorMessage));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/favorites")
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus()
-                .isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(MessageDto.class)
-                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
-
-        verify(challengeService, times(0)).addChallengeToFavorites(anyString(), anyString());
-    }
-
-    @Test
     void addChallengeToBookmarks_InvalidHeader_Returns400() {
         String challengeId = "Existing_challengeId";
         String authHeader = "badHeader";
@@ -627,24 +540,6 @@ class ChallengeControllerTest {
                 .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
 
         verify(challengeService, times(0)).addChallengeToBookmarks(anyString(), anyString());
-    }
-
-    @Test
-    void addChallengeToFavorites_MissingHeader_Returns400() {
-        String challengeId = "Existing_challengeId";
-        String errorMessage = "ErrorMessage";
-
-        when(jwtService.getUserUuIdFromAuthenticationHeader(null)).thenThrow(new JwtException(errorMessage));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/favorites")
-                .exchange()
-                .expectStatus()
-                .isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(MessageDto.class)
-                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
-
-        verify(challengeService, times(0)).addChallengeToFavorites(anyString(), anyString());
     }
 
     @Test
@@ -693,112 +588,6 @@ class ChallengeControllerTest {
                 .jsonPath("$.limit").isEqualTo(2);
 
         verify(tagService).getAllTags();
-    }
-
-    @Test
-    void removeChallengeFromFavorite_Success_Returns200() {
-        String challengeId = "existing_challengeId";
-        String userId = "existing_userId";
-        String authHeader = "validAuthHeader";
-
-        FavoriteDto expectedResponse = new FavoriteDto(false, 20);
-
-        when(challengeService.removeChallengeFromFavorites(challengeId, userId)).thenReturn(Mono.just(expectedResponse));
-        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/favorites")
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(FavoriteDto.class)
-                .isEqualTo(expectedResponse);
-
-        verify(challengeService, times(1)).removeChallengeFromFavorites(challengeId, userId);
-    }
-
-    @Test
-    void removeChallengeFromFavorite_ChallengeNotFound_Returns404() {
-        String challengeId = "nonExisting_challengeId";
-        String userId = "existing_userId";
-        String authHeader = "validAuthHeader";
-
-        String errorMessage = "ErrorMessage";
-
-        when(challengeService.removeChallengeFromFavorites(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundException(errorMessage)));
-        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/favorites")
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus().isNotFound()
-                .expectBody(MessageDto.class)
-                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
-
-        verify(challengeService, times(1)).removeChallengeFromFavorites(challengeId, userId);
-    }
-
-    @Test
-    void removeChallengeFromFavorite_InternalServerError_Returns500() {
-        String challengeId = "Existing_challengeId";
-        String userId = "existing_userId";
-        String authHeader = "validAuthHeader";
-
-        String errorMessage = "ErrorMessage";
-
-        when(challengeService.removeChallengeFromFavorites(challengeId, userId)).thenReturn(Mono.error(new InternalServerErrorException(errorMessage)));
-        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/favorites")
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus()
-                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(MessageDto.class)
-                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
-
-        verify(challengeService, times(1)).removeChallengeFromFavorites(challengeId, userId);
-    }
-
-    @Test
-    void removeChallengeFromFavorite_InvalidHeader_Returns400() {
-        String challengeId = "Existing_challengeId";
-        String authHeader = "BadHeader";
-        String errorMessage = "Error message";
-
-        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenThrow(new JwtException(errorMessage));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/favorites")
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus()
-                .isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(MessageDto.class)
-                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
-
-        verify(challengeService, times(0)).removeChallengeFromFavorites(anyString(), anyString());
-    }
-
-    @Test
-    void removeChallengeFromFavorite_MissingHeader_Returns400() {
-        String challengeId = "Existing_challengeId";
-        String errorMessage = "ErrorMessage";
-
-        when(jwtService.getUserUuIdFromAuthenticationHeader(null)).thenThrow(new JwtException(errorMessage));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/favorites")
-                .exchange()
-                .expectStatus()
-                .isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(MessageDto.class)
-                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
-
-        verify(challengeService, times(0)).removeChallengeFromFavorites(anyString(), anyString());
-
     }
 
     @Test

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/FavoriteControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/FavoriteControllerTest.java
@@ -9,7 +9,6 @@ import com.itachallenge.challenge.service.IFavoriteService;
 import com.itachallenge.challenge.service.IJwtService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -27,9 +26,7 @@ public class FavoriteControllerTest {
     void setUp() {
         favoriteService = mock(IFavoriteService.class);
         jwtService = mock(IJwtService.class);
-        favoriteController = new FavoriteController();
-        favoriteController.favoriteService = favoriteService;
-        favoriteController.jwtService = jwtService;
+        favoriteController = new FavoriteController(favoriteService, jwtService);
     }
 
     @Test

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/FavoriteControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/FavoriteControllerTest.java
@@ -13,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class FavoriteControllerTest {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/FavoriteControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/FavoriteControllerTest.java
@@ -1,0 +1,177 @@
+package com.itachallenge.challenge.controller;
+
+import com.itachallenge.challenge.dto.FavoriteDto;
+import com.itachallenge.challenge.exception.BadRequestException;
+import com.itachallenge.challenge.exception.ChallengeNotFoundException;
+import com.itachallenge.challenge.exception.JwtException;
+import com.itachallenge.challenge.exception.InternalServerErrorException;
+import com.itachallenge.challenge.service.IFavoriteService;
+import com.itachallenge.challenge.service.IJwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class FavoriteControllerTest {
+
+    private IFavoriteService favoriteService;
+    private IJwtService jwtService;
+    private FavoriteController favoriteController;
+
+    @BeforeEach
+    void setUp() {
+        favoriteService = mock(IFavoriteService.class);
+        jwtService = mock(IJwtService.class);
+        favoriteController = new FavoriteController();
+        favoriteController.favoriteService = favoriteService;
+        favoriteController.jwtService = jwtService;
+    }
+
+    @Test
+    void addFavorite_success_200() {
+        String challengeId = "123e4567-e89b-12d3-a456-426614174000";
+        String userId = "321e4567-e89b-12d3-a456-426614174000";
+        String authHeader = "Bearer token";
+        FavoriteDto dto = new FavoriteDto(true, 1);
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+        when(favoriteService.addChallengeToFavorites(challengeId, userId)).thenReturn(Mono.just(dto));
+
+        Mono<ResponseEntity<FavoriteDto>> result = favoriteController.addFavorite(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectNextMatches(response -> response.getStatusCode().is2xxSuccessful() &&
+                        response.getBody().isFavorite() && response.getBody().getTimesFavorited() == 1)
+                .verifyComplete();
+    }
+
+    @Test
+    void addFavorite_missingAuthHeader_400() {
+        String challengeId = "123e4567-e89b-12d3-a456-426614174000";
+        String authHeader = null;
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenThrow(new JwtException("Missing header"));
+
+        Mono<ResponseEntity<FavoriteDto>> result = favoriteController.addFavorite(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+
+    @Test
+    void addFavorite_invalidAuthHeader_400() {
+        String challengeId = "123e4567-e89b-12d3-a456-426614174000";
+        String authHeader = "invalid";
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenThrow(new JwtException("Invalid header"));
+
+        Mono<ResponseEntity<FavoriteDto>> result = favoriteController.addFavorite(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+
+    @Test
+    void addFavorite_challengeNotFound_404() {
+        String challengeId = "not-found-id";
+        String userId = "321e4567-e89b-12d3-a456-426614174000";
+        String authHeader = "Bearer token";
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+        when(favoriteService.addChallengeToFavorites(challengeId, userId))
+                .thenReturn(Mono.error(new ChallengeNotFoundException("Challenge not found")));
+
+        Mono<ResponseEntity<FavoriteDto>> result = favoriteController.addFavorite(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectError(ChallengeNotFoundException.class)
+                .verify();
+    }
+
+    @Test
+    void addFavorite_internalServerError_500() {
+        String challengeId = "123e4567-e89b-12d3-a456-426614174000";
+        String userId = "321e4567-e89b-12d3-a456-426614174000";
+        String authHeader = "Bearer token";
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+        when(favoriteService.addChallengeToFavorites(challengeId, userId))
+                .thenReturn(Mono.error(new InternalServerErrorException("Internal error")));
+
+        Mono<ResponseEntity<FavoriteDto>> result = favoriteController.addFavorite(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectError(InternalServerErrorException.class)
+                .verify();
+    }
+
+    @Test
+    void removeFavorite_success_200() {
+        String challengeId = "123e4567-e89b-12d3-a456-426614174000";
+        String userId = "321e4567-e89b-12d3-a456-426614174000";
+        String authHeader = "Bearer token";
+        FavoriteDto dto = new FavoriteDto(false, 0);
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+        when(favoriteService.removeChallengeFromFavorites(challengeId, userId)).thenReturn(Mono.just(dto));
+
+        Mono<ResponseEntity<FavoriteDto>> result = favoriteController.removeFavorite(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectNextMatches(response -> response.getStatusCode().is2xxSuccessful() &&
+                        !response.getBody().isFavorite() && response.getBody().getTimesFavorited() == 0)
+                .verifyComplete();
+    }
+
+    @Test
+    void removeFavorite_missingAuthHeader_400() {
+        String challengeId = "123e4567-e89b-12d3-a456-426614174000";
+        String authHeader = null;
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenThrow(new JwtException("Missing header"));
+
+        Mono<ResponseEntity<FavoriteDto>> result = favoriteController.removeFavorite(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+
+    @Test
+    void removeFavorite_challengeNotFound_404() {
+        String challengeId = "not-found-id";
+        String userId = "321e4567-e89b-12d3-a456-426614174000";
+        String authHeader = "Bearer token";
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+        when(favoriteService.removeChallengeFromFavorites(challengeId, userId))
+                .thenReturn(Mono.error(new ChallengeNotFoundException("Challenge not found")));
+
+        Mono<ResponseEntity<FavoriteDto>> result = favoriteController.removeFavorite(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectError(ChallengeNotFoundException.class)
+                .verify();
+    }
+
+    @Test
+    void removeFavorite_internalServerError_500() {
+        String challengeId = "123e4567-e89b-12d3-a456-426614174000";
+        String userId = "321e4567-e89b-12d3-a456-426614174000";
+        String authHeader = "Bearer token";
+
+        when(jwtService.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+        when(favoriteService.removeChallengeFromFavorites(challengeId, userId))
+                .thenReturn(Mono.error(new InternalServerErrorException("Internal error")));
+
+        Mono<ResponseEntity<FavoriteDto>> result = favoriteController.removeFavorite(challengeId, authHeader);
+
+        StepVerifier.create(result)
+                .expectError(InternalServerErrorException.class)
+                .verify();
+    }
+}


### PR DESCRIPTION
This PR is a new branch based on #883 to rename the branch name.

This PR is a continuation of https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/876

What was done:

- Created a new FavoriteController: Extracted all favorite-related endpoints from ChallengeController to this new controller.
- Refactored endpoints: Moved and updated existing favorites endpoints to be handled by FavoriteController.
- Updated references: Adjusted service, interface, and usage references in the codebase to use the new controller.
- Added new tests: Created comprehensive tests for FavoriteController to ensure correct behavior.

Why:

- To improve code maintainability and follow the single-responsibility principle by decoupling favorite-specific logic from the general challenge logic.
- To make the codebase cleaner and easier to extend or debug in the future.

How:

- Moved favorite-related REST endpoints and their logic from ChallengeController to FavoriteController.
- Updated the service layer and removed unnecessary methods from IChallengeService and its implementation.
- Added a new test class dedicated to FavoriteController, migrating and adapting relevant tests from ChallengeControllerTest.