### PR TITLE
feat(tag): add language field and findByLanguageUuid method (#481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [itachallenge-challenge-2.0.4-RELEASE] - 2023-06-03
 
 ### Added
-- Added `idLanguage` field to `Tag` model and `findByLanguageUuid` method to the Tag repository to filter tags by language UUID. (Taiga [#481], PR [#900])
 - Add validation to verify that the provided user ID exists for the getAllSolutionsByUser endpoint. (Taiga [#437], PR [#889])
 - FavoriteController and extracted endpoints from ChallengeController. (Taiga [#418], PR [#886]) 
 - POST endpoint in Auth microservice to allow user role change at runtime (Taiga [#404], PR [#882])  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [itachallenge-challenge-2.0.4-RELEASE] - 2023-06-03
 
 ### Added
+- Added `idLanguage` field to `Tag` model and `findByLanguageUuid` method to the Tag repository to filter tags by language UUID. (Taiga [#481], PR [#900])
 - Add validation to verify that the provided user ID exists for the getAllSolutionsByUser endpoint. (Taiga [#437], PR [#889])
 - FavoriteController and extracted endpoints from ChallengeController. (Taiga [#418], PR [#886]) 
 - POST endpoint in Auth microservice to allow user role change at runtime (Taiga [#404], PR [#882])  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-challenge-2.2.0-RELEASE] - 2025-06-19
+
+### Added
+- Added `idLanguage` field to `Tag` model and `findByLanguageUuid` method to the Tag repository to filter tags by language UUID. (Taiga [#481], PR [#906])
+
 ### [itachallenge-challenge-2.1.1-RELEASE] - 2025-06-18
 
 #### Fixed

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -5,7 +5,7 @@ MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
 MICROSERVICE_VERSION_itachallenge-user=1.1.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
-MICROSERVICE_VERSION_itachallenge-challenge=2.1.1-RELEASE
+MICROSERVICE_VERSION_itachallenge-challenge=2.2.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-document=itachallenge-document
 MICROSERVICE_VERSION_itachallenge-document=1.0.1-RELEASE

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/config/dbchangelog/DatabaseUpdater.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/config/dbchangelog/DatabaseUpdater.java
@@ -106,13 +106,9 @@ public class DatabaseUpdater {
                 update(STATE_FIELD, "ACTIVE"),
                 COLLECTION_NAME
         ).doOnSuccess(result -> {
-                        if (result != null && result.wasAcknowledged()) {
-                            logger.info("Matched count: {}", result.getMatchedCount());
-                            logger.info("Modified count: {}", result.getModifiedCount());
-                        } else {
-                            logger.warn("Update result was null or not acknowledged");
-                        }
-                    }).doOnError(error -> logger.error(ERROR_UPDATE, error.getMessage())).subscribe();
+            logger.info("Matched count: {}", result.getMatchedCount());
+            logger.info("Modified count: {}", result.getModifiedCount());
+        }).doOnError(error -> logger.error(ERROR_UPDATE, error.getMessage())).subscribe();
     }
 
     // Method to remove a field from all documents in a collection
@@ -121,12 +117,8 @@ public class DatabaseUpdater {
         reactiveMongoTemplate.updateMulti(query, new Update().unset(STATE_FIELD), COLLECTION_NAME)
                 .defaultIfEmpty(UpdateResult.unacknowledged())
                 .doOnSuccess(result -> {
-                    if (result != null && result.wasAcknowledged()) {
-                        logger.info("Matched count: {}", result.getMatchedCount());
-                        logger.info("Modified count: {}", result.getModifiedCount());
-                    } else {
-                        logger.warn("Update result was null or not acknowledged");
-                    }
+                    logger.info("Matched count: {}", result.getMatchedCount());
+                    logger.info("Modified count: {}", result.getModifiedCount());
                 })
                 .doOnError(error -> logger.error(ERROR_UPDATE, error.getMessage()))
                 .subscribe();

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/config/dbchangelog/DatabaseUpdater.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/config/dbchangelog/DatabaseUpdater.java
@@ -106,9 +106,13 @@ public class DatabaseUpdater {
                 update(STATE_FIELD, "ACTIVE"),
                 COLLECTION_NAME
         ).doOnSuccess(result -> {
-            logger.info("Matched count: {}", result.getMatchedCount());
-            logger.info("Modified count: {}", result.getModifiedCount());
-        }).doOnError(error -> logger.error(ERROR_UPDATE, error.getMessage())).subscribe();
+                        if (result != null && result.wasAcknowledged()) {
+                            logger.info("Matched count: {}", result.getMatchedCount());
+                            logger.info("Modified count: {}", result.getModifiedCount());
+                        } else {
+                            logger.warn("Update result was null or not acknowledged");
+                        }
+                    }).doOnError(error -> logger.error(ERROR_UPDATE, error.getMessage())).subscribe();
     }
 
     // Method to remove a field from all documents in a collection
@@ -117,8 +121,12 @@ public class DatabaseUpdater {
         reactiveMongoTemplate.updateMulti(query, new Update().unset(STATE_FIELD), COLLECTION_NAME)
                 .defaultIfEmpty(UpdateResult.unacknowledged())
                 .doOnSuccess(result -> {
-                    logger.info("Matched count: {}", result.getMatchedCount());
-                    logger.info("Modified count: {}", result.getModifiedCount());
+                    if (result != null && result.wasAcknowledged()) {
+                        logger.info("Matched count: {}", result.getMatchedCount());
+                        logger.info("Modified count: {}", result.getModifiedCount());
+                    } else {
+                        logger.warn("Update result was null or not acknowledged");
+                    }
                 })
                 .doOnError(error -> logger.error(ERROR_UPDATE, error.getMessage()))
                 .subscribe();

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/TagDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/TagDocument.java
@@ -23,5 +23,7 @@ public class TagDocument {
     @Field(name="tag_description")
     private String tagDescription;
 
+    @Field(name = "language")
+    private UUID idLanguage;
 
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/TagDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/document/TagDocument.java
@@ -23,7 +23,7 @@ public class TagDocument {
     @Field(name="tag_description")
     private String tagDescription;
 
-    @Field(name = "language")
-    private UUID idLanguage;
+    @Field(name = "language_id")
+    private UUID languageId;
 
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/TagDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/TagDto.java
@@ -24,7 +24,7 @@ public class TagDto {
     @JsonProperty(value = "tag_description", index = 2)
     private String tagDescription;
 
-    @JsonProperty("uuid_language")
-    private UUID idLanguage;
+    @JsonProperty("language_id")
+    private UUID languageId;
 
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/TagDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/TagDto.java
@@ -23,4 +23,8 @@ public class TagDto {
 
     @JsonProperty(value = "tag_description", index = 2)
     private String tagDescription;
+
+    @JsonProperty("uuid_language")
+    private UUID idLanguage;
+
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/helper/DocumentToDtoConverter.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/helper/DocumentToDtoConverter.java
@@ -68,7 +68,8 @@ public class DocumentToDtoConverter<S,D> {
             mapper.createTypeMap(TagDocument.class, TagDto.class)
                     .addMapping(TagDocument::getIdTag,TagDto::setTagId)
                     .addMapping(TagDocument::getTagName, TagDto::setTagName)
-                    .addMapping(TagDocument::getTagDescription, TagDto::setTagDescription);
+                    .addMapping(TagDocument::getTagDescription, TagDto::setTagDescription)
+                    .addMapping(TagDocument::getIdLanguage, TagDto::setIdLanguage);
         }
 
         if (dtoClass.isAssignableFrom(ResourceDto.class) && document instanceof ResourceDocument) {

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/helper/DocumentToDtoConverter.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/helper/DocumentToDtoConverter.java
@@ -69,7 +69,7 @@ public class DocumentToDtoConverter<S,D> {
                     .addMapping(TagDocument::getIdTag,TagDto::setTagId)
                     .addMapping(TagDocument::getTagName, TagDto::setTagName)
                     .addMapping(TagDocument::getTagDescription, TagDto::setTagDescription)
-                    .addMapping(TagDocument::getIdLanguage, TagDto::setIdLanguage);
+                    .addMapping(TagDocument::getLanguageId, TagDto::setLanguageId);
         }
 
         if (dtoClass.isAssignableFrom(ResourceDto.class) && document instanceof ResourceDocument) {

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/repository/TagRepository.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/repository/TagRepository.java
@@ -10,6 +10,5 @@ import java.util.UUID;
 
 @Repository
 public interface TagRepository extends ReactiveMongoRepository<TagDocument, UUID> {
-    Mono<TagDocument> findByTagName(String tagName);
     Flux<TagDocument> findByLanguageId(UUID languageId);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/repository/TagRepository.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/repository/TagRepository.java
@@ -11,5 +11,5 @@ import java.util.UUID;
 @Repository
 public interface TagRepository extends ReactiveMongoRepository<TagDocument, UUID> {
     Mono<TagDocument> findByTagName(String tagName);
-    Flux<TagDocument> findByIdLanguage(UUID idLanguage);
+    Flux<TagDocument> findByLanguageId(UUID languageId);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/repository/TagRepository.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/repository/TagRepository.java
@@ -3,13 +3,13 @@ package com.itachallenge.challenge.repository;
 import com.itachallenge.challenge.document.TagDocument;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 @Repository
 public interface TagRepository extends ReactiveMongoRepository<TagDocument, UUID> {
-
     Mono<TagDocument> findByTagName(String tagName);
-
+    Flux<TagDocument> findByIdLanguage(UUID idLanguage);
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -572,8 +572,8 @@ class ChallengeControllerTest {
     @DisplayName("GET recibir respuesta 200 a getTags")
     void getTags_test_validRequest() {
 
-        TagDto tag1 = new TagDto(UUID.randomUUID(), "POO", "Programación orientada a objetos");
-        TagDto tag2 = new TagDto(UUID.randomUUID(), "Algoritmos", "Retos de lógica y eficiencia");
+        TagDto tag1 = new TagDto(UUID.randomUUID(), "POO", "Programación orientada a objetos",UUID.randomUUID());
+        TagDto tag2 = new TagDto(UUID.randomUUID(), "Algoritmos", "Retos de lógica y eficiencia",UUID.randomUUID());
 
         GenericResultDto<TagDto> resultDto = new GenericResultDto<>();
         resultDto.setInfo(0, 2, 2, new TagDto[]{tag1, tag2});

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/ChallengeTest.java
@@ -185,7 +185,8 @@ class ChallengeTest {
     @Test
     void getTagsTest() {
         UUID uuid = UUID.randomUUID();
-        TagDocument tag = new TagDocument(uuid, "POO", "bla bla bla");
+        UUID idLanguage = UUID.randomUUID();
+        TagDocument tag = new TagDocument(uuid, "POO", "bla bla bla",idLanguage);
 
         ChallengeDocument challenge = new ChallengeDocument(
                 null,

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/TagTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/document/TagTest.java
@@ -13,14 +13,14 @@ public class TagTest {
     @Test
     void getTestName() {
         String tagNameTest = "POO";
-        TagDocument tag = new TagDocument(null, tagNameTest, null);
+        TagDocument tag = new TagDocument(null, tagNameTest, null, UUID.randomUUID());
         assertEquals(tagNameTest, tag.getTagName());
     }
 
     @Test
     void getDescriptionTest() {
         String tagDescriptionTest = "Programació orientada a objectes";
-        TagDocument tag = new TagDocument(null, "POO", tagDescriptionTest);
+        TagDocument tag = new TagDocument(null, "POO", tagDescriptionTest, UUID.randomUUID());
         assertEquals(tagDescriptionTest, tag.getTagDescription());
     }
 
@@ -28,7 +28,7 @@ public class TagTest {
     void setTestName() {
         String firstTagName = "POO";
         String tagNameTest = "TEST";
-        TagDocument tag = new TagDocument(null, firstTagName, null);
+        TagDocument tag = new TagDocument(null, firstTagName, null, UUID.randomUUID());
         tag.setTagName(tagNameTest);
         assertEquals(tagNameTest, tag.getTagName());
     }
@@ -37,7 +37,7 @@ public class TagTest {
     void setDescriptionTest() {
         String firstTagDescription = "Programació orientada a objectes";
         String tagDescriptionTest = "TEST";
-        TagDocument tag = new TagDocument(null, "POO", firstTagDescription);
+        TagDocument tag = new TagDocument(null, "POO", firstTagDescription, UUID.randomUUID());
         tag.setTagDescription(tagDescriptionTest);
         assertEquals(tagDescriptionTest, tag.getTagDescription());
     }
@@ -48,7 +48,7 @@ public class TagTest {
         String name = "POO";
         String desc = "Programació orientada a objectes";
 
-        TagDocument tag = new TagDocument(id, name, desc);
+        TagDocument tag = new TagDocument(id, name, desc, UUID.randomUUID());
 
         assertEquals(id, tag.getIdTag());
         assertEquals(name, tag.getTagName());

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/TagDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/TagDtoTest.java
@@ -20,7 +20,7 @@ class TagDtoTest {
         String name = "POO";
         String description = "Programación orientada a objetos";
 
-        TagDto tagDto = new TagDto(id, name, description);
+        TagDto tagDto = new TagDto(id, name, description,UUID.randomUUID());
 
         assertEquals(id, tagDto.getTagId());
         assertEquals(name, tagDto.getTagName());
@@ -48,7 +48,7 @@ class TagDtoTest {
         ObjectMapper mapper = new ObjectMapper();
         TagDto tagDto = new TagDto(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
                 "Recursividad",
-                "Funciones que se llaman a sí mismas");
+                "Funciones que se llaman a sí mismas",UUID.randomUUID());
 
         String json = mapper.writeValueAsString(tagDto);
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/helper/TagDocumentToDtoConverterTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/helper/TagDocumentToDtoConverterTest.java
@@ -38,11 +38,11 @@ class TagDocumentToDtoConverterTest {
         String[] tagsNames = new String[]{"POO", "Refactorizacion"};
         String description = "bla bla bla";
 
-        tagDocument1 = new TagDocument(tagsID[0], tagsNames[0], description);
-        tagDocument2 = new TagDocument(tagsID[1], tagsNames[1], description);
+        tagDocument1 = new TagDocument(tagsID[0], tagsNames[0], description, UUID.randomUUID());
+        tagDocument2 = new TagDocument(tagsID[1], tagsNames[1], description, UUID.randomUUID());
 
-        tagDto1 = new TagDto(tagsID[0], tagsNames[0], description);
-        tagDto2 = new TagDto(tagsID[1], tagsNames[1], description);
+        tagDto1 = new TagDto(tagsID[0], tagsNames[0], description, UUID.randomUUID());
+        tagDto2 = new TagDto(tagsID[1], tagsNames[1], description, UUID.randomUUID());
 
     }
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/helper/TagDocumentToDtoConverterTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/helper/TagDocumentToDtoConverterTest.java
@@ -32,17 +32,19 @@ class TagDocumentToDtoConverterTest {
 
     @BeforeEach
     public void setUp() {
-        mapper  = new DocumentToDtoConverter();
+        mapper = new DocumentToDtoConverter<>();
 
         UUID[] tagsID = new UUID[]{UUID.randomUUID(), UUID.randomUUID()};
         String[] tagsNames = new String[]{"POO", "Refactorizacion"};
         String description = "bla bla bla";
+        UUID idLanguage1 = UUID.fromString("7bcf4ad3-092d-4c13-8f78-685c2a8803a9");
+        UUID idLanguage2 = UUID.fromString("bf893476-bf0f-464a-927c-4fee3b207123");
 
-        tagDocument1 = new TagDocument(tagsID[0], tagsNames[0], description, UUID.randomUUID());
-        tagDocument2 = new TagDocument(tagsID[1], tagsNames[1], description, UUID.randomUUID());
+        tagDocument1 = new TagDocument(tagsID[0], tagsNames[0], description, idLanguage1);
+        tagDocument2 = new TagDocument(tagsID[1], tagsNames[1], description, idLanguage2);
 
-        tagDto1 = new TagDto(tagsID[0], tagsNames[0], description, UUID.randomUUID());
-        tagDto2 = new TagDto(tagsID[1], tagsNames[1], description, UUID.randomUUID());
+        tagDto1 = new TagDto(tagsID[0], tagsNames[0], description, idLanguage1);
+        tagDto2 = new TagDto(tagsID[1], tagsNames[1], description, idLanguage2);
 
     }
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
@@ -113,7 +113,7 @@ class TagRepositoryTest {
     @DisplayName("Find by Language ID")
     @Test
     void findByIdLanguageTest() {
-        Flux<TagDocument> tagsByLanguage = tagRepository.findByIdLanguage(uuidLang1);
+        Flux<TagDocument> tagsByLanguage = tagRepository.findByLanguageId(uuidLang1);
 
         StepVerifier.create(tagsByLanguage)
                 .expectNextMatches(tag -> tag.getTagName().equals("POO") && tag.getLanguageId().equals(uuidLang1))

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
@@ -31,7 +31,7 @@ import static org.springframework.test.util.AssertionErrors.fail;
 @Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-public class TagRepositoryTest {
+class TagRepositoryTest {
 
     @Container
     static MongoDBContainer container = new MongoDBContainer("mongo")
@@ -116,7 +116,7 @@ public class TagRepositoryTest {
         Flux<TagDocument> tagsByLanguage = tagRepository.findByIdLanguage(uuidLang1);
 
         StepVerifier.create(tagsByLanguage)
-                .expectNextMatches(tag -> tag.getTagName().equals("POO") && tag.getIdLanguage().equals(uuidLang1))
+                .expectNextMatches(tag -> tag.getTagName().equals("POO") && tag.getLanguageId().equals(uuidLang1))
                 .verifyComplete();
     }
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
@@ -66,6 +66,7 @@ public class TagRepositoryTest {
 
         TagDocument tag1 = new TagDocument(uuidTag1, "POO", "Programació orientada a objectes", uuidLang1);
         TagDocument tag2 = new TagDocument(uuidTag2, "Bucles", "Bucles 'for' y 'while'", uuidLang2);
+
         Set<TagDocument> tagSet = new HashSet<>(Arrays.asList(tag1, tag2));
 
         tagRepository.saveAll(Flux.just(tag1, tag2)).blockLast();

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
@@ -59,10 +59,13 @@ public class TagRepositoryTest {
         uuidLang1 = UUID.fromString("09fabe32-7362-4bfb-ac05-b7bf854c6e0f");
         uuidLang2 = UUID.fromString("409c9fe8-74de-4db3-81a1-a55280cf92ef");
 
+        UUID uuidTag1 = UUID.randomUUID();
+        UUID uuidTag2 = UUID.randomUUID();
+
         tagRepository.deleteAll().block();
 
-        TagDocument tag1 = new TagDocument(uuidLang1, "POO", "Programació orientada a objectes");
-        TagDocument tag2 = new TagDocument(uuidLang2, "Bucles", "Bucles 'for' y 'while'");
+        TagDocument tag1 = new TagDocument(uuidTag1, "POO", "Programació orientada a objectes", uuidLang1);
+        TagDocument tag2 = new TagDocument(uuidTag2, "Bucles", "Bucles 'for' y 'while'", uuidLang2);
         Set<TagDocument> tagSet = new HashSet<>(Arrays.asList(tag1, tag2));
 
         tagRepository.saveAll(Flux.just(tag1, tag2)).blockLast();
@@ -106,6 +109,15 @@ public class TagRepositoryTest {
                 () -> fail("Tag with name " + tagNameByFound2 + " not found"));
     }
 
+    @DisplayName("Find by Language ID")
+    @Test
+    void findByIdLanguageTest() {
+        Flux<TagDocument> tagsByLanguage = tagRepository.findByIdLanguage(uuidLang1);
+
+        StepVerifier.create(tagsByLanguage)
+                .expectNextMatches(tag -> tag.getTagName().equals("POO") && tag.getIdLanguage().equals(uuidLang1))
+                .verifyComplete();
+    }
 
 
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
@@ -91,25 +91,6 @@ class TagRepositoryTest {
                 .verifyComplete();
     }
 
-    @DisplayName("Find by TagName")
-    @Test
-    void findByNameTagTest() {
-
-        String tagNameByFound = "POO";
-
-        Mono<TagDocument> tag1 = tagRepository.findByTagName(tagNameByFound);
-        tag1.blockOptional().ifPresentOrElse(
-                u -> assertEquals(u.getTagName(), tagNameByFound),
-                () -> fail("Tag with name " + tagNameByFound + " not found"));
-
-        String tagNameByFound2 = "Bucles";
-
-        Mono<TagDocument> tag2 = tagRepository.findByTagName(tagNameByFound2);
-        tag2.blockOptional().ifPresentOrElse(
-                u -> assertEquals(u.getTagName(), tagNameByFound2),
-                () -> fail("Tag with name " + tagNameByFound2 + " not found"));
-    }
-
     @DisplayName("Find by Language ID")
     @Test
     void findByIdLanguageTest() {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/TagServiceImplCacheTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/TagServiceImplCacheTest.java
@@ -42,7 +42,7 @@ class TagServiceImplCacheTest {
 
     @Test
     void testGetAllTagsUsesCache() {
-        TagDocument tag = new TagDocument(UUID.randomUUID(), "Algoritmos", "bla bla");
+        TagDocument tag = new TagDocument(UUID.randomUUID(), "Algoritmos", "bla bla", UUID.randomUUID());
         when(tagRepository.findAll()).thenReturn(Flux.just(tag));
 
         // Primera llamada

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/TagServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/TagServiceImplTest.java
@@ -42,11 +42,11 @@ class TagServiceImplTest {
     @DisplayName("return todos los tags y generar GenericResultDto<TagDto>")
     void testGetAllTags() {
 
-        TagDocument tag1 = new TagDocument(UUID.randomUUID(), "POO", "Programación orientada a objetos");
-        TagDocument tag2 = new TagDocument(UUID.randomUUID(), "Algoritmos", "Retos de lógica y eficiencia");
+        TagDocument tag1 = new TagDocument(UUID.randomUUID(), "POO", "Programación orientada a objetos", UUID.randomUUID());
+        TagDocument tag2 = new TagDocument(UUID.randomUUID(), "Algoritmos", "Retos de lógica y eficiencia", UUID.randomUUID());
 
-        TagDto dto1 = new TagDto(tag1.getIdTag(), tag1.getTagName(), tag1.getTagDescription());
-        TagDto dto2 = new TagDto(tag2.getIdTag(), tag2.getTagName(), tag2.getTagDescription());
+        TagDto dto1 = new TagDto(tag1.getIdTag(), tag1.getTagName(), tag1.getTagDescription(), UUID.randomUUID());
+        TagDto dto2 = new TagDto(tag2.getIdTag(), tag2.getTagName(), tag2.getTagDescription(), UUID.randomUUID());
 
         Flux<TagDocument> tagDocumentFlux = Flux.just(tag1, tag2);
         Flux<TagDto> tagDtoFlux = Flux.just(dto1, dto2);
@@ -79,8 +79,8 @@ class TagServiceImplTest {
         UUID id1 = UUID.randomUUID();
         UUID id2 = UUID.randomUUID();
 
-        TagDocument tag1 = new TagDocument(id1, "POO", "Programación orientada a objetos");
-        TagDocument tag2 = new TagDocument(id2, "Lógica", "Retos de lógica");
+        TagDocument tag1 = new TagDocument(id1, "POO", "Programación orientada a objetos", UUID.randomUUID());
+        TagDocument tag2 = new TagDocument(id2, "Lógica", "Retos de lógica", UUID.randomUUID());
 
         when(tagRepository.findById(id1)).thenReturn(Mono.just(tag1));
         when(tagRepository.findById(id2)).thenReturn(Mono.just(tag2));
@@ -131,7 +131,7 @@ class TagServiceImplTest {
     @Test
     @DisplayName("Returns Mono<true> when tag has been found")
     void getValidatedTags_returnsTrue_test(){
-        TagDocument tagDocument = new TagDocument(UUID.randomUUID(), "Tag Title", "Tag Description");
+        TagDocument tagDocument = new TagDocument(UUID.randomUUID(), "Tag Title", "Tag Description", UUID.randomUUID());
         when(tagRepository.findById(tagDocument.getIdTag())).thenReturn(Mono.just(tagDocument));
         List<UUID> tagsAssigned = List.of(tagDocument.getIdTag());
         StepVerifier.create(tagService.getValidatedTags(tagsAssigned))


### PR DESCRIPTION
User Story: #481

Summary
This PR adds a new idLanguage field to the TagDocument and TagDto classes to support language tagging. Additionally, it introduces a new repository method findByIdLanguage(UUID idLanguage) to query tags by their associated language UUID.

Changes

TagDocument.java
Added a new field idLanguage of type UUID, mapped to the language field in the MongoDB document.

TagDto.java

Added a new field idLanguage of type UUID, serialized as uuid_language in JSON.

TagRepository.java

Added method findByIdLanguage(UUID idLanguage) to query tags by language.

TagRepositoryTest.java

Added unit tests to verify the correct behavior of findByIdLanguage.

Unit tests

findByIdLanguage is covered by unit tests to ensure expected repository behavior. No integration tests added as this change is limited to the repository and DTO/document layers.

Note on unrelated changes

The changes made to the logging in DatabaseUpdater.java were removed, as they were not related to the main goal of adding the language field to TagDocument. These changes were not necessary for the PR and have been discarded.

Additional note on removed method

The method findByTagName(String tagName) was removed from TagRepository because it was unused and there is currently no requirement to filter tags by name. Removing unused methods helps keep the repository interface clean and easier to maintain.

Next Steps

The following PRs will address updates to the service and controller layers to fully integrate the language field into the tag management functionality.