### PR TITLE
fix(postman): postman challenge collection correction (#665)

### DIFF
--- a/postman/ITA-Challenges.postman_collection.json
+++ b/postman/ITA-Challenges.postman_collection.json
@@ -779,7 +779,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\r\n    \"challengeTitle\": \"t\u00edtol\",\r\n    \"description\": \"descripci\u00f3\",\r\n    \"level\": \"EASY\",\r\n    \"language\": \"Java\",\r\n    \"solution\": \"soluci\u00f3\"\r\n}",
+              "raw": "{\r\n    \"challengeTitle\": \"t\u00edtol\",\r\n    \"description\": \"descripci\u00f3\",\r\n    \"level\": \"EASY\",\r\n    \"language\": \"Java\",\r\n    \"solution\": \"soluci\u00f3\",\r\n    \"topic\": \"ALL\",\r\n    \"tags\": []\r\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION
The raw request body for the POST /challenges endpoint in our Postman collection is outdated. It is missing the topic and tags fields, which were recently added to the ChallengeCreateDto.

### **Changes Made 💻**

-  Postman Collection: Modified the raw JSON body of the POST Create Challenge request within the ITA-Challenges.postman_collection.json file.

 - Added the topic field to match the DTO.

 - Added the tags field, initialized as an empty array ([]), to directly support testing the @NotEmpty validation introduced in PR #961.
 
### **How to verify the change? 🧪**
Since this change modifies the testing tool itself, verification involves confirming the update within Postman rather than testing API endpoints.

 - Pull the latest changes from this branch.

 - Open Postman and import the updated ITA-Challenges.postman_collection.json file.

 - In the collection, navigate to the POST Create Challenge request.

 - Select the "Body" tab and view the "raw" JSON content.

### **Expected Result:**
The request body should now be updated to the following structure, including the topic and tags fields:

JSON

{
    "challengeTitle": "títol",
    "description": "descripció",
    "level": "EASY",
    "language": "Java",
    "solution": "solució",
    "topic": "ALL",
    "tags": []
}
With this updated request, you can now easily test the failure case (sending tags: [] to get a 400 Bad Request) and the success case (adding a UUID to the tags array).

### **PR Author Self-check 📋**
✅ I tested my changes locally and verified they work as expected.
✅ The PR has a clear and focused purpose (only one feature, fix, or refactor).
✅ Title, description, and changelog (if needed) are filled in correctly.
✅ There are no leftover merge conflicts or unrelated changes from previous branches.
✅ All automated checks (like SonarCloud) have passed.