### PR TITLE
refactor(document): refactor document to use constructor injection #657

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-document-1.0.2-RELEASE] - 2025-09-17
+
+### Changed
+- Refactored DocumentController to use constructor injection, removing all instances of @Autowired to align with project standards. (Taiga [#657], PR [#963])
+
 ### [itachallenge-user-1.4.2-RELEASE] 2025-09-17
 
 ### Changed

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -8,7 +8,7 @@ MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=2.4.2-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-document=itachallenge-document
-MICROSERVICE_VERSION_itachallenge-document=1.0.1-RELEASE
+MICROSERVICE_VERSION_itachallenge-document=1.0.2-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-mock=itachallenge-mock
 MICROSERVICE_VERSION_itachallenge-mock=1.0.0-RELEASE

--- a/itachallenge-document/src/main/java/com/itachallenge/document/controller/DocumentController.java
+++ b/itachallenge-document/src/main/java/com/itachallenge/document/controller/DocumentController.java
@@ -3,7 +3,6 @@ package com.itachallenge.document.controller;
 import com.itachallenge.document.config.OpenApiConfig;
 import com.itachallenge.document.service.DocumentService;
 import io.swagger.v3.oas.models.OpenAPI;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
@@ -25,9 +24,7 @@ public class DocumentController {
 
     private final OpenApiConfig openApiConfig;
     private final DocumentService documentService;
-
-    @Autowired
-    private Environment env;
+    private final Environment env;
 
     @Value("${spring.application.version}")
     private String version;
@@ -35,10 +32,10 @@ public class DocumentController {
     @Value("${spring.application.name}")
     private String appName;
 
-    @Autowired
-    public DocumentController(OpenApiConfig openApiConfig, DocumentService documentService) {
+    public DocumentController(OpenApiConfig openApiConfig, DocumentService documentService, Environment env) {
         this.openApiConfig = openApiConfig;
         this.documentService = documentService;
+        this.env = env;
     }
 
     @GetMapping(value = "/api-docs/{apiname}", produces = {"application/json"})

--- a/itachallenge-document/src/test/java/com/itachallenge/document/controller/DocumentControllerTest.java
+++ b/itachallenge-document/src/test/java/com/itachallenge/document/controller/DocumentControllerTest.java
@@ -9,16 +9,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -40,8 +37,7 @@ class DocumentControllerTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        documentController = new DocumentController(openApiConfig, documentService);
-        ReflectionTestUtils.setField(documentController, "env", env);
+        documentController = new DocumentController(openApiConfig, documentService, env);
     }
 
     @Test


### PR DESCRIPTION
✅ Summary
This Pull Request addresses Task #657 (subtask of user story #644), which required refactoring the Document microservice to eliminate the use of @Autowired in its production code. The analysis focused on the DocumentController class, which used a mix of @Autowired on a field and a constructor. This PR resolves these instances, aligning the microservice with modern best practices.

🛠️ Implemented Changes
Migration to Constructor Injection:
All @Autowired annotations have been removed from the DocumentController class. The dependencies are now injected exclusively through a single constructor with final fields, promoting immutability and readability.

Test Adaptation:
No new tests were added in this PR. Instead, the existing DocumentControllerTest was updated to reflect the change in the controller's constructor. This adaptation ensures that the existing test suite continues to correctly validate the functionality of the class without introducing new code.

Justifies the technical approach
The chosen approach was to eliminate all instances of @Autowired from the microservice's production code. This refactoring aligns with the "Definition of Done" for this project's technical debt. This design:

Improves code quality and testability, making the class easier to unit test without needing a full Spring context.

Enhances readability by making all dependencies explicit and mandatory via the constructor.

Promotes immutability by allowing dependencies to be declared as final.

⚠️ Technical Debt & Justification
This PR successfully resolves a specific piece of technical debt by completing the refactoring for the Document microservice. The remaining refactoring tasks for the Challenge microservice will be addressed in future sprints as part of the overarching user story #644.

📋 PR Author Self-check
[✅] The @Autowired annotations have been removed from the Document microservice's production code.
[✅] The DocumentController class now uses a single constructor injection with final fields.
[✅] The existing test suite was adapted to the code changes.
[✅] All related tests pass successfully, confirming no regressions.
[✅] This is PR #963 for user story #644 and task #657.