### PR TITLE
chore(contributors): add Isaac Díez to contributors.md (#535)

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -95,3 +95,4 @@
 * Jofre Coca - https://github.com/JofreCoca
 * Alfonso Cocinas - https://github.com/acocinas
 * Marc Luque - https://github.com/Heyvkram
+* Isaac Díez - https://github.com/isaac-diez


### PR DESCRIPTION
Added Isaac Díez to the contributor's list as per onboarding guide requirements.