### PR TITLE
feat(user): add status field to response DTOs (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 - Changed HTTP status from 201 Created to 200 OK in ChallengeSolvedController to fix client error handling (Taiga [#533], PR [#921])
 
+### [itachallenge-user-1.2.0-RELEASE] - 2025-06-19
+
+### Added
+- Added `status` field to `UserSolutionResponseDto` and `SubmitSolutionResponseDto`, allowing frontend to detect if a solution is in progress or completed. (Taiga [#522], PR [#922])
+
 [itachallenge-user-1.1.0-RELEASE] - 2025-06-18
 
 ### Added

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.4-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=1.1.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=1.2.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=2.1.1-RELEASE

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/SubmitSolutionResponseDto.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/SubmitSolutionResponseDto.java
@@ -20,4 +20,7 @@ public class SubmitSolutionResponseDto {
 
     @JsonProperty("timesSolved")
     private Integer timesSolved;
+
+    @JsonProperty("status")
+    private String status;
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/UserSolutionResponseDto.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/UserSolutionResponseDto.java
@@ -23,5 +23,8 @@ public class UserSolutionResponseDto {
 
     @JsonProperty(value ="solution_text")
     private String solutionText;
+
+    @JsonProperty("status")
+    private String status;
 }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/SubmitSolutionResponseDtoTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/SubmitSolutionResponseDtoTest.java
@@ -1,0 +1,39 @@
+package com.itachallenge.user.dto;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class SubmitSolutionResponseDtoTest {
+
+    @Test
+    void jsonSerialization_includesStatusField_withInProgressStatus() throws Exception {
+        SubmitSolutionResponseDto dto = SubmitSolutionResponseDto.builder()
+                .solutionText("print('Hola Mundo')")
+                .isSolved(true)
+                .timesSolved(3)
+                .status("IN_PROGRESS")
+                .build();
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(dto);
+
+        assertTrue(json.contains("\"status\":\"IN_PROGRESS\""));
+    }
+
+    @Test
+    void jsonSerialization_includesStatusField_withEndedStatus() throws Exception {
+        SubmitSolutionResponseDto dto = SubmitSolutionResponseDto.builder()
+                .solutionText("print('Hola Mundo')")
+                .isSolved(false)
+                .timesSolved(3)
+                .status("ENDED")
+                .build();
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(dto);
+
+        assertTrue(json.contains("\"status\":\"ENDED\""));
+    }
+}

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/UserSolutionResponseDtoTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/UserSolutionResponseDtoTest.java
@@ -1,6 +1,7 @@
 package com.itachallenge.user.dto;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itachallenge.user.document.enums.ChallengeStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +17,7 @@ class UserSolutionResponseDtoTest {
     String challengeId = UUID.randomUUID().toString();
     String languageId = UUID.randomUUID().toString();
     String solutionText = "This is my solution";
+    String status = ChallengeStatus.IN_PROGRESS.name();
     UserSolutionResponseDto solutionScoreDto = new UserSolutionResponseDto();
     UserSolutionResponseDto dto1 = UserSolutionResponseDto.builder().build();
 
@@ -70,10 +72,11 @@ class UserSolutionResponseDtoTest {
     @Test
     void requiredArgsConstructor_userSolutionScoreDto_test(){
         UserSolutionResponseDto userSolutionResponseDto1 = new UserSolutionResponseDto(
-                userId, challengeId, languageId, solutionText);
+                userId, challengeId, languageId, solutionText,status);
         assertThat(userSolutionResponseDto1.getUserId()).isEqualTo(userId);
         assertThat(userSolutionResponseDto1.getChallengeId()).isEqualTo(challengeId);
         assertThat(userSolutionResponseDto1.getLanguageId()).isEqualTo(languageId);
         assertThat(userSolutionResponseDto1.getSolutionText()).isEqualTo(solutionText);
+        assertThat(userSolutionResponseDto1.getStatus()).isEqualTo(status);
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/UserSolutionResponseDtoTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/UserSolutionResponseDtoTest.java
@@ -79,4 +79,36 @@ class UserSolutionResponseDtoTest {
         assertThat(userSolutionResponseDto1.getSolutionText()).isEqualTo(solutionText);
         assertThat(userSolutionResponseDto1.getStatus()).isEqualTo(status);
     }
+
+    @Test
+    void jsonSerialization_includesStatusField_withEndedStatus() throws Exception {
+        UserSolutionResponseDto dto = UserSolutionResponseDto.builder()
+                .userId("validUserId")
+                .challengeId("validChallengeId")
+                .languageId("validLanguageId")
+                .solutionText("Valid solution text")
+                .status("ENDED")
+                .build();
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(dto);
+
+        assertTrue(json.contains("\"status\":\"ENDED\""));
+    }
+
+    @Test
+    void jsonSerialization_includesStatusField_withInProgressStatus() throws Exception {
+        UserSolutionResponseDto dto = UserSolutionResponseDto.builder()
+                .userId("validUserId")
+                .challengeId("validChallengeId")
+                .languageId("validLanguageId")
+                .solutionText("Valid solution text")
+                .status("IN_PROGRESS")
+                .build();
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(dto);
+
+        assertTrue(json.contains("\"status\":\"IN_PROGRESS\""));
+    }
 }


### PR DESCRIPTION
### Purpose

Add the `status` field (`IN_PROGRESS` or `ENDED`) to the response DTOs in the `user` microservice, allowing the frontend to determine whether a solution is in progress or completed.

Related to task [#522].

---

### Changes made

- Added `status` field to `UserSolutionResponseDto`.
- Added `status` field to `SubmitSolutionResponseDto`.
- Created serialization tests to ensure the `status` field is correctly included in both `UserSolutionResponseDto` and `SubmitSolutionResponseDto`.
- Adjusted related unit tests to reflect the new status field.

---

### Tests performed

- Tested using Postman.  
- Verified that the `status` field appears correctly in the responses of the `PUT /solution` and `GET /users/{userId}/solutions` endpoints.  

---

## PR Author Self-check

- [x] The PR is focused and does only one thing.  
- [x] Branch name follows the convention: `feat(user): add status field to response DTOs (#522)`  
- [x] All related business logic is implemented and tested locally.  
- [x] The code is compiling and passing tests.  
- [x] No console.log or debugging artifacts were left behind.  
- [x] DTOs and endpoints are updated and consistent.  
- [x] I verified that only one solution per user/challenge/language is allowed in IN_PROGRESS.  
- [x] I verified that ENDED solutions are no longer editable.  
- [x] The PR description explains the purpose and context clearly.  
- [x] This PR is part of Issue #922 and follows the task breakdown logic described in the wiki #522.