### PR TITLE
feat(challenges) Save and return challenge creation date (#478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+### [itachallenge-challenge-2.0.5-RELEASE] - 2023-06-17
+
+### Added
+-Save and return challenge creation date (Taiga [#478], PR [#902])
+
+### [itachallenge-challenge-2.0.4-RELEASE] - 2023-06-03
 
 ### Added
 - Add validation to verify that the provided user ID exists for the getAllSolutionsByUser endpoint. (Taiga [#437], PR [#889])
@@ -40,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Secured POST endpoint `addChallenge` for creating a challenge in Challenge microservice (PR #871)
 - Secured PUT endpoint for updating a challenge in Challenge microservice (PR #875)
 
-### [itachallenge-challenge-2.0.4-RELEASE] - 2023-11-12
+### [itachallenge-challenge-2.0.3-RELEASE] - 2023-11-12
 * Issue #441b: Added Mongock to tracing database changes
 
 ### [itachallenge-challenge-1.6.0-RELEASE] - 2023-05-16

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -278,7 +278,7 @@ public class ChallengeServiceImpl implements IChallengeService {
                 .uuid(UUID.randomUUID())
                 .title(dto.getChallengeTitle())
                 .level(dto.getLevel().toString())
-                .creationDate(LocalDateTime.ofInstant(Instant.now(), ZoneId.of("Europe/Madrid")))
+                .creationDate(LocalDateTime.now())
                 .detail(detail)
                 .languages(Set.of(language))
                 .solutions(List.of(solutionId))

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -25,6 +25,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.lang.reflect.Field;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -275,6 +278,7 @@ public class ChallengeServiceImpl implements IChallengeService {
                 .uuid(UUID.randomUUID())
                 .title(dto.getChallengeTitle())
                 .level(dto.getLevel().toString())
+                .creationDate(LocalDateTime.ofInstant(Instant.now(), ZoneId.of("Europe/Madrid")))
                 .detail(detail)
                 .languages(Set.of(language))
                 .solutions(List.of(solutionId))


### PR DESCRIPTION
#478 Guardar la fecha de creación de un reto en la base de datos al ser creado. 
En la clase: ChallengeServiceImpl
En el metodo: buildChallengeDocument
He añadido: .creationDate(LocalDateTime.ofInstant(Instant.now(), ZoneId.of("Europe/Madrid")))