### PR TITLE
PR Created Endpoint for Related Challenges (#563)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -165,6 +165,23 @@ public class ChallengeController {
         );
     }
 
+    @GetMapping("/challenges/{challengeId}/related")
+    @Operation(
+            operationId = "Get 3 related challenges on the \"Relacionat\" tab of a Challenge detail by (language, difficulty, or tags).",
+            summary = "Get to see 3 related challenges on a challenge detail page and their levels, details and their depending on the first language, difficulty and any tags.",
+            description = "Requesting 3 related challenges for the challenge the user is actually looking at or working on.",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = {@Content(schema = @Schema(implementation = ChallengeDto.class), mediaType = "application/json")}),
+                    @ApiResponse(responseCode = "200", description = "The language with given Id was not found."),
+                    @ApiResponse(responseCode = "400", description = "Missing or unexpected parameters"),
+                    @ApiResponse(responseCode = "400", description = "Malformed UUID")
+            })
+
+    public Mono<GenericResultDto<ChallengeDto>> getRelatedChallenges(@PathVariable("challengeId") String challengeId) {
+        log.info("Getting related challenges for challenge ID: " + challengeId);
+        return challengeService.getRelatedChallenges(challengeId);
+    }
+
     @GetMapping("/solution/challenge/{idChallenge}/language/{idLanguage}")
     @Operation(
             operationId = "Get the solutions from a chosen challenge and language.",

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -178,7 +178,7 @@ public class ChallengeController {
             })
 
     public Mono<GenericResultDto<ChallengeDto>> getRelatedChallenges(@PathVariable("challengeId") String challengeId) {
-        log.info("Getting related challenges for challenge ID: " + challengeId);
+
         return challengeService.getRelatedChallenges(challengeId);
     }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -117,7 +117,11 @@ public class ChallengeServiceImpl implements IChallengeService {
                 });
     }
 
-    public Mono<GenericResultDto<ChallengeDto>> getRelatedChallenges(String challengeId) { return null;}
+    @Override
+    public Mono<GenericResultDto<ChallengeDto>> getRelatedChallenges(String challengeId) {
+        return Mono.just(new GenericResultDto<>());
+    }
+
 
     @Cacheable(value = "challenges", key = "{#offset, #limit}", unless = "#result==null")
     @Override

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -117,6 +117,8 @@ public class ChallengeServiceImpl implements IChallengeService {
                 });
     }
 
