### PR TITLE
fix(user) add post users/create without validation (#618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-user-1.4.1-RELEASE] - 2025-07-22
+### [itachallenge-user-1.4.1-RELEASE] - 2025-07-28
 
 ### Fixed
 - Added back "roll' to the AdminCrateUserService and to the AdminCreateUserResponseDto due to create the user with USER roll assigned.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-1.4.1-RELEASE] - 2025-07-22
+
+### Fixed
+- Added back "roll' to the AdminCrateUserService and to the AdminCreateUserResponseDto due to create the user with USER roll assigned.
 
 ### [itachallenge-auth-2.0.5-RELEASE] - 2025-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [itachallenge-user-1.4.1-RELEASE] - 2025-07-28
 
 ### Fixed
-- Added back "roll' to the AdminCrateUserService and to the AdminCreateUserResponseDto due to create the user with USER roll assigned.
+- Added back "roll' to the AdminCrateUserService and to the AdminCreateUserResponseDto due to create the user with USER roll assigned. (Taiga [#634], PR [#956])
 
 ### [itachallenge-auth-2.0.5-RELEASE] - 2025-07-22
 

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=1.4.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=1.4.1-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=2.4.1-RELEASE

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/AdminCreateUserResponseDto.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/AdminCreateUserResponseDto.java
@@ -16,4 +16,7 @@ public class AdminCreateUserResponseDto {
     @JsonProperty("username")
     private String username;
 
+    @JsonProperty("role")
+    private String role;
+
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -1,6 +1,7 @@
 package com.itachallenge.user.service;
 
 import com.itachallenge.user.document.UserDocument;
+import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
@@ -37,12 +38,14 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                     UserDocument newUser = UserDocument.builder()
                             .uuid(UUID.randomUUID())
                             .username(username)
+                            .role(Role.USER)
                             .build();
 
                     return userRepository.save(newUser)
                             .map(savedUser -> AdminCreateUserResponseDto.builder()
                                     .userId(savedUser.getUuid().toString())
                                     .username(savedUser.getUsername())
+                                    .role(savedUser.getRole().toString())
                                     .build());
                 }))
 


### PR DESCRIPTION
added back "roll' to the AdminCrateUserService and to the AdminCreateUserResponseDto due to create the user with USER roll assigned.

Fix of PR #953 