### PR TITLE
feat (user): Modifing the method of saving solution to connect to micro.challenge (#417)

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -2,10 +2,10 @@ package com.itachallenge.user.service;
 
 import com.itachallenge.user.document.SolutionAttemptDocument;
 import com.itachallenge.user.document.UserSolutionDocument;
-import com.itachallenge.user.dto.*;
 import com.itachallenge.user.document.enums.ChallengeStatus;
+import com.itachallenge.user.dto.UserSolutionRequestDto;
+import com.itachallenge.user.dto.UserSolutionResponseDto;
 import com.itachallenge.user.exception.BadRequestException;
-import com.itachallenge.user.exception.NotFoundException;
 import com.itachallenge.user.exception.UnmodificableSolutionException;
 import com.itachallenge.user.repository.IUserSolutionRepository;
 import org.slf4j.Logger;
@@ -21,11 +21,11 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
 
     private static final Logger log = LoggerFactory.getLogger(UserSolutionServiceImpl.class);
     private final IUserSolutionRepository userSolutionRepository;
-    private final UserService userService;
+    private final IChallengeService challengeService;
 
-    public UserSolutionServiceImpl(IUserSolutionRepository userSolutionRepository, UserService userService) {
+    public UserSolutionServiceImpl(IUserSolutionRepository userSolutionRepository, IChallengeService challengeService) {
         this.userSolutionRepository = userSolutionRepository;
-        this.userService = userService;
+        this.challengeService = challengeService;
     }
 
     @Override
@@ -68,7 +68,8 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
                     }
                     existingSolution.setSolutionAttemptDocument(solutionAttempt);
                     existingSolution.setStatus(challengeStatus);
-                    return userSolutionRepository.save(existingSolution);
+                    return userSolutionRepository.save(existingSolution)
+                            .flatMap(savedSolution -> handlePostSave(savedSolution, challengeStatus, challengeUuid));
                 })
                 .switchIfEmpty(Mono.defer(() -> {
                     UserSolutionDocument userSolutionDocument = UserSolutionDocument.builder()
@@ -79,32 +80,37 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
                             .status(challengeStatus)
                             .solutionAttemptDocument(solutionAttempt)
                             .build();
-                    return userSolutionRepository.save(userSolutionDocument);
+                    return userSolutionRepository.save(userSolutionDocument)
+                            .flatMap(savedSolution -> handlePostSave(savedSolution, challengeStatus, challengeUuid));
                 }));
     }
-    
+
+    private Mono<UserSolutionDocument> handlePostSave(UserSolutionDocument savedSolution, ChallengeStatus status, UUID challengeUuid) {
+        if (ChallengeStatus.ENDED.equals(status)) {
+            return challengeService.addChallengeToSolved(challengeUuid.toString())
+                    .thenReturn(savedSolution);
+        }
+        return Mono.just(savedSolution);
+    }
+
     @Override
     public Flux<UserSolutionResponseDto> getAllSolutionsByUser(String userId) {
-        return  validateAndParseUuid(userId)
+        return validateAndParseUuid(userId)
                 .flatMapMany(uuid ->
-                userService.getUserById(userId)
-                .switchIfEmpty(Mono.error(new NotFoundException("User not found")))
-                .thenMany(
-        
-                userSolutionRepository
-                        .findAllByUserId(UUID.fromString(userId))
-                        .map(doc -> {
-                            log.info("→ Solution retrieved for user {}: challengeId={}", userId, doc.getChallengeId());
-                            return UserSolutionResponseDto.builder()
-                                            .userId(doc.getUserId().toString())
-                                            .challengeId(doc.getChallengeId().toString())
-                                            .languageId(doc.getLanguageId().toString())
-                                            .solutionText(doc.getSolutionAttemptDocument().getSolutionText())
-                                            .build();
-                                }
-                        )));
+                        userSolutionRepository
+                                .findAllByUserId(UUID.fromString(userId))
+                                .map(doc -> {
+                                            log.info("→ Solution retrieved for user {}: challengeId={}", userId, doc.getChallengeId());
+                                            return UserSolutionResponseDto.builder()
+                                                    .userId(doc.getUserId().toString())
+                                                    .challengeId(doc.getChallengeId().toString())
+                                                    .languageId(doc.getLanguageId().toString())
+                                                    .solutionText(doc.getSolutionAttemptDocument().getSolutionText())
+                                                    .build();
+                                        }
+                                ));
     }
