### PR TITLE
chore: add changelog and .env.CI.dev entry for version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-challenge-2.0.5-RELEASE] - 2023-06-17
+### [itachallenge-challenge-2.1.0-RELEASE] - 2025-06-12
 
 ### Added
 -Save and return challenge creation date (Taiga [#478], PR [#902])

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -5,7 +5,7 @@ MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
 MICROSERVICE_VERSION_itachallenge-user=1.0.1-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
-MICROSERVICE_VERSION_itachallenge-challenge=2.0.4-RELEASE
+MICROSERVICE_VERSION_itachallenge-challenge=2.1.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-document=itachallenge-document
 MICROSERVICE_VERSION_itachallenge-document=1.0.1-RELEASE

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/LanguageServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/LanguageServiceImpl.java
@@ -1,6 +1,5 @@
 package com.itachallenge.challenge.service;
 
-import com.itachallenge.challenge.document.ChallengeDocument;
 import com.itachallenge.challenge.document.LanguageDocument;
 import com.itachallenge.challenge.dto.GenericResultDto;
 import com.itachallenge.challenge.dto.LanguageDto;
@@ -14,8 +13,6 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
 


### PR DESCRIPTION
Follow-up to Taiga [#478] (PR #902)

This PR adds the missing changelog entry and the corresponding version update 
in `.env.CI.dev` for the itachallenge-challenge microservice after merging 
the feature that saves and returns the challenge creation date.

✅ CHANGELOG.md updated with 2.1.0-RELEASE
✅ conf/.env.CI.dev updated with 2.1.0-RELEASE