### PR TITLE
feat(user): map status in service methods (#523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 - Changed HTTP status from 201 Created to 200 OK in ChallengeSolvedController to fix client error handling (Taiga [#533], PR [#921])
 
+### [itachallenge-user-1.3.0-RELEASE] - 2025-06-19
+
+### Added
+- Mapped and returned `status` field in `UserSolutionServiceImpl` methods: `addSolution()` and `getAllSolutionsByUser()` (Taiga [#523], PR [#923])
+
 ### [itachallenge-user-1.2.0-RELEASE] - 2025-06-19
 
 ### Added

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.4-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=1.2.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=1.3.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=2.3.0-RELEASE

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -85,12 +85,14 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
                             .solutionText(solutionText)
                             .isSolved(solvedDto.isSolved())
                             .timesSolved(solvedDto.getTimesSolved())
+                            .status(status.name())
                             .build());
         } else {
             // TODO: Enhance the response for non-ended statuses like IN_PROGRESS if additional info is needed
             return Mono.just(SubmitSolutionResponseDto.builder()
                     .solutionText(solutionText)
                     .isSolved(false)
+                    .status(status.name())
                     .build());
         }
     }
@@ -105,6 +107,7 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
                                         .challengeId(doc.getChallengeId().toString())
                                         .languageId(doc.getLanguageId().toString())
                                         .solutionText(doc.getSolutionAttemptDocument().getSolutionText())
+                                        .status(doc.getStatus().name())
                                         .build())
                 );
     }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -217,4 +217,36 @@ class UserSolutionServiceImplTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    @DisplayName("addSolution creates new IN_PROGRESS solution and returns response")
+    void addSolutionNewInProgressSolution() {
+        UserSolutionRequestDto request = UserSolutionRequestDto.builder()
+                .userId(userUuid.toString())
+                .challengeId(challengeUuid.toString())
+                .languageId(languageUuid.toString())
+                .status("IN_PROGRESS")  // ⬅️ acá cambiamos ENDED por IN_PROGRESS
+                .solutionText(solutionText)
+                .build();
+
+        when(userSolutionRepository.findByUserIdAndChallengeIdAndLanguageId(userUuid, challengeUuid, languageUuid))
+                .thenReturn(Mono.empty());
+
+        when(userSolutionRepository.save(any(UserSolutionDocument.class)))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        Mono<SubmitSolutionResponseDto> result = userSolutionService.addSolution(request);
+
+        StepVerifier.create(result)
+                .assertNext(dto -> {
+                    assertEquals(solutionText, dto.getSolutionText());
+                    assertFalse(dto.getIsSolved());
+                    assertEquals("IN_PROGRESS", dto.getStatus());
+                })
+                .verifyComplete();
+
+        verify(userSolutionRepository).findByUserIdAndChallengeIdAndLanguageId(userUuid, challengeUuid, languageUuid);
+        verify(userSolutionRepository).save(any(UserSolutionDocument.class));
+        verifyNoInteractions(challengeService);
+    }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -219,6 +219,40 @@ class UserSolutionServiceImplTest {
     }
 
     @Test