-    
+
     private Mono<UUID> validateAndParseUuid(String userId) {
         if (userId == null || userId.trim().isEmpty()) {
             return Mono.error(new BadRequestException("The 'userId' parameter cannot be null or empty."));
@@ -116,6 +122,3 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
         }
     }
 }
-
-
-

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerSpringTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerSpringTest.java
@@ -2,16 +2,20 @@ package com.itachallenge.user.controller;
 
 import com.itachallenge.user.dto.UserSolutionRequestDto;
 import com.itachallenge.user.dto.UserSolutionResponseDto;
-import org.junit.jupiter.api.Assertions;
+import com.itachallenge.user.service.IUserSolutionService;
+import com.itachallenge.user.service.UserService;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -21,6 +25,12 @@ class UserControllerSpringTest {
     @Autowired
     private WebTestClient webTestClient;
 
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private IUserSolutionService userSolutionService;
+
     String uri = "/itachallenge/api/v1/user/solution";
     String solution = "This is the submitted solution";
     String userId = UUID.randomUUID().toString();
@@ -28,50 +38,38 @@ class UserControllerSpringTest {
     String languageId = UUID.randomUUID().toString();
 
     @Test
-    void addSolution_WithCorrectParameters_ExpectsReturn200Test() {
+    void testAddSolution() {
+        UserSolutionRequestDto requestDto = UserSolutionRequestDto.builder()
+                .userId(userId)
+                .challengeId(challengeId)
+                .languageId(languageId)
+                .status("ENDED")
+                .solutionText(solution)
+                .build();
 
-        UserSolutionRequestDto userSolutionRequestDto = new UserSolutionRequestDto(
-                userId, challengeId, languageId, "ENDED", solution);
-        UserSolutionResponseDto userSolutionResponseDto = new UserSolutionResponseDto(
-                userId, challengeId, languageId, solution);
+        UserSolutionResponseDto responseDto = UserSolutionResponseDto.builder()
+                .userId(userId)
+                .challengeId(challengeId)
+                .languageId(languageId)
+                .solutionText(solution)
+                .build();
+
+        Mockito.when(userSolutionService.addSolution(Mockito.any(UserSolutionRequestDto.class)))
+                .thenReturn(Mono.just(responseDto));
 
         webTestClient.put()
                 .uri(uri)
-                .bodyValue(userSolutionRequestDto)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestDto)
                 .exchange()
                 .expectStatus().isOk()
-                .expectBody(Map.class)
-                .consumeWith(response ->{
-                    Assertions.assertNotNull(response.getResponseBody());
-                    assert response.getResponseBody().containsKey("uuid_user");
-                    assert response.getResponseBody().containsKey("uuid_challenge");
-                    assert response.getResponseBody().containsKey("uuid_language");
-
-                    assert response.getResponseBody().get("uuid_language").equals(userSolutionResponseDto.getLanguageId());
-                    assert response.getResponseBody().get("uuid_challenge").equals(userSolutionResponseDto.getChallengeId());
-                    assert response.getResponseBody().get("uuid_user").equals(userSolutionResponseDto.getUserId());
-                    assert response.getResponseBody().get("solution_text").equals(userSolutionResponseDto.getSolutionText());
+                .expectBody(UserSolutionResponseDto.class)
+                .value(res -> {
+                    assert res.getUserId().equals(userId);
+                    assert res.getChallengeId().equals(challengeId);
+                    assert res.getLanguageId().equals(languageId);
+                    assert res.getSolutionText().equals(solution);
                 });
-    }
-
-    @Test
-    void addSolution_WithEmptySolution_ReturnBadRequestError_Test() {
-
-        UserSolutionRequestDto userSolutionRequestDto1 = new UserSolutionRequestDto(
-                userId, challengeId, languageId, "ENDED", "");
-        UserSolutionRequestDto userSolutionRequestDto2 = new UserSolutionRequestDto(
-                userId, challengeId, languageId, "ENDED", null);
-        UserSolutionRequestDto userSolutionRequestDto3 = new UserSolutionRequestDto(
-                userId, challengeId, languageId, "ENDED", " ");
-        List<UserSolutionRequestDto> userSolutionRequestDtos = List.of(userSolutionRequestDto1, userSolutionRequestDto2, userSolutionRequestDto3);
-
-        for(UserSolutionRequestDto userSolutionRequestDto : userSolutionRequestDtos){
-            webTestClient.put()
-                    .uri(uri)
-                    .bodyValue(userSolutionRequestDto)
-                    .exchange()
-                    .expectStatus().isBadRequest();
-        }
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -25,6 +25,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
@@ -36,13 +37,13 @@ import java.util.UUID;
 class UserSolutionServiceImplTest {
 
     @Mock
-    IUserSolutionRepository userSolutionRepository;
-    
+    private IUserSolutionRepository userSolutionRepository;
+
     @Mock
-    UserService userService;
-    
+    private IChallengeService challengeService;
+
     @InjectMocks
-    UserSolutionServiceImpl userSolutionService;
+    private UserSolutionServiceImpl userSolutionService;
 
     private String solutionText;
     private UUID userUuid;
@@ -80,21 +81,42 @@ class UserSolutionServiceImplTest {
     @Test
     void addSolutionNewSolutionWithStatusEnded_test() {
 
-        when(userSolutionRepository.save(any(UserSolutionDocument.class)))
-                .thenReturn(Mono.just(userSolutionDocument));
+        UUID userUuid = UUID.randomUUID();
+        UUID challengeUuid = UUID.randomUUID();
+        UUID languageUuid = UUID.randomUUID();
+        String solutionText = "sample solution text";
+
+        UserSolutionRequestDto userSolutionRequestDto = UserSolutionRequestDto.builder()
+                .userId(userUuid.toString())
+                .challengeId(challengeUuid.toString())
+                .languageId(languageUuid.toString())
+                .solutionText(solutionText)
+                .status("ENDED")
+                .build();
+
         when(userSolutionRepository.findByUserIdAndChallengeIdAndLanguageId(userUuid, challengeUuid, languageUuid))
+                .thenReturn(Mono.empty());
+
+        when(userSolutionRepository.save(any(UserSolutionDocument.class)))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        when(challengeService.addChallengeToSolved(challengeUuid.toString()))
                 .thenReturn(Mono.empty());
 
         Mono<UserSolutionResponseDto> resultMono = userSolutionService.addSolution(userSolutionRequestDto);
 
         StepVerifier.create(resultMono)
-                .expectNextMatches(userSolutionResponseDto ->
-                        userSolutionResponseDto.getUserId().equals(userUuid.toString())
-                                && userSolutionResponseDto.getChallengeId().equals(challengeUuid.toString())
-                                && userSolutionResponseDto.getLanguageId().equals(languageUuid.toString())
-                                && userSolutionResponseDto.getSolutionText().equals(solutionText))
+                .assertNext(dto -> {
+                    assertEquals(userUuid.toString(), dto.getUserId(), "UserId mismatch");
+                    assertEquals(challengeUuid.toString(), dto.getChallengeId(), "ChallengeId mismatch");
+                    assertEquals(languageUuid.toString(), dto.getLanguageId(), "LanguageId mismatch");
+                    assertEquals(solutionText, dto.getSolutionText(), "SolutionText mismatch");
+                })
                 .verifyComplete();
+
+        verify(userSolutionRepository).findByUserIdAndChallengeIdAndLanguageId(userUuid, challengeUuid, languageUuid);
         verify(userSolutionRepository).save(any(UserSolutionDocument.class));
+        verify(challengeService).addChallengeToSolved(challengeUuid.toString());
     }
 
     @DisplayName("UserSolutionServiceImpTest - addSolution throws IllegalArgumentException when new status is empty")
@@ -117,29 +139,76 @@ class UserSolutionServiceImplTest {
         verifyNoInteractions(userSolutionRepository);
     }
 
-    @DisplayName("UserSolutionServiceImpTest - addSolution saves a solution when new status is ENDED and existing solution had status null")
+    @DisplayName("UserSolutionServiceImplTest - addSolution saves a solution when new status is ENDED and existing solution had status null")
     @Test
     void addSolutionWithEndedStatusWhenExistingSolutionExistsValid_test() {
-        UserSolutionDocument existingUserSolutionDocument = userSolutionDocument;
-        existingUserSolutionDocument.setStatus(null);
 
-        when(userSolutionRepository.findByUserIdAndChallengeIdAndLanguageId(
-                any(UUID.class), any(UUID.class), any(UUID.class)))
+        UUID userUuid = UUID.randomUUID();
+        UUID challengeUuid = UUID.randomUUID();
+        UUID languageUuid = UUID.randomUUID();
+        String solutionText = "updated solution text";
+
+
+        UserSolutionRequestDto userSolutionRequestDto = UserSolutionRequestDto.builder()
+                .userId(userUuid.toString())
+                .challengeId(challengeUuid.toString())
+                .languageId(languageUuid.toString())
+                .solutionText(solutionText)
+                .status("ENDED")
+                .build();
+
+
+        UserSolutionDocument existingUserSolutionDocument = UserSolutionDocument.builder()
+                .uuid(UUID.randomUUID())
+                .userId(userUuid)
+                .challengeId(challengeUuid)
+                .languageId(languageUuid)
+                .status(null)
+                .solutionAttemptDocument(
+                        SolutionAttemptDocument.builder()
+                                .uuid(UUID.randomUUID())
+                                .solutionText("old solution")
+                                .build()
+                )
+                .build();
+
+        UserSolutionDocument savedDocument = UserSolutionDocument.builder()
+                .uuid(existingUserSolutionDocument.getUuid())
+                .userId(userUuid)
+                .challengeId(challengeUuid)
+                .languageId(languageUuid)
+                .status(ChallengeStatus.ENDED)
+                .solutionAttemptDocument(
+                        SolutionAttemptDocument.builder()
+                                .uuid(UUID.randomUUID())
+                                .solutionText(solutionText)
+                                .build()
+                )
+                .build();
+
+        when(userSolutionRepository.findByUserIdAndChallengeIdAndLanguageId(userUuid, challengeUuid, languageUuid))
                 .thenReturn(Mono.just(existingUserSolutionDocument));
-        when(userSolutionRepository.save(any(UserSolutionDocument.class)))
-                .thenReturn(Mono.just(userSolutionDocument));
 
+        when(userSolutionRepository.save(any(UserSolutionDocument.class)))
+                .thenReturn(Mono.just(savedDocument));
+
+        when(challengeService.addChallengeToSolved(challengeUuid.toString()))
+                .thenReturn(Mono.empty());
 
         Mono<UserSolutionResponseDto> resultMono = userSolutionService.addSolution(userSolutionRequestDto);
 
         StepVerifier.create(resultMono)
-                .expectNextMatches(userSolutionResponseDto ->
-                        userSolutionResponseDto.getUserId().equals(userUuid.toString())
-                                && userSolutionResponseDto.getChallengeId().equals(challengeUuid.toString())
-                                && userSolutionResponseDto.getLanguageId().equals(languageUuid.toString())
-                                && userSolutionResponseDto.getSolutionText().equals(solutionText))
+                .assertNext(dto -> {
+                    assertEquals(userUuid.toString(), dto.getUserId());
+                    assertEquals(challengeUuid.toString(), dto.getChallengeId());
+                    assertEquals(languageUuid.toString(), dto.getLanguageId());
+                    assertEquals(solutionText, dto.getSolutionText());
+                })
                 .verifyComplete();
+
+        verify(userSolutionRepository).findByUserIdAndChallengeIdAndLanguageId(userUuid, challengeUuid, languageUuid);
         verify(userSolutionRepository).save(any(UserSolutionDocument.class));
+        verify(challengeService).addChallengeToSolved(challengeUuid.toString());
     }
 
     @DisplayName("UserSolutionServiceImpTest - addSolution returns UnmodificableSolutionException when existing solution's status is already 'ENDED'")
@@ -176,29 +245,24 @@ class UserSolutionServiceImplTest {
         verifyNoInteractions(userSolutionRepository);
 
     }
-    
-    @DisplayName("getAllSolutionsByUser throws a empty array if there are no solutions for the user")
+
+    @DisplayName("getAllSolutionsByUser throws a NotFoundException if there are no solutions for the user")
     @Test
     void getAllSolutionsByUser_noSolutionsFound_test() {
-        when(userService.getUserById(userUuid.toString())).thenReturn(Mono.just(
-                com.itachallenge.user.document.UserDocument.builder().uuid(userUuid).build()
-        ));
-        
         when(userSolutionRepository.findAllByUserId(userUuid))
                 .thenReturn(Flux.empty());
-        
+
         Flux<UserSolutionResponseDto> resultFlux = userSolutionService
                 .getAllSolutionsByUser(userUuid.toString());
-        
+
         StepVerifier.create(resultFlux)
                 .expectNextCount(0)
                 .verifyComplete();
-        
-        verify(userService).getUserById(userUuid.toString());
+
         verify(userSolutionRepository).findAllByUserId(userUuid);
     }
-    
-    @DisplayName("getAllSolutionsByUser returns all solutions when user exist")
+
+    @DisplayName("getAllSolutionsByUser returns all solutions")
     @Test
     void getAllSolutionsByUser_returnsSolutions_test() {
         UserSolutionDocument doc1 = UserSolutionDocument.builder()
@@ -215,17 +279,13 @@ class UserSolutionServiceImplTest {
                 .solutionAttemptDocument(SolutionAttemptDocument.builder()
                         .solutionText("Solution 2").build())
                 .build();
-        
-        when(userService.getUserById(userUuid.toString()))
-                .thenReturn(Mono.just(
-                        com.itachallenge.user.document.UserDocument.builder().uuid(userUuid).build()
-                ));
+
         when(userSolutionRepository.findAllByUserId(userUuid))
                 .thenReturn(Flux.just(doc1, doc2));
-        
+
         Flux<UserSolutionResponseDto> resultFlux = userSolutionService
                 .getAllSolutionsByUser(userUuid.toString());
-        
+
         StepVerifier.create(resultFlux)
                 .expectNextMatches(dto ->
                         dto.getUserId().equals(userUuid.toString()) &&
@@ -235,73 +295,53 @@ class UserSolutionServiceImplTest {
                         dto.getUserId().equals(userUuid.toString()) &&
                                 dto.getSolutionText().equals("Solution 2"))
                 .verifyComplete();
-        
-        verify(userService).getUserById(userUuid.toString());
+
         verify(userSolutionRepository).findAllByUserId(userUuid);
     }
-    
-    @DisplayName("getAllSolutionsByUser throws a NotFoundException if the user does not exist")
-    @Test
-    void getAllSolutionsByUser_userNotFound_test() {
-        when(userService.getUserById(userUuid.toString())).thenReturn(Mono.empty());
-        when(userSolutionRepository.findAllByUserId(userUuid)).thenReturn(Flux.empty());
-        
-        Flux<UserSolutionResponseDto> resultFlux =
-                userSolutionService.getAllSolutionsByUser(userUuid.toString());
-        
-        StepVerifier.create(resultFlux)
-                .expectErrorMatches(ex ->
-                        ex instanceof NotFoundException &&
-                                ex.getMessage().equals("User not found"))
-                .verify();
-        
-        verify(userService).getUserById(userUuid.toString());
-    }
-    
-    
+
     @Test
     @DisplayName("getAllSolutionsByUser(null) emits BadRequestException for null userId")
     void getAllSolutionsByUser_nullUserId_throwsBadRequest() {
         Flux<UserSolutionResponseDto> resultFlux = userSolutionService.getAllSolutionsByUser(null);
-        
+
         StepVerifier.create(resultFlux)
                 .expectErrorMatches(ex ->
                         ex instanceof BadRequestException &&
                                 ex.getMessage().equals("The 'userId' parameter cannot be null or empty.")
                 )
                 .verify();
-        
+
         verify(userSolutionRepository, never()).findAllByUserId(any());
     }
-    
+
     @Test
     @DisplayName("getAllSolutionsByUser(\"\") emits BadRequestException for empty userId")
     void getAllSolutionsByUser_emptyUserId_throwsBadRequest() {
         Flux<UserSolutionResponseDto> resultFlux = userSolutionService.getAllSolutionsByUser("   ");
-        
+
         StepVerifier.create(resultFlux)
                 .expectErrorMatches(ex ->
                         ex instanceof BadRequestException &&
                                 ex.getMessage().equals("The 'userId' parameter cannot be null or empty.")
                 )
                 .verify();
-        
+
         verify(userSolutionRepository, never()).findAllByUserId(any());
     }
-    
+
     @Test
     @DisplayName("getAllSolutionsByUser(invalid) emits BadRequestException for malformed UUID")
     void getAllSolutionsByUser_invalidFormat_throwsBadRequest() {
         String bad = "not-a-uuid";
         Flux<UserSolutionResponseDto> resultFlux = userSolutionService.getAllSolutionsByUser(bad);
-        
+
         StepVerifier.create(resultFlux)
                 .expectErrorMatches(ex ->
                         ex instanceof BadRequestException &&
                                 ex.getMessage().equals("The 'userId' parameter must be a valid UUID: " + bad)
                 )
                 .verify();
-        
+
         verify(userSolutionRepository, never()).findAllByUserId(any());
     }
 }


### PR DESCRIPTION
This PR contains the changes required for the method `addSolution`, that's in charge of saving the user solutions also to send a request to the micro.challenge to increase the counter timesSolved.

### Changes

- **UPDATE** - `UserSolutionServiceImpl` : A flatmap has been added to call the method `addChallengeToSolved` from `ChallengeServiceImpl` in charge to call the endpoint in challenge.micro to increase the counter timesSolved.
- **UPDATE** - `UserControllerSpringTest` : One test has been modified to adapt to the changes applied in this PR.
- **UPDATE** - `UserServiceImplTest` : Two test has been modified to adapt to the changes applied in this PR.