### PR TITLE
chore(contributors): add Alfonso Cocinas to contributors.md (#536)

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -93,4 +93,4 @@
 * Fernando Giménez - https://github.com/FerGimenezRoglia
 * Antonio Carrasco - https://github.com/Deimus23
 * Jofre Coca - https://github.com/JofreCoca
-
+* Alfonso Cocinas - https://github.com/acocinas


### PR DESCRIPTION
Added Alfonso Cocinas to the contributor's list as per onboarding guide requirements