### PR TITLE
update(user): Integrate validation in user creation endpoint (#650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-1.5.0-RELEASE] - 2025-09-12
+
+### Refactored
+- Added github username validation to user microservice upon creation of a new user  (Taiga [#650], PR [#960])
+
 ### [itachallenge-githubcore-1.0.0-RELEASE] - 2025-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-user-1.5.0-RELEASE] - 2025-09-12
+### [itachallenge-user-2.0.0-RELEASE] - 2025-09-12
 
 ### Changed
-- Added github username validation to user microservice upon creation of a new user  (Taiga [#650], PR [#960])
+- Added github username validation to user microservice upon creation of a new user (Taiga [#650], PR [#960])
+  - Before: POST /users/create accepted any githubUsername value and returned success (201/ok) even if that wasn't a GitHub username. 
+  - After: POST /users/create now calls the GitHub API and rejects the request when the GitHub username does not exist. 
+  - Clients that previously relied on creating users with invalid GitHub usernames will now get errors for some requests that used to succeed.
 
 ### [itachallenge-githubcore-1.0.0-RELEASE] - 2025-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [itachallenge-user-1.5.0-RELEASE] - 2025-09-12
 
-### Refactored
+### Changed
 - Added github username validation to user microservice upon creation of a new user  (Taiga [#650], PR [#960])
 
 ### [itachallenge-githubcore-1.0.0-RELEASE] - 2025-09-11

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=1.4.2-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=1.5.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=2.4.2-RELEASE

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=1.5.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=2.0.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=2.4.2-RELEASE

--- a/github-core/README.md
+++ b/github-core/README.md
@@ -1,0 +1,38 @@
+# ITA GITHUB-CORE MODULE
+
+`github-core` is a shared library module designed to centralize all Github checks logic across ITA Challenge microservices.
+
+## Features
+
+- 👤 **Username Validation**: Checks whether the username is a valid Github username.
+- ⚙️ **Configuration**: easy change of API Github URL should there be the need.
+- ⚠️ **Exceptions**: for when the Username is not found in Github and for when the API is not working.
+- 🧪 **Test Coverage**: Comes with unit tests to ensure reliability and ease of maintenance.
+- 🚫 **No BootJar**: This module is a pure library and not a Spring Boot application.
+
+## Usage
+
+Add the dependency to your Spring Boot microservice in `build.gradle`:
+
+```groovy
+implementation(project(":github-core"))
+
+testImplementation project(':github-core')
+```
+
+## Project structure
+```markdown
+github-core/
+├── src/main/java/com/itachallenge/githubcore/
+│   ├── service/      # IGithubApiService & GithubApiService
+    ├── exception/    # GithubApiException & GithubUserNotFoundException
+    ├── config/       # GithubServiceConfig
+├── src/test/         # Unit tests
+├── build.gradle      # Gradle module configuration
+└── readme.md         # This text file           
+```
+## Development notes
+
+- The module disables bootJar since it’s not a standalone Spring Boot app.
+- SonarQube quality gate compliance with minimum test coverage is enforced.
+- This library is versioned and updated in sync with other ITA Challenge services.

--- a/itachallenge-user/build.gradle
+++ b/itachallenge-user/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap:4.0.2'
     implementation 'org.springframework.boot:spring-boot-starter-actuator:3.0.6'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive:3.1.1'
+    implementation project(":github-core")
 
 
     //testing

--- a/itachallenge-user/src/main/java/com/itachallenge/user/App.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/App.java
@@ -1,12 +1,15 @@
 package com.itachallenge.user;
 
+import com.itachallenge.githubcore.config.GithubConfig;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@Import(GithubConfig.class)
 @EnableDiscoveryClient
 @OpenAPIDefinition(info = @Info(title = "Ita Backend User", version = "1.0", description = "Description"))
 public class App {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/App.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/App.java
@@ -1,6 +1,6 @@
 package com.itachallenge.user;
 
-import com.itachallenge.githubcore.config.GithubConfig;
+import com.itachallenge.githubcore.config.GithubServiceConfig;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
@@ -9,7 +9,7 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@Import(GithubConfig.class)
+@Import(GithubServiceConfig.class)
 @EnableDiscoveryClient
 @OpenAPIDefinition(info = @Info(title = "Ita Backend User", version = "1.0", description = "Description"))
 public class App {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -1,0 +1,25 @@
+package com.itachallenge.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class APIErrorResponse {
+
+    @JsonProperty("error")
+    String error;
+
+    @JsonProperty("message")
+    String message;
+
+    @JsonProperty("timestamp")
+    Instant timestamp;
+
+}
+

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.Instant;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 public class APIErrorResponse {
 
     @JsonProperty("error")

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -2,14 +2,14 @@ package com.itachallenge.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@Data
+@Getter
 public class APIErrorResponse {
 
     @JsonProperty("error")

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/GithubUserNotFoundException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/GithubUserNotFoundException.java
@@ -1,7 +1,0 @@
-package com.itachallenge.user.exception;
-
-public class GithubUserNotFoundException extends RuntimeException {
-    public GithubUserNotFoundException(String username) {
-        super("The username '" + username + "' is not a Github username.");
-    }
-}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/GithubUserNotFoundException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/GithubUserNotFoundException.java
@@ -1,0 +1,6 @@
+package com.itachallenge.user.exception;
+
+public class GithubUserNotFoundException extends RuntimeException {
+  public GithubUserNotFoundException(String message) {super(message);
+  }
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/GithubUserNotFoundException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/GithubUserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.itachallenge.user.exception;
+
+public class GithubUserNotFoundException extends RuntimeException {
+    public GithubUserNotFoundException(String username) {
+        super("The username '" + username + "' is not a Github username.");
+    }
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/GithubUserNotFoundException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/GithubUserNotFoundException.java
@@ -1,6 +1,0 @@
-package com.itachallenge.user.exception;
-
-public class GithubUserNotFoundException extends RuntimeException {
-  public GithubUserNotFoundException(String message) {super(message);
-  }
-}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-import com.itachallenge.githubcore.exception.GithubUserNotFoundException;
 
 import jakarta.validation.ConstraintViolationException;
 
@@ -81,12 +80,6 @@ public class UserGlobalExceptionHandler {
     @ExceptionHandler(UsernameAlreadyExistsException.class)
     public ResponseEntity<String> handleUsernameAlreadyExistsException(UsernameAlreadyExistsException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
-    }
-
-    @ExceptionHandler(GithubUserNotFoundException.class)
-    public ResponseEntity<String> handleGithubUserNotFound(Exception ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ex.getMessage());
     }
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -5,7 +5,6 @@ import com.itachallenge.user.dto.APIErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import com.itachallenge.githubcore.exception.GithubUserNotFoundException;
 
 import jakarta.validation.ConstraintViolationException;
 
@@ -80,6 +81,13 @@ public class UserGlobalExceptionHandler {
     @ExceptionHandler(UsernameAlreadyExistsException.class)
     public ResponseEntity<String> handleUsernameAlreadyExistsException(UsernameAlreadyExistsException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+    }
+
+    @ExceptionHandler(GithubUserNotFoundException.class)
+    public ResponseEntity<String> handleGithubUserNotFound(Exception ex) {
+        log.warn("GitHub user not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ex.getMessage());
     }
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -1,8 +1,11 @@
 package com.itachallenge.user.exception;
 
+import com.itachallenge.githubcore.exception.GithubUnavailableException;
+import com.itachallenge.user.dto.APIErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,6 +13,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import jakarta.validation.ConstraintViolationException;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -82,9 +86,19 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
 
-    @ExceptionHandler(GithubUserNotFoundException.class)
-    public ResponseEntity<String> handleGithubUserNotFoundException(GithubUserNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    @ExceptionHandler(GithubUnavailableException.class)
+    public ResponseEntity<APIErrorResponse> handleGithubUnavailable(GithubUnavailableException ex) {
+        HttpStatus status;
+
+        if ("timeout".equalsIgnoreCase(ex.getMessage())) {
+            status = HttpStatus.GATEWAY_TIMEOUT; // 504
+        } else {
+            status = HttpStatus.SERVICE_UNAVAILABLE; // 503
+        }
+
+        return ResponseEntity.status(status).body(
+                new APIErrorResponse("GitHub API error", ex.getMessage(), Instant.now())
+        );
     }
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -82,4 +82,9 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
 
+    @ExceptionHandler(GithubUserNotFoundException.class)
+    public ResponseEntity<String> handleGithubUserNotFoundException(GithubUserNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -85,7 +85,6 @@ public class UserGlobalExceptionHandler {
 
     @ExceptionHandler(GithubUserNotFoundException.class)
     public ResponseEntity<String> handleGithubUserNotFound(Exception ex) {
-        log.warn("GitHub user not found: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ex.getMessage());
     }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -1,5 +1,6 @@
 package com.itachallenge.user.service;
 
+import com.itachallenge.githubcore.service.IGithubApiService;
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
@@ -18,9 +19,11 @@ public class AdminCreateUserService implements IAdminCreateUserService {
     private static final Logger log = LoggerFactory.getLogger(AdminCreateUserService.class);
 
     private final UserRepository userRepository;
+    private final IGithubApiService githubApiService;
 
-    public AdminCreateUserService(UserRepository userRepository) {
+    public AdminCreateUserService(UserRepository userRepository, IGithubApiService githubApiService) {
         this.userRepository = userRepository;
+        this.githubApiService = githubApiService;
     }
 
     @Override
@@ -28,12 +31,14 @@ public class AdminCreateUserService implements IAdminCreateUserService {
         final String username = request.getUsername();
         log.info("Attempting to create user with username: {}", username);
 
-        return userRepository.findByUsername(username)
-                .flatMap(existingUser ->
-
-                        Mono.<AdminCreateUserResponseDto>error(new UsernameAlreadyExistsException(username))
-                )
-                .switchIfEmpty(Mono.defer(() -> {
+        return userRepository.findByUsername(request.getUsername())
+                .flatMap(existing -> Mono.<AdminCreateUserResponseDto>error(new UsernameAlreadyExistsException(username)))
+                .switchIfEmpty(
+                        githubApiService.userExists(username)
+                                .flatMap(exists -> {
+                                    if (!exists) {
+                                        return Mono.error(new RuntimeException("GitHub user does not exist"));
+                                    }
 
                     UserDocument newUser = UserDocument.builder()
                             .uuid(UUID.randomUUID())

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -32,30 +32,30 @@ public class AdminCreateUserService implements IAdminCreateUserService {
         final String username = request.getUsername();
         log.info("Attempting to create user with username: {}", username);
 
-        return userRepository.findByUsername(request.getUsername())
-                .flatMap(existing -> {
-                    return Mono.<AdminCreateUserResponseDto>error(new UsernameAlreadyExistsException(username));
-                })
-                .switchIfEmpty(Mono.defer(() -> {
-                    return githubApiService.userExists(username)
+        return userRepository.findByUsername(username)
+                .flatMap(existing ->
+                    Mono.<AdminCreateUserResponseDto>error(new UsernameAlreadyExistsException(username))
+                )
+                .switchIfEmpty(Mono.defer(() ->
+                    githubApiService.userExists(username)
                             .flatMap(exists -> {
                                     if (Boolean.FALSE.equals(exists)) {
                                         return Mono.error(new GithubUserNotFoundException(username));
                                     }
 
-                    UserDocument newUser = UserDocument.builder()
-                            .uuid(UUID.randomUUID())
-                            .username(username)
-                            .role(Role.USER)
-                            .build();
+                                    UserDocument newUser = UserDocument.builder()
+                                            .uuid(UUID.randomUUID())
+                                            .username(username)
+                                            .role(Role.USER)
+                                            .build();
 
-                    return userRepository.save(newUser)
-                            .map(savedUser -> AdminCreateUserResponseDto.builder()
-                                    .userId(savedUser.getUuid().toString())
-                                    .username(savedUser.getUsername())
-                                    .role(savedUser.getRole().toString())
-                                    .build());
-                })
+                                    return userRepository.save(newUser)
+                                            .map(savedUser -> AdminCreateUserResponseDto.builder()
+                                                    .userId(savedUser.getUuid().toString())
+                                                    .username(savedUser.getUsername())
+                                                    .role(savedUser.getRole().toString())
+                                                    .build());
+                            })
 
                 .doOnSuccess(responseDto ->
                         log.info("Successfully created user '{}'", responseDto.getUsername())
@@ -65,7 +65,7 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                 )
                 .doOnError(e -> !(e instanceof UsernameAlreadyExistsException), e ->
                         log.error("An unexpected error occurred while creating user {}", username, e)
-                );
-    }));
+                )
+    ));
 }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -5,7 +5,7 @@ import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
-import com.itachallenge.user.exception.GithubUserNotFoundException;
+import com.itachallenge.githubcore.exception.GithubUserNotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -37,7 +37,7 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                 .switchIfEmpty(
                         githubApiService.userExists(username)
                                 .flatMap(exists -> {
-                                    if (!exists) {
+                                    if (Boolean.FALSE.equals(exists)) {
                                         return Mono.error(new GithubUserNotFoundException(username));
                                     }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -50,7 +50,7 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                                     }
                                 })
                                 .flatMap(exists -> {
-                                    if (!exists) {
+                                    if (Boolean.FALSE.equals(exists)) {
                                         log.warn("GitHub user '{}' does not exist", username);
                                         return Mono.error(new NotFoundException("GitHub user not found: " + username));
                                     }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -1,11 +1,11 @@
 package com.itachallenge.user.service;
 
-import com.itachallenge.githubcore.service.IGithubApiService;
+import com.itachallenge.githubcore.document.enums.GithubUserStatus;
+import com.itachallenge.githubcore.service.GithubApiService;
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
-import com.itachallenge.githubcore.exception.GithubUserNotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -20,9 +20,9 @@ public class AdminCreateUserService implements IAdminCreateUserService {
     private static final Logger log = LoggerFactory.getLogger(AdminCreateUserService.class);
 
     private final UserRepository userRepository;
-    private final IGithubApiService githubApiService;
+    private final GithubApiService githubApiService;
 
-    public AdminCreateUserService(UserRepository userRepository, IGithubApiService githubApiService) {
+    public AdminCreateUserService(UserRepository userRepository, GithubApiService githubApiService) {
         this.userRepository = userRepository;
         this.githubApiService = githubApiService;
     }
@@ -38,9 +38,10 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                 )
                 .switchIfEmpty(Mono.defer(() ->
                     githubApiService.userExists(username)
-                            .flatMap(exists -> {
-                                    if (Boolean.FALSE.equals(exists)) {
-                                        return Mono.error(new GithubUserNotFoundException(username));
+                            .flatMap(status -> {
+                                    if (status == GithubUserStatus.NOT_FOUND) {
+                                        log.warn("GitHub user '{}' does not exist", username);
+                                        return Mono.empty();
                                     }
 
                                     UserDocument newUser = UserDocument.builder()

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -33,10 +33,12 @@ public class AdminCreateUserService implements IAdminCreateUserService {
         log.info("Attempting to create user with username: {}", username);
 
         return userRepository.findByUsername(request.getUsername())
-                .flatMap(existing -> Mono.<AdminCreateUserResponseDto>error(new UsernameAlreadyExistsException(username)))
-                .switchIfEmpty(
-                        githubApiService.userExists(username)
-                                .flatMap(exists -> {
+                .flatMap(existing -> {
+                    return Mono.<AdminCreateUserResponseDto>error(new UsernameAlreadyExistsException(username));
+                })
+                .switchIfEmpty(Mono.defer(() -> {
+                    return githubApiService.userExists(username)
+                            .flatMap(exists -> {
                                     if (Boolean.FALSE.equals(exists)) {
                                         return Mono.error(new GithubUserNotFoundException(username));
                                     }
@@ -53,7 +55,7 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                                     .username(savedUser.getUsername())
                                     .role(savedUser.getRole().toString())
                                     .build());
-                }))
+                })
 
                 .doOnSuccess(responseDto ->
                         log.info("Successfully created user '{}'", responseDto.getUsername())
@@ -64,5 +66,6 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                 .doOnError(e -> !(e instanceof UsernameAlreadyExistsException), e ->
                         log.error("An unexpected error occurred while creating user {}", username, e)
                 );
-    }
+    }));
+}
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -6,6 +6,7 @@ import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
+import com.itachallenge.user.exception.GithubUserNotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -33,15 +34,16 @@ public class AdminCreateUserService implements IAdminCreateUserService {
         log.info("Attempting to create user with username: {}", username);
 
         return userRepository.findByUsername(username)
-                .flatMap(existing ->
-                    Mono.<AdminCreateUserResponseDto>error(new UsernameAlreadyExistsException(username))
-                )
+                .flatMap(existing -> {
+                    log.warn("Attempt to create a user that already exists: {}", username);
+                    return Mono.<AdminCreateUserResponseDto>error(new UsernameAlreadyExistsException(username));
+                })
                 .switchIfEmpty(Mono.defer(() ->
-                    githubApiService.userExists(username)
-                            .flatMap(status -> {
+                        githubApiService.userExists(username)
+                                .flatMap(status -> {
                                     if (status == GithubUserStatus.NOT_FOUND) {
                                         log.warn("GitHub user '{}' does not exist", username);
-                                        return Mono.empty();
+                                        return Mono.error(new GithubUserNotFoundException("GitHub user not found: " + username));
                                     }
 
                                     UserDocument newUser = UserDocument.builder()
@@ -55,18 +57,13 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                                                     .userId(savedUser.getUuid().toString())
                                                     .username(savedUser.getUsername())
                                                     .role(savedUser.getRole().toString())
-                                                    .build());
-                            })
-
-                .doOnSuccess(responseDto ->
-                        log.info("Successfully created user '{}'", responseDto.getUsername())
-                )
-                .doOnError(UsernameAlreadyExistsException.class, e ->
-                        log.warn("Attempt to create a user that already exists: {}", username)
-                )
-                .doOnError(e -> !(e instanceof UsernameAlreadyExistsException), e ->
-                        log.error("An unexpected error occurred while creating user {}", username, e)
-                )
-    ));
-}
+                                                    .build())
+                                            .doOnSuccess(responseDto ->
+                                                    log.info("Successfully created user '{}'", responseDto.getUsername()));
+                                })
+                                .doOnError(e -> !(e instanceof UsernameAlreadyExistsException || e instanceof GithubUserNotFoundException), e ->
+                                        log.error("An unexpected error occurred while creating user {}", username, e)
+                                )
+                ));
+    }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -1,16 +1,17 @@
 package com.itachallenge.user.service;
 
-import com.itachallenge.githubcore.document.enums.GithubUserStatus;
-import com.itachallenge.githubcore.service.GithubApiService;
+import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
-import com.itachallenge.user.exception.GithubUserNotFoundException;
+import com.itachallenge.user.exception.NotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+
+import java.time.Duration;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,11 +22,11 @@ public class AdminCreateUserService implements IAdminCreateUserService {
     private static final Logger log = LoggerFactory.getLogger(AdminCreateUserService.class);
 
     private final UserRepository userRepository;
-    private final GithubApiService githubApiService;
+    private final ExternalGithubService externalGithubService;
 
-    public AdminCreateUserService(UserRepository userRepository, GithubApiService githubApiService) {
+    public AdminCreateUserService(UserRepository userRepository, ExternalGithubService externalGithubService) {
         this.userRepository = userRepository;
-        this.githubApiService = githubApiService;
+        this.externalGithubService = externalGithubService;
     }
 
     @Override
@@ -39,11 +40,19 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                     return Mono.<AdminCreateUserResponseDto>error(new UsernameAlreadyExistsException(username));
                 })
                 .switchIfEmpty(Mono.defer(() ->
-                        githubApiService.userExists(username)
-                                .flatMap(status -> {
-                                    if (status == GithubUserStatus.NOT_FOUND) {
+                        externalGithubService.userExists(username)
+                                .timeout(Duration.ofSeconds(3))
+                                .onErrorMap(throwable -> {
+                                    if (throwable instanceof java.util.concurrent.TimeoutException) {
+                                        return new GithubUnavailableException("timeout");
+                                    } else {
+                                        return new GithubUnavailableException(throwable.getMessage());
+                                    }
+                                })
+                                .flatMap(exists -> {
+                                    if (!exists) {
                                         log.warn("GitHub user '{}' does not exist", username);
-                                        return Mono.error(new GithubUserNotFoundException("GitHub user not found: " + username));
+                                        return Mono.error(new NotFoundException("GitHub user not found: " + username));
                                     }
 
                                     UserDocument newUser = UserDocument.builder()
@@ -61,9 +70,6 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                                             .doOnSuccess(responseDto ->
                                                     log.info("Successfully created user '{}'", responseDto.getUsername()));
                                 })
-                                .doOnError(e -> !(e instanceof UsernameAlreadyExistsException || e instanceof GithubUserNotFoundException), e ->
-                                        log.error("An unexpected error occurred while creating user {}", username, e)
-                                )
                 ));
     }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -5,6 +5,7 @@ import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
+import com.itachallenge.user.exception.GithubUserNotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,7 @@ public class AdminCreateUserService implements IAdminCreateUserService {
                         githubApiService.userExists(username)
                                 .flatMap(exists -> {
                                     if (!exists) {
-                                        return Mono.error(new RuntimeException("GitHub user does not exist"));
+                                        return Mono.error(new GithubUserNotFoundException(username));
                                     }
 
                     UserDocument newUser = UserDocument.builder()

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/ExternalGithubService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/ExternalGithubService.java
@@ -1,0 +1,7 @@
+package com.itachallenge.user.service;
+
+import reactor.core.publisher.Mono;
+
+public interface ExternalGithubService {
+    Mono<Boolean> userExists(String username);
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/ExternalGithubServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/ExternalGithubServiceImpl.java
@@ -1,0 +1,20 @@
+package com.itachallenge.user.service;
+
+import com.itachallenge.githubcore.document.enums.GithubUserStatus;
+import com.itachallenge.githubcore.service.GithubApiService;
+import reactor.core.publisher.Mono;
+
+public class ExternalGithubServiceImpl implements ExternalGithubService {
+
+    private final GithubApiService githubApiService;
+
+    public ExternalGithubServiceImpl(GithubApiService githubApiService) {
+        this.githubApiService = githubApiService;
+    }
+
+    @Override
+    public Mono<Boolean> userExists(String username) {
+        return githubApiService.userExists(username)
+                .map(status -> status != GithubUserStatus.NOT_FOUND);
+    }
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/ExternalGithubServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/ExternalGithubServiceImpl.java
@@ -2,8 +2,10 @@ package com.itachallenge.user.service;
 
 import com.itachallenge.githubcore.document.enums.GithubUserStatus;
 import com.itachallenge.githubcore.service.GithubApiService;
+import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+@Service
 public class ExternalGithubServiceImpl implements ExternalGithubService {
 
     private final GithubApiService githubApiService;

--- a/itachallenge-user/src/main/resources/application.yml
+++ b/itachallenge-user/src/main/resources/application.yml
@@ -32,6 +32,9 @@ server:
   tomcat:
     max-http-form-post-size: 2097152
 
+github:
+  user-info-uri: https://api.github.com/user
+
 management:
   endpoints:
     web:

--- a/itachallenge-user/src/main/resources/application.yml
+++ b/itachallenge-user/src/main/resources/application.yml
@@ -33,7 +33,7 @@ server:
     max-http-form-post-size: 2097152
 
 github:
-  user-info-uri: https://api.github.com/user
+  user-info-uri: https://api.github.com
 
 management:
   endpoints:

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/AdminCreateUserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/AdminCreateUserControllerTest.java
@@ -1,4 +1,5 @@
 package com.itachallenge.user.controller;
+import com.itachallenge.user.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
@@ -8,7 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
@@ -19,6 +22,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @WebFluxTest(controllers = AdminCreateUserController.class)
+@ContextConfiguration(classes = { AdminCreateUserController.class })
+@Import(UserGlobalExceptionHandler.class)
 class AdminCreateUserControllerTest {
 
     @Autowired

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerSpringTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerSpringTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.user.controller;
 
 import com.itachallenge.user.dto.SubmitSolutionResponseDto;
 import com.itachallenge.user.dto.UserSolutionRequestDto;
+import com.itachallenge.user.service.ExternalGithubService;
 import com.itachallenge.user.service.IUserSolutionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +28,9 @@ class UserControllerSpringTest {
 
     @MockBean
     private IUserSolutionService userSolutionService;
+
+    @MockBean
+    private ExternalGithubService externalGithubService;
 
     private String uri;
     private String userId;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerSpringTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerSpringTest.java
@@ -5,7 +5,6 @@ import com.itachallenge.user.dto.UserSolutionRequestDto;
 import com.itachallenge.user.service.ExternalGithubService;
 import com.itachallenge.user.service.IUserSolutionService;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class APIErrorResponseTest {
 
@@ -30,18 +29,5 @@ class APIErrorResponseTest {
         assertEquals("Another error", errorResponse.getError());
         assertEquals("Different message", errorResponse.getMessage());
         assertEquals(now, errorResponse.getTimestamp());
-    }
-
-    @Test
-    void testToString() {
-        Instant now = Instant.now();
-        APIErrorResponse errorResponse = new APIErrorResponse("Error", "Msg", now);
-
-        String toString = errorResponse.toString();
-        assertNotNull(toString);
-        // Optionally check that the toString contains field values
-        assert(toString.contains("Error"));
-        assert(toString.contains("Msg"));
-        assert(toString.contains(now.toString()));
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -1,0 +1,47 @@
+package com.itachallenge.user.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class APIErrorResponseTest {
+
+    @Test
+    void testConstructorAndGetters() {
+        Instant now = Instant.now();
+        APIErrorResponse errorResponse = new APIErrorResponse("Some error", "Something went wrong", now);
+
+        assertEquals("Some error", errorResponse.getError());
+        assertEquals("Something went wrong", errorResponse.getMessage());
+        assertEquals(now, errorResponse.getTimestamp());
+    }
+
+    @Test
+    void testNoArgsConstructorAndSetters() {
+        Instant now = Instant.now();
+        APIErrorResponse errorResponse = new APIErrorResponse();
+        errorResponse.setError("Another error");
+        errorResponse.setMessage("Different message");
+        errorResponse.setTimestamp(now);
+
+        assertEquals("Another error", errorResponse.getError());
+        assertEquals("Different message", errorResponse.getMessage());
+        assertEquals(now, errorResponse.getTimestamp());
+    }
+
+    @Test
+    void testToString() {
+        Instant now = Instant.now();
+        APIErrorResponse errorResponse = new APIErrorResponse("Error", "Msg", now);
+
+        String toString = errorResponse.toString();
+        assertNotNull(toString);
+        // Optionally check that the toString contains field values
+        assert(toString.contains("Error"));
+        assert(toString.contains("Msg"));
+        assert(toString.contains(now.toString()));
+    }
+}

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -1,6 +1,5 @@
 package com.itachallenge.user.exception;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -15,9 +14,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import jakarta.validation.ConstraintViolationException;
 
-import java.time.Instant;
 import java.util.Objects;
-import java.util.concurrent.TimeoutException;
 
 class UserGlobalExceptionHandlerTest {
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -106,5 +106,16 @@ class UserGlobalExceptionHandlerTest {
         assertEquals("The username 'alfonso79' is already registered.", response.getBody());
     }
 
+    @Test
+    void testHandleGithubUserNotFoundException() {
+        String username = "alfonso79";
+        String message = username;
+        GithubUserNotFoundException exception = new GithubUserNotFoundException(username);
+        ResponseEntity<String> response = exceptionHandler.handleGithubUserNotFoundException(exception);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(message, response.getBody());
+    }
+
 }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -1,9 +1,12 @@
 package com.itachallenge.user.exception;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.itachallenge.githubcore.exception.GithubUnavailableException;
+import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -12,7 +15,9 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import jakarta.validation.ConstraintViolationException;
 
+import java.time.Instant;
 import java.util.Objects;
+import java.util.concurrent.TimeoutException;
 
 class UserGlobalExceptionHandlerTest {
 
@@ -106,15 +111,25 @@ class UserGlobalExceptionHandlerTest {
         assertEquals("The username 'alfonso79' is already registered.", response.getBody());
     }
 
-    @Test
-    void testHandleGithubUserNotFoundException() {
-        String username = "alfonso79";
-        String message = username;
-        GithubUserNotFoundException exception = new GithubUserNotFoundException(username);
-        ResponseEntity<String> response = exceptionHandler.handleGithubUserNotFoundException(exception);
 
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertEquals(message, response.getBody());
+    @Test
+    void handleGithubUnavailable_shouldReturn503() {
+        GithubUnavailableException ex = new GithubUnavailableException("Some 5xx error");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals("GitHub API error", response.getBody().getError());
+    }
+
+    @Test
+    void handleGithubUnavailable_shouldReturn504() {
+        GithubUnavailableException ex = new GithubUnavailableException("timeout");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
+
+        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode());
+        assertEquals("GitHub API error", response.getBody().getError());
     }
 
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -1,6 +1,7 @@
 package com.itachallenge.user.service;
 
 import com.itachallenge.user.document.UserDocument;
+import com.itachallenge.githubcore.service.IGithubApiService;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
@@ -26,6 +27,9 @@ class AdminCreateUserServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private IGithubApiService githubApiService;
+
     @InjectMocks
     private AdminCreateUserService adminCreateUserService;
 
@@ -43,6 +47,7 @@ class AdminCreateUserServiceTest {
                 .build();
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
+        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(true));
         when(userRepository.save(any(UserDocument.class))).thenReturn(Mono.just(savedUser));
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
@@ -53,6 +58,7 @@ class AdminCreateUserServiceTest {
                 .verifyComplete();
 
         verify(userRepository).save(any(UserDocument.class));
+        verify(githubApiService).userExists("newUser");
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -5,7 +5,7 @@ import com.itachallenge.githubcore.service.IGithubApiService;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
-import com.itachallenge.user.exception.GithubUserNotFoundException;
+import com.itachallenge.githubcore.exception.GithubUserNotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -6,6 +6,7 @@ import com.itachallenge.githubcore.service.GithubApiService;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
+import com.itachallenge.user.exception.GithubUserNotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -48,7 +49,7 @@ class AdminCreateUserServiceTest {
                 .build();
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
-        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(GithubUserStatus.NOT_FOUND));
+        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(GithubUserStatus.FOUND));
         when(userRepository.save(any(UserDocument.class))).thenReturn(Mono.just(savedUser));
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
@@ -69,12 +70,13 @@ class AdminCreateUserServiceTest {
         request.setUsername("newUser");
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
-        when(githubApiService.userExists("newUser")).thenReturn(Mono.empty());
+        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(GithubUserStatus.NOT_FOUND));
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
 
         StepVerifier.create(result)
-                .verifyComplete();
+                .expectError(GithubUserNotFoundException.class)
+                .verify();
 
         verify(userRepository, never()).save(any());
         verify(githubApiService).userExists("newUser");
@@ -132,7 +134,7 @@ class AdminCreateUserServiceTest {
                 .build();
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
-        when(githubApiService.userExists("newUser")).thenReturn(Mono.empty());
+        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(GithubUserStatus.FOUND));
         when(userRepository.save(any(UserDocument.class))).thenReturn(Mono.just(savedUser));
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -100,4 +100,49 @@ class AdminCreateUserServiceTest {
 
         verify(userRepository, never()).save(any());
     }
+
+    @Test
+    @DisplayName("Test: GitHub API failure should propagate error")
+    void createUser_whenGithubApiFails_shouldPropagateError() {
+        AdminCreateUserRequestDto request = new AdminCreateUserRequestDto();
+        request.setUsername("newUser");
+
+        when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
+        when(githubApiService.userExists("newUser")).thenReturn(Mono.error(new RuntimeException("GitHub API error")));
+
+        Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(ex -> ex instanceof RuntimeException &&
+                        ex.getMessage().contains("GitHub API error"))
+                .verify();
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Test: New user should always have default USER role")
+    void createUser_shouldAssignDefaultUserRole() {
+        AdminCreateUserRequestDto request = new AdminCreateUserRequestDto();
+        request.setUsername("newUser");
+
+        UserDocument savedUser = UserDocument.builder()
+                .uuid(UUID.randomUUID())
+                .username("newUser")
+                .role(Role.USER)
+                .build();
+
+        when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
+        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(true));
+        when(userRepository.save(any(UserDocument.class))).thenReturn(Mono.just(savedUser));
+
+        Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
+
+        StepVerifier.create(result)
+                .expectNextMatches(response -> response.getUsername().equals("newUser") &&
+                        response.getUserId() != null)
+                .verifyComplete();
+
+        verify(userRepository).save(argThat(user -> user.getRole() == Role.USER));
+    }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -1,12 +1,10 @@
 package com.itachallenge.user.service;
 
-import com.itachallenge.githubcore.document.enums.GithubUserStatus;
 import com.itachallenge.user.document.UserDocument;
-import com.itachallenge.githubcore.service.GithubApiService;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
-import com.itachallenge.user.exception.GithubUserNotFoundException;
+import com.itachallenge.user.exception.NotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.time.Duration;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -30,7 +29,7 @@ class AdminCreateUserServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private GithubApiService githubApiService;
+    private ExternalGithubService externalGithubService;
 
     @InjectMocks
     private AdminCreateUserService adminCreateUserService;
@@ -49,7 +48,7 @@ class AdminCreateUserServiceTest {
                 .build();
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
-        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(GithubUserStatus.FOUND));
+        when(externalGithubService.userExists("newUser")).thenReturn(Mono.just(true));
         when(userRepository.save(any(UserDocument.class))).thenReturn(Mono.just(savedUser));
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
@@ -60,7 +59,7 @@ class AdminCreateUserServiceTest {
                 .verifyComplete();
 
         verify(userRepository).save(any(UserDocument.class));
-        verify(githubApiService).userExists("newUser");
+        verify(externalGithubService).userExists("newUser");
     }
 
     @Test
@@ -70,16 +69,16 @@ class AdminCreateUserServiceTest {
         request.setUsername("newUser");
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
-        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(GithubUserStatus.NOT_FOUND));
+        when(externalGithubService.userExists("newUser")).thenReturn(Mono.just(false));
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
 
         StepVerifier.create(result)
-                .expectError(GithubUserNotFoundException.class)
+                .expectError(NotFoundException.class)
                 .verify();
 
         verify(userRepository, never()).save(any());
-        verify(githubApiService).userExists("newUser");
+        verify(externalGithubService).userExists("newUser");
     }
 
     @Test
@@ -103,19 +102,39 @@ class AdminCreateUserServiceTest {
     }
 
     @Test
-    @DisplayName("Test: GitHub API failure should propagate error")
-    void createUser_whenGithubApiFails_shouldPropagateError() {
+    @DisplayName("Test: GitHub API timeout should propagate GithubUnavailableException (504)")
+    void createUser_whenGithubApiTimeout_shouldThrowGithubUnavailableException() {
         AdminCreateUserRequestDto request = new AdminCreateUserRequestDto();
         request.setUsername("newUser");
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
-        when(githubApiService.userExists("newUser")).thenReturn(Mono.error(new RuntimeException("GitHub API error")));
+        when(externalGithubService.userExists("newUser"))
+                .thenReturn(Mono.delay(Duration.ofSeconds(5)).thenReturn(true));
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
 
         StepVerifier.create(result)
-                .expectErrorMatches(ex -> ex instanceof RuntimeException &&
-                        ex.getMessage().contains("GitHub API error"))
+                .expectErrorMatches(ex -> ex instanceof com.itachallenge.githubcore.exception.GithubUnavailableException)
+                .verify();
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Test: GitHub API immediate failure should propagate GithubUnavailableException (503)")
+    void createUser_whenGithubApiFailsImmediately_shouldThrowGithubUnavailableException() {
+        AdminCreateUserRequestDto request = new AdminCreateUserRequestDto();
+        request.setUsername("newUser");
+
+        when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
+        when(externalGithubService.userExists("newUser"))
+                .thenReturn(Mono.error(new RuntimeException("GitHub API down")));
+
+        Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(ex -> ex instanceof com.itachallenge.githubcore.exception.GithubUnavailableException &&
+                        ex.getMessage().equals("GitHub API down"))
                 .verify();
 
         verify(userRepository, never()).save(any());
@@ -134,7 +153,7 @@ class AdminCreateUserServiceTest {
                 .build();
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
-        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(GithubUserStatus.FOUND));
+        when(externalGithubService.userExists("newUser")).thenReturn(Mono.just(true));
         when(userRepository.save(any(UserDocument.class))).thenReturn(Mono.just(savedUser));
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -1,11 +1,11 @@
 package com.itachallenge.user.service;
 
+import com.itachallenge.githubcore.document.enums.GithubUserStatus;
 import com.itachallenge.user.document.UserDocument;
-import com.itachallenge.githubcore.service.IGithubApiService;
+import com.itachallenge.githubcore.service.GithubApiService;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
-import com.itachallenge.githubcore.exception.GithubUserNotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +29,7 @@ class AdminCreateUserServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private IGithubApiService githubApiService;
+    private GithubApiService githubApiService;
 
     @InjectMocks
     private AdminCreateUserService adminCreateUserService;
@@ -48,7 +48,7 @@ class AdminCreateUserServiceTest {
                 .build();
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
-        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(true));
+        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(GithubUserStatus.NOT_FOUND));
         when(userRepository.save(any(UserDocument.class))).thenReturn(Mono.just(savedUser));
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
@@ -69,13 +69,12 @@ class AdminCreateUserServiceTest {
         request.setUsername("newUser");
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
-        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(false));
+        when(githubApiService.userExists("newUser")).thenReturn(Mono.empty());
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
 
         StepVerifier.create(result)
-                .expectError(GithubUserNotFoundException.class)
-                .verify();
+                .verifyComplete();
 
         verify(userRepository, never()).save(any());
         verify(githubApiService).userExists("newUser");
@@ -133,7 +132,7 @@ class AdminCreateUserServiceTest {
                 .build();
 
         when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
-        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(true));
+        when(githubApiService.userExists("newUser")).thenReturn(Mono.empty());
         when(userRepository.save(any(UserDocument.class))).thenReturn(Mono.just(savedUser));
 
         Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -5,6 +5,7 @@ import com.itachallenge.githubcore.service.IGithubApiService;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
+import com.itachallenge.user.exception.GithubUserNotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -34,8 +35,8 @@ class AdminCreateUserServiceTest {
     private AdminCreateUserService adminCreateUserService;
 
     @Test
-    @DisplayName("Test: Create user when username does not exist")
-    void createUser_whenUserDoesNotExist_shouldCreateAndReturnUser() {
+    @DisplayName("Test: Create user when username does not exist in DB but in Github does")
+    void createUser_whenUserDoesNotExistInDB_shouldCreateAndReturnUser() {
 
         AdminCreateUserRequestDto request = new AdminCreateUserRequestDto();
         request.setUsername("newUser");
@@ -58,6 +59,25 @@ class AdminCreateUserServiceTest {
                 .verifyComplete();
 
         verify(userRepository).save(any(UserDocument.class));
+        verify(githubApiService).userExists("newUser");
+    }
+
+    @Test
+    @DisplayName("Test: Create user when username does not exist in DB but it's not a real Github username")
+    void createUser_whenUserDoesNotExistInDBAndIsNotAGithubUser_shouldThrowException() {
+        AdminCreateUserRequestDto request = new AdminCreateUserRequestDto();
+        request.setUsername("newUser");
+
+        when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
+        when(githubApiService.userExists("newUser")).thenReturn(Mono.just(false));
+
+        Mono<AdminCreateUserResponseDto> result = adminCreateUserService.createUser(request);
+
+        StepVerifier.create(result)
+                .expectError(GithubUserNotFoundException.class)
+                .verify();
+
+        verify(userRepository, never()).save(any());
         verify(githubApiService).userExists("newUser");
     }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/ExternalGithubServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/ExternalGithubServiceImplTest.java
@@ -1,0 +1,61 @@
+package com.itachallenge.user.service;
+
+import com.itachallenge.githubcore.document.enums.GithubUserStatus;
+import com.itachallenge.githubcore.exception.GithubUnavailableException;
+import com.itachallenge.githubcore.service.GithubApiService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class ExternalGithubServiceImplTest {
+
+    private GithubApiService githubApiService;
+    private ExternalGithubServiceImpl externalGithubService;
+
+    @BeforeEach
+    void setUp() {
+        githubApiService = Mockito.mock(GithubApiService.class);
+        externalGithubService = new ExternalGithubServiceImpl(githubApiService);
+    }
+
+    @Test
+    @DisplayName("Should return true when GitHub user exists")
+    void testUserExistsReturnsTrue() {
+        when(githubApiService.userExists(anyString()))
+                .thenReturn(Mono.just(GithubUserStatus.FOUND));
+
+        StepVerifier.create(externalGithubService.userExists("someUser"))
+                .expectNext(true)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return false when GitHub user is NOT_FOUND")
+    void testUserExistsReturnsFalse() {
+        when(githubApiService.userExists(anyString()))
+                .thenReturn(Mono.just(GithubUserStatus.NOT_FOUND));
+
+        StepVerifier.create(externalGithubService.userExists("ghostUser"))
+                .expectNext(false)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should propagate error when GitHub API fails")
+    void testUserExistsPropagatesError() {
+        when(githubApiService.userExists(anyString()))
+                .thenReturn(Mono.error(new GithubUnavailableException("GitHub API down")));
+
+        StepVerifier.create(externalGithubService.userExists("anyUser"))
+                .expectErrorMatches(throwable ->
+                        throwable instanceof GithubUnavailableException &&
+                                throwable.getMessage().equals("GitHub API down"))
+                .verify();
+    }
+}

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -35,6 +36,9 @@ class UserSolutionServiceImplTest {
 
     @Mock
     private IChallengeService challengeService;
+
+    @MockBean
+    private ExternalGithubService externalGithubService;
 
     @InjectMocks
     private UserSolutionServiceImpl userSolutionService;


### PR DESCRIPTION
### Summary

This PR updated the behaviour of AdminCreateUserService() so the username is checked against the  a centralized Github Username Validation that will be shared with User and Auth microservices. 

This PR is the second part of 3 which are derived from the following tasks:
- [#649](https://tree.taiga.io/project/luisvi-ita-challenges/task/649) 1/3 Create GitHub Username Validation in Shared Module
- [#650](https://tree.taiga.io/project/luisvi-ita-challenges/task/650) 2/3 Integrate Validation in User Creation Endpoint
- [#651](https://tree.taiga.io/project/luisvi-ita-challenges/task/651) 3/3 Refactor & Reuse in Auth-Service

**Context**

When creating a new user in the user microservice, the GitHub username provided needed to be validated against GitHub’s user base to ensure it actually exists. Previously, this validation was missing.

**Before**

The user microservice allowed creating users with any GitHub username, even if it did not exist. No external check against GitHub’s API was performed.

**After**

The user microservice now validates GitHub usernames by calling the GitHub API via the new github-core module. 
On user creation, the service checks if the GitHub user exists and rejects invalid usernames.

**Impact**

- Breaking change: Clients must now provide valid GitHub usernames when creating users (invalid ones will be rejected with a validation error).
- Functional case (GithubUserStatus.NOT_FOUND) is now translated in user-service into a NotFoundException, which results in 404 Not Found to clients.
- Provider failures (GithubUnavailableException, timeouts, 5xx) are surfaced from github-core and consistently mapped in GlobalExceptionHandler to 503 Service Unavailable/504 Gateway Timeout.


IMPORTANT: 
-
**Since this task depends on the #649 all its changes and new contributions also appear in this PR, so refrain from checking everything that falls under the github-core folder.**

### Main tasks:
- Refactor AdminCreateUserService to implement Github username validation for which the creation of a new user is depends on the username being a Github user.
- Update all dependent classes.
- Keep all tests green in case the new implementation needs some refactoring.


### Changes 

**App.java**
Added annotation to import the GithubServiceConfig() class to get the Github API URL to validate the username.
It is important because, this class needs the github user info uri to be in the application.yml or as environment variables of every micro that is using the Github-core module until it is moved into a central config server. Here is, for reference, the GithubServiceConfig():

    @Configuration
    public class GithubServiceConfig {

    @Value("${github.user-info-uri}")
    private String githubApiUrl;

    @Bean
    public GithubApiService githubApiService(WebClient.Builder webClientBuilder) {
        return new GithubApiServiceImpl(webClientBuilder, githubApiUrl);
        }
    }

and the application.yml:

    github:
      user-info-uri: https://api.github.com

**ExternalGithubService  & ExternalGithubServiceImpl**
In order to fully decouple the main service from the github-core module, this interface and its implementation take care of passing true/false on github username validation to the main service.

**AdminCreateUserService**
Passed the interface ExternalGithubService as an argument and run the username by its userExists() method right after checking if the user is alredy in the database.

**APIErrorResponse**
Created to conveniently inform when the Github API fails.
--> TECHNICAL DEBT: Right now the handler is misaligned so the APIResponse should be adapted  to the rest of the exceptions so that they follow the same format.

**UserGlobalExceptionHandler**
Added the GithubUnavailableException handler for when the Github API is unavailable (code 503) or times out (504), returning an APIErrorResponse DTO.
--> TECHNICAL DEBT: a more robust solution to throw codes 503 or 504 and informs more securely.

**AdminCreateUserServiceTest**
Added the following tests:
- for the situation when the user in not on the database but neither is a Github user.
- for when the Github API fails and should propagate error
- to check that the new user should always have default USER role

**ExternalGithubServiceTest & APIErrorResponseTest**
Created to test the new middleware service and DTO.

**AdminCreateUserControllerTest**
The tests were not returning the right server codes because they needed injecting of @ContextConfiguration and @Import of the UserGlobalExceptionHandler.class to throw the right exceptions and Http responses. 

**UserGlobalExceptionHandlerTest**
Tested the new GithybUnavailableException handler that checks whether a 503 or 504 code is thrown.

**UserControllerSpringTest & UserSolucitonServiceImplTest**
The new ExternalGithubService bean is needed to be injected for the test to work.

**settings.gradle**
Include github-core for the build to use the new module and its services.

**CHANGELOG.md & .env.CI,dev**
Moved to version 1.5.0 of user microservice.

**README.md** for Github-core module
This was left from the previous PR where i created the module. It explains what the new module Github-core does, structure and usage.

**POSTMAN TESTS**
<img width="1413" height="466" alt="Screenshot-2025-09-16-17:38:27" src="https://github.com/user-attachments/assets/6ed77c8a-d153-40fd-914e-aa446d01356b" />


## 📋 PR Author Self-check
✅ PR is focused and isolated
✅ Branch follows naming conventions.
✅ No debug logs left.
✅ Exception mapped correctly.
✅ PR clearly documents scope and purpose.