### PR TITLE
refactor: move solved challenge endpoint to its own base path to avoi…

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeSolvedController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeSolvedController.java
@@ -18,7 +18,7 @@ import reactor.core.publisher.Mono;
 
 @RestController
 @Validated
-@RequestMapping(value = "/itachallenge/api/v1/challenge")
+@RequestMapping(value = "/itachallenge/api/v1/challenge/solved")
 @RequiredArgsConstructor
 public class ChallengeSolvedController {
 
@@ -26,7 +26,7 @@ public class ChallengeSolvedController {
 
     private final IChallengeService challengeService;
 
-    @PostMapping("/challenges/ended/{challengeId}")
+    @PostMapping("/ended/{challengeId}")
     @Operation(
             operationId = "Add a challenge to User's solved challenges.",
             summary = "Add a challenge to solved challenges.",


### PR DESCRIPTION
This PR moves the solved challenge endpoint from the shared controller (ChallengeController) to a dedicated ChallengeSolvedController.
By doing so, it avoids potential route conflicts caused by multiple controllers sharing the same base @RequestMapping.