### PR TITLE
#475 [BE] Hardcodear la respuesta

### DIFF
--- a/itachallenge-auth/src/main/resources/application.yml
+++ b/itachallenge-auth/src/main/resources/application.yml
@@ -45,7 +45,7 @@ uri_validate_token : https://dev.sso.itawiki.eurecatacademy.org/api/v1/tokens/va
 user:
   service:
     url: http://apisix-gateway:9080 # IN PRODUCTION
-    #url: http://172.17.0.2:8764 # LOCAL IP
+    #url: http://localhost:8761 # LOCAL IP
 
 logging:
   level:

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -126,6 +126,7 @@ public class ChallengeServiceImpl implements IChallengeService {
                 ChallengeDto.class);
 
         return countMono.zipWith(challengeDtoFlux.collectList(), (totalCount, challenges) -> {
+            challenges.forEach(dto -> dto.setCreationDate("2025-06-05T00:00:00Z"));
             ChallengeDto[] challengeArray = challenges.toArray(new ChallengeDto[0]);
             return new GenericResultDto<>(offset, limit, totalCount.intValue(), challengeArray);
         }).onErrorResume(e -> Mono.just(new GenericResultDto<>(offset, limit, 0, new ChallengeDto[0])));


### PR DESCRIPTION
Esta PR Hardcodea la fecha de regitro del reto para el FE. La API de Get de Challenge tiene de devolver la fecha de creación.
En la clase ChallengeServiceImpl
En el metodo getAllChallenges
He añadido challenges.forEach(dto -> dto.setCreationDate("2025-06-05T00:00:00Z"));