+    public Mono<GenericResultDto<ChallengeDto>> getRelatedChallenges(String challengeId) { return null;}
+
     @Cacheable(value = "challenges", key = "{#offset, #limit}", unless = "#result==null")
     @Override
     public Mono<GenericResultDto<ChallengeDto>> getAllChallenges(int offset, int limit) {

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/ChallengeServiceImpl.java
@@ -119,9 +119,43 @@ public class ChallengeServiceImpl implements IChallengeService {
 
     @Override
     public Mono<GenericResultDto<ChallengeDto>> getRelatedChallenges(String challengeId) {
-        return Mono.just(new GenericResultDto<>());
-    }
+        return challengeRepository.findByUuid(UUID.fromString(challengeId))
+                .flatMap(currentChallenge -> {
+                    Optional<UUID> languageId = currentChallenge.getLanguages().stream()
+                            .map(LanguageDocument::getIdLanguage)
+                            .filter(Objects::nonNull)
+                            .findFirst();
+                    Optional<String> level = Optional.ofNullable(currentChallenge.getLevel());
+                    Optional<List<UUID>> tags = Optional.ofNullable(currentChallenge.getTags());
 
+                    return challengeRepository.findAllByUuidNotNullExcludingTestingValues()
+                            .filter(challenge -> !challenge.getUuid().toString().equals(challengeId))
+                            .filter(challenge -> languageId.isEmpty() || (
+                                    challenge.getLanguages() != null &&
+                                            challenge.getLanguages().stream()
+                                                    .anyMatch(lang -> lang.getIdLanguage() != null &&
+                                                            lang.getIdLanguage().equals(languageId.get()))
+                            ))
+                            .filter(challenge -> level.isEmpty() ||
+                                    level.get().equalsIgnoreCase(challenge.getLevel()))
+                            .filter(challenge -> tags.isEmpty() || (
+                                    challenge.getTags() != null &&
+                                            challenge.getTags().stream().anyMatch(tags.get()::contains)
+                            ))
+                            .map(challenge -> challengeConverter.convertDocumentToDto(challenge, ChallengeDto.class))
+                            .collectList()
+                            .map(challengeDtos -> {
+                                Collections.shuffle(challengeDtos);
+                                List<ChallengeDto> selectedChallenges = challengeDtos.stream()
+                                        .limit(3)
+                                        .toList();
+                                GenericResultDto<ChallengeDto> resultDto = new GenericResultDto<>();
+                                resultDto.setInfo(0, 3, selectedChallenges.size(), selectedChallenges.toArray(new ChallengeDto[0]));
+                                return resultDto;
+                            });
+                })
+                .switchIfEmpty(Mono.just(new GenericResultDto<>()));
+    }
 
     @Cacheable(value = "challenges", key = "{#offset, #limit}", unless = "#result==null")
     @Override

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/IChallengeService.java
@@ -27,6 +27,8 @@ public interface IChallengeService {
                                                                int offset,
                                                                int limit);
 
+    Mono<GenericResultDto<ChallengeDto>> getRelatedChallenges(String challengeId);
+
     Mono<String> updateResourceByUuid(String id, Map<String, Object> updates);
 
     Mono<ChallengeDto> addChallenge(ChallengeCreateDto challengeCreateDto);

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -204,6 +204,36 @@ class ChallengeControllerTest {
     }
 
     @Test
+    void getRelatedChallenges_ValidId_RelatedChallengesReturned() {
+        // Arrange
+        String challengeId = "8514dd47-9800-4fde-a376-f31d450fcd07";
+
+        ChallengeDto challenge1 = new ChallengeDto();
+        challenge1.setChallengeId(UUID.randomUUID());
+
+        ChallengeDto challenge2 = new ChallengeDto();
+        challenge2.setChallengeId(UUID.randomUUID());
+
+        ChallengeDto challenge3 = new ChallengeDto();
+        challenge3.setChallengeId(UUID.randomUUID());
+
+        GenericResultDto<ChallengeDto> expectedResponse = new GenericResultDto<>();
+        expectedResponse.setInfo(0, 3, 3, new ChallengeDto[]{challenge1, challenge2, challenge3});
+
+        when(challengeService.getRelatedChallenges(challengeId))
+                .thenReturn(Mono.just(expectedResponse));
+
+        // Act & Assert
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/challenge/challenges/{challengeId}/related", challengeId)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(GenericResultDto.class);
+    }
+
+    @Test
     void AddSolution_validIdChallenge_validIdLanguage() {
         // Mock del servicio
         SolutionDto inputDto = new SolutionDto();

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -206,7 +206,7 @@ class ChallengeControllerTest {
     @Test
     void getRelatedChallenges_ValidId_RelatedChallengesReturned() {
         // Arrange
-        String challengeId = "8514dd47-9800-4fde-a376-f31d450fcd07";
+        challengeId = "8514dd47-9800-4fde-a376-f31d450fcd07";
 
         ChallengeDto challenge1 = new ChallengeDto();
         challenge1.setChallengeId(UUID.randomUUID());

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -1103,6 +1103,101 @@ void addChallengeToSolved_WhenChallengeTimesSolvedIsZero_IncreasesTimesSolvedAnd
     }
 
     @Test
+    void getRelatedChallenges_NoRelatedChallenges_ReturnsEmptyList() {
+        // Arrange
+        when(challengeRepository.findByUuid(challengeDocument.getUuid()))
+                .thenReturn(Mono.just(challengeDocument));
+
+        when(challengeRepository.findAllByUuidNotNullExcludingTestingValues())
+                .thenReturn(Flux.empty());
+
+        // Act & Assert
+        StepVerifier.create(challengeService.getRelatedChallenges(challengeDocument.getUuid().toString()))
+                .assertNext(result -> {
+                    assertNotNull(result);
+                    assertEquals(0, result.getCount());
+                    assertEquals(0, result.getResults().length);
+                })
+                .verifyComplete();
+    }
+
+
+    @Test
+    void getRelatedChallenges_LessThanThreeRelatedChallenges_ReturnsAll() {
+        // Arrange: se crean 2 retos relacionados compatibles en idioma, nivel y tags
+        ChallengeDocument related1 = new ChallengeDocument(
+                UUID.randomUUID(), title, challengeDocument.getLevel(), LocalDateTime.now(), challengeDocument.getDetail(),
+                Set.of(languageDocument), List.of(), Topic.COMPONENTS,
+                10, 20, 30, challengeDocument.getTags()
+        );
+
+        ChallengeDocument related2 = new ChallengeDocument(
+                UUID.randomUUID(), title, challengeDocument.getLevel(), LocalDateTime.now(), challengeDocument.getDetail(),
+                Set.of(languageDocument), List.of(), Topic.COMPONENTS,
+                15, 25, 35, challengeDocument.getTags()
+        );
+
+        when(challengeRepository.findByUuid(challengeDocument.getUuid()))
+                .thenReturn(Mono.just(challengeDocument));
+
+        when(challengeRepository.findAllByUuidNotNullExcludingTestingValues())
+                .thenReturn(Flux.just(related1, related2));
+
+        when(challengeConverter.convertDocumentToDto(any(), eq(ChallengeDto.class)))
+                .thenAnswer(invocation -> {
+                    ChallengeDocument doc = invocation.getArgument(0);
+                    ChallengeDto dto = new ChallengeDto();
+                    dto.setChallengeId(doc.getUuid());
+                    return dto;
+                });
+
+        // Act & Assert
+        StepVerifier.create(challengeService.getRelatedChallenges(challengeDocument.getUuid().toString()))
+                .assertNext(result -> {
+                    assertNotNull(result);
+                    assertEquals(2, result.getCount());
+                    assertEquals(2, result.getResults().length);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void getRelatedChallenges_MoreThanThreeRelatedChallenges_ReturnsThreeRandom() {
+        // Arrange: 4 retos compatibles
+        Integer[] indices = {0, 1, 2, 3};
+        List<ChallengeDocument> relatedChallenges = Arrays.stream(indices)
+                .map(i -> new ChallengeDocument(
+                        UUID.randomUUID(), title, challengeDocument.getLevel(), LocalDateTime.now(), challengeDocument.getDetail(),
+                        Set.of(languageDocument), List.of(), Topic.COMPONENTS,
+                        10, 20, 30, challengeDocument.getTags()))
+                .collect(Collectors.toList());
+
+        when(challengeRepository.findByUuid(challengeDocument.getUuid()))
+                .thenReturn(Mono.just(challengeDocument));
+
+        when(challengeRepository.findAllByUuidNotNullExcludingTestingValues())
+                .thenReturn(Flux.fromIterable(relatedChallenges));
+
+        when(challengeConverter.convertDocumentToDto(any(), eq(ChallengeDto.class)))
+                .thenAnswer(invocation -> {
+                    ChallengeDocument doc = invocation.getArgument(0);
+                    ChallengeDto dto = new ChallengeDto();
+                    dto.setChallengeId(doc.getUuid());
+                    return dto;
+                });
+
+        // Act & Assert
+        StepVerifier.create(challengeService.getRelatedChallenges(challengeDocument.getUuid().toString()))
+                .assertNext(result -> {
+                    assertNotNull(result);
+                    assertEquals(3, result.getCount());
+                    assertEquals(3, result.getResults().length);
+                })
+                .verifyComplete();
+    }
+
+
+    @Test
     void removeChallengeFromBookmarks_WhenChallengeUuidNotValid_ReturnsError() {
         StepVerifier.create(challengeService.removeChallengeFromBookmarks("InvalidUuid", UUID.randomUUID().toString()))
                 .expectErrorMatches(error ->

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/ChallengeServiceImplTest.java
@@ -1121,6 +1121,93 @@ void addChallengeToSolved_WhenChallengeTimesSolvedIsZero_IncreasesTimesSolvedAnd
                 .verifyComplete();
     }
 
+    @Test
+    void getRelatedChallenges_LanguageIdEmpty_ShouldNotFilterByLanguage() {
+        // Arrange
+        ChallengeDocument baseChallenge = new ChallengeDocument(
+                UUID.randomUUID(), title, challengeDocument.getLevel(), LocalDateTime.now(), challengeDocument.getDetail(),
+                Set.of(), List.of(), Topic.COMPONENTS, 0, 0, 0, challengeDocument.getTags());
+
+        ChallengeDocument other = new ChallengeDocument(
+                UUID.randomUUID(), title, challengeDocument.getLevel(), LocalDateTime.now(), challengeDocument.getDetail(),
+                Set.of(languageDocument), List.of(), Topic.COMPONENTS, 0, 0, 0, challengeDocument.getTags());
+
+        when(challengeRepository.findByUuid(baseChallenge.getUuid()))
+                .thenReturn(Mono.just(baseChallenge));
+        when(challengeRepository.findAllByUuidNotNullExcludingTestingValues())
+                .thenReturn(Flux.just(other));
+        when(challengeConverter.convertDocumentToDto(any(), eq(ChallengeDto.class)))
+                .thenReturn(new ChallengeDto());
+
+        // Act & Assert
+        StepVerifier.create(challengeService.getRelatedChallenges(baseChallenge.getUuid().toString()))
+                .assertNext(result -> assertEquals(1, result.getCount()))
+                .verifyComplete();
+    }
+
+    @Test
+    void getRelatedChallenges_ChallengeWithNullLanguageId_ShouldBeExcluded() {
+        // Arrange
+        LanguageDocument langNull = new LanguageDocument(null, "lang", "img");
+        ChallengeDocument other = new ChallengeDocument(
+                UUID.randomUUID(), title, challengeDocument.getLevel(), LocalDateTime.now(), challengeDocument.getDetail(),
+                Set.of(langNull), List.of(), Topic.COMPONENTS, 0, 0, 0, challengeDocument.getTags());
+
+        when(challengeRepository.findByUuid(challengeDocument.getUuid()))
+                .thenReturn(Mono.just(challengeDocument));
+        when(challengeRepository.findAllByUuidNotNullExcludingTestingValues())
+                .thenReturn(Flux.just(other));
+
+        // Act & Assert
+        StepVerifier.create(challengeService.getRelatedChallenges(challengeDocument.getUuid().toString()))
+                .assertNext(result -> assertEquals(0, result.getCount()))
+                .verifyComplete();
+    }
+
+    @Test
+    void getRelatedChallenges_LevelEmpty_ShouldNotFilterByLevel() {
+        // Arrange
+        ChallengeDocument base = new ChallengeDocument(
+                UUID.randomUUID(), title, null, LocalDateTime.now(), challengeDocument.getDetail(),
+                Set.of(languageDocument), List.of(), Topic.COMPONENTS, 0, 0, 0, challengeDocument.getTags());
+
+        ChallengeDocument other = new ChallengeDocument(
+                UUID.randomUUID(), title, "MEDIUM", LocalDateTime.now(), challengeDocument.getDetail(),
+                Set.of(languageDocument), List.of(), Topic.COMPONENTS, 0, 0, 0, challengeDocument.getTags());
+
+        when(challengeRepository.findByUuid(base.getUuid()))
+                .thenReturn(Mono.just(base));
+        when(challengeRepository.findAllByUuidNotNullExcludingTestingValues())
+                .thenReturn(Flux.just(other));
+        when(challengeConverter.convertDocumentToDto(any(), eq(ChallengeDto.class)))
+                .thenReturn(new ChallengeDto());
+
+        // Act & Assert
+        StepVerifier.create(challengeService.getRelatedChallenges(base.getUuid().toString()))
+                .assertNext(result -> assertEquals(1, result.getCount()))
+                .verifyComplete();
+    }
+
+    @Test
+    void getRelatedChallenges_TagsExistButChallengeHasNoTags_ShouldBeExcluded() {
+        // Arrange
+        ChallengeDocument other = new ChallengeDocument(
+                UUID.randomUUID(), title, challengeDocument.getLevel(), LocalDateTime.now(), challengeDocument.getDetail(),
+                Set.of(languageDocument), List.of(), Topic.COMPONENTS, 0, 0, 0, null);
+
+        when(challengeRepository.findByUuid(challengeDocument.getUuid()))
+                .thenReturn(Mono.just(challengeDocument));
+        when(challengeRepository.findAllByUuidNotNullExcludingTestingValues())
+                .thenReturn(Flux.just(other));
+
+        // Act & Assert
+        StepVerifier.create(challengeService.getRelatedChallenges(challengeDocument.getUuid().toString()))
+                .assertNext(result -> assertEquals(0, result.getCount()))
+                .verifyComplete();
+    }
+
+
+
 
     @Test
     void getRelatedChallenges_LessThanThreeRelatedChallenges_ReturnsAll() {


### PR DESCRIPTION
### Summary

This PR introduces the GET /challenges/{challengeId}/related endpoint in the ChallengeController, which retrieves up to three challenges related to the given challengeId. The relation is determined based on shared attributes such as language, difficulty level, and optionally tags.

The controller delegates the logic to the ChallengeService, which fetches the current challenge and then filters all others by the defined criteria. The related challenges are returned in a GenericResultDto wrapper with pagination info. A random subset of up to three challenges is selected to ensure variation across multiple requests.

Integration tests were added using WebTestClient to validate the endpoint in different scenarios. Manual testing was also performed with Postman to ensure the expected behavior in local environments.

### Changes
**ChallengeController.java**

-  Added GET /challenges/{challengeId}/related endpoint to retrieve up to 3 related challenges.
- Annotated with OpenAPI documentation (@Operation, @ApiResponse).
- Supports filtering by:
  - Same language UUID
  - Same difficulty
  - Shared tags (optional; can be disabled to broaden results)
- Returns:
  - 200 OK with a wrapped list of related challenges
  - 200 OK with empty list if no related challenges are found
  - 400 Bad Request for invalid UUID format

**ChallengeService.java**
- Implemented logic to:
  - Fetch the base challenge by UUID
  - Filter other challenges based on shared language, difficulty, and tags
  - Shuffle results and return up to 3 random items
- Returns a GenericResultDto<ChallengeDto> via a Mono
- Ensures that the base challenge is excluded from the result

**ChallengeControllerTest.java**
- Added test for case where 3 related challenges are returned
- Added test for case where no related challenges are found
- Added test for when fewer than 3 challenges match
- All tests use WebTestClient and mock the service with Mockito

**ChallengeServiceTest.java**
- Added unit tests for:
  - No related challenges → empty result
  - Fewer than 3 matching challenges → all returned
  - More than 3 matching challenges → random 3 selected
- All dependencies are mocked
- Assertions validate that results respect filtering and count constraints

### Manual testing
Manually verified the endpoint with Postman using valid challengeId values.

Confirmed that:
- When 3 related challenges exist, they are returned as expected.
- When no matches exist (e.g. due to non-overlapping tags), an empty array is returned.
- Responses vary on repeated requests due to the randomization of related challenges.