### PR TITLE
feat(user): add CreateUserRequest DTO and UsernameAlreadyExistsException (#555)(1/3)

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/CreateUserRequest.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/CreateUserRequest.java
@@ -1,0 +1,13 @@
+package com.itachallenge.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+public class CreateUserRequest {
+
+    @NotBlank(message = "Username must not be blank")
+    private String username;
+
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -76,4 +76,10 @@ public class UserGlobalExceptionHandler {
     public ResponseEntity<String> handleInternalServerErrorException(InternalServerErrorException e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
     }
+
+    @ExceptionHandler(UsernameAlreadyExistsException.class)
+    public ResponseEntity<String> handleUsernameAlreadyExistsException(UsernameAlreadyExistsException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+    }
+
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UsernameAlreadyExistsException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UsernameAlreadyExistsException.java
@@ -2,6 +2,6 @@ package com.itachallenge.user.exception;
 
 public class UsernameAlreadyExistsException extends RuntimeException {
     public UsernameAlreadyExistsException(String username) {
-        super("The username " + username + " is already exists.");
+        super("The username '" + username + "' is already registered.");
     }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UsernameAlreadyExistsException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UsernameAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.itachallenge.user.exception;
+
+public class UsernameAlreadyExistsException extends RuntimeException {
+    public UsernameAlreadyExistsException(String username) {
+        super("The username " + username + " is already exists.");
+    }
+}

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/CreateUserRequestTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/CreateUserRequestTest.java
@@ -1,0 +1,35 @@
+package com.itachallenge.user.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CreateUserRequestTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    void whenUsernameIsBlank_thenValidationFails() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setUsername("");
+
+        Set<ConstraintViolation<CreateUserRequest>> violations = validator.validate(request);
+
+        assertEquals(1, violations.size());
+        assertEquals("Username must not be blank", violations.iterator().next().getMessage());
+    }
+}

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -95,5 +95,16 @@ class UserGlobalExceptionHandlerTest {
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
         assertEquals(message, response.getBody());
     }
+
+    @Test
+    void testHandleUsernameAlreadyExistsException() {
+        String username = "alfonso79";
+        UsernameAlreadyExistsException exception = new UsernameAlreadyExistsException(username);
+        ResponseEntity<String> response = exceptionHandler.handleUsernameAlreadyExistsException(exception);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals("The username 'alfonso79' is already registered.", response.getBody());
+    }
+
 }
 


### PR DESCRIPTION
## 🟦 Purpose
Add the CreateUserRequest DTO and custom exception UsernameAlreadyExistsException to the itachallenge-user microservice. This is the first step (1/3) in the implementation of the user creation feature requested in user story #553.

### 🔗 Related to task [#555]
This PR addresses task #555 and is part of the full implementation of user story #553.

### 🛠️ Changes made
Created CreateUserRequest DTO with @NotBlank validation on the username field.

Created custom exception UsernameAlreadyExistsException, as none of the existing exceptions in the project covered this specific business case (attempting to create a user with a username that already exists).

Added @ExceptionHandler for it in UserGlobalExceptionHandler (HTTP 409 Conflict).

Added unit tests:

CreateUserRequestTest: validates DTO behavior.

UserGlobalExceptionHandlerTest: validates exception handling.

### ✅ Tests performed
DTO validation tested with Hibernate Validator.

Exception handling tested via unit test.

Build passed with:
./gradlew :itachallenge-user:test --tests "com.itachallenge.user.dto.CreateUserRequestTest"
./gradlew :itachallenge-user:test --tests "com.itachallenge.user.exception.UserGlobalExceptionHandlerTest"

## 📋 PR Author Self-check
✅ PR is focused and isolated (DTO + Exception).
✅Branch follows naming conventions: feature/555-create-dto-exception.
✅All logic tested locally.
✅ No debug logs left.
✅ Exception mapped correctly.
✅ Tests included and passing.
✅ PR clearly documents scope and purpose.
✅ This is PR 1/3 for user story #553.