+    @DisplayName("getAllSolutionsByUser returns ENDED solution")
+    void getAllSolutionsByUser_returnsEndedSolution() {
+        UserSolutionDocument doc = UserSolutionDocument.builder()
+                .userId(userUuid)
+                .challengeId(challengeUuid)
+                .languageId(languageUuid)
+                .solutionAttemptDocument(SolutionAttemptDocument.builder().solutionText("Ended solution").build())
+                .status(com.itachallenge.user.document.enums.ChallengeStatus.ENDED)
+                .build();
+
+        when(userSolutionRepository.findAllByUserId(userUuid))
+                .thenReturn(Flux.just(doc));
+
+        StepVerifier.create(userSolutionService.getAllSolutionsByUser(userUuid.toString()))
+                .assertNext(dto -> {
+                    assertEquals("Ended solution", dto.getSolutionText());
+                    assertEquals(userUuid.toString(), dto.getUserId());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getAllSolutionsByUser returns empty when user has no solutions")
+    void getAllSolutionsByUser_returnsEmptyWhenNoSolutions() {
+        when(userSolutionRepository.findAllByUserId(userUuid))
+                .thenReturn(Flux.empty());
+
+        StepVerifier.create(userSolutionService.getAllSolutionsByUser(userUuid.toString()))
+                .expectNextCount(0)
+                .verifyComplete();
+    }
+
+
+    @Test
     @DisplayName("addSolution creates new IN_PROGRESS solution and returns response")
     void addSolutionNewInProgressSolution() {
         UserSolutionRequestDto request = UserSolutionRequestDto.builder()

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -204,6 +204,7 @@ class UserSolutionServiceImplTest {
                 .challengeId(challengeUuid)
                 .languageId(languageUuid)
                 .solutionAttemptDocument(SolutionAttemptDocument.builder().solutionText("My solution").build())
+                .status(com.itachallenge.user.document.enums.ChallengeStatus.IN_PROGRESS)
                 .build();
 
         when(userSolutionRepository.findAllByUserId(userUuid))

--- a/postman/ITA-Challenges.postman_collection.json
+++ b/postman/ITA-Challenges.postman_collection.json
@@ -1140,6 +1140,38 @@
 					"response": []
 				},
 				{
+					"name": "User/solution - IN_PROGRESS",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"uuid_challenge\": \"dcacb291-b4aa-4029-8e9b-284c8ca80296\",\n  \"uuid_language\": \"660e1b18-0c0a-4262-a28a-85de9df6ac5f\",\n  \"uuid_user\": \"c3a92f9d-5d10-4f76-8c0b-6d884c549b1c\",\n  \"status\": \"IN_PROGRESS\",\n  \"solution_text\": \"This is a solution still in progress.\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/user/solution",
+							"protocol": "http",
+							"host": [
+								"{{ip}}"
+							],
+							"port": "{{user_port}}",
+							"path": [
+								"itachallenge",
+								"api",
+								"v1",
+								"user",
+								"solution"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "User/challenges/solutions",
 					"request": {
 						"method": "GET",


### PR DESCRIPTION
### Purpose

Map the `status` field (IN_PROGRESS or ENDED) in the service logic of the `user` microservice, so that solutions saved by users reflect the correct status in the response.

Related to task [#523]

---

### Changes made

- Mapped the `status` field in `UserSolutionServiceImpl.addSolution()` when building the `SubmitSolutionResponseDto`.
- Mapped the `status` field in `getAllSolutionsByUser()` when building each `UserSolutionResponseDto`.
- Included status when mocking `UserSolutionDocument` in `UserSolutionServiceImplTest`.
- Created unit test to verify that a new solution with IN_PROGRESS status is accepted and properly returned.
- Added example requests to `ITA-Challenges.postman_collection.json` to test `IN_PROGRESS` and `ENDED` statuses in solution creation.

---

### Tests performed

- Verified manually via Postman.
- Confirmed that status is returned correctly in both `PUT /solution` and `GET /users/{userId}/solutions`.

## PR Author Self-check

- [x] The PR is focused and does only one thing.
- [x] Branch name follows the convention: `feat(user): map status in service methods (#523)`
- [x] All related business logic is implemented and tested locally.
- [x] The code is compiling and passing tests.
- [x] No console.log or debugging artifacts were left behind.
- [x] The service layer correctly maps `IN_PROGRESS` and `ENDED` status values.
- [x] I verified that updates respect the business rules for editing solutions.
- [x] I verified that ENDED solutions are not modifiable through the service.
- [x] The PR description explains the purpose and context clearly.
- [x] This PR is part of Issue #923 and follows the task breakdown logic described in the wiki (#523).