### PR TITLE
docs(user): document changes for user story 705 (#749)

### DIFF
--- a/itachallenge-user/README.md
+++ b/itachallenge-user/README.md
@@ -91,7 +91,33 @@ When you execute the redis-cli command to import the data, make sure you are in 
 
 Ensure that your Redis server is running and accessible on the specified host and port
 
-For more info check [Import Data into Redis](https://developer.redis.com/guides/import/)
+For more info check [Import Data into Redis](https://developer.redis.com/guides/import/
+
+### Model
+
+#### UserDocument
+
+The `UserDocument` represents a user within the system. It is stored in the `users` collection in MongoDB and contains
+both basic and custom user data.
+
+##### Document Structure:
+
+| Field                | Type          | Description                                                          |
+|----------------------|---------------|----------------------------------------------------------------------|
+| `uuid`               | `UUID`        | Unique identifier for the user (used as the primary key in MongoDB). |
+| `username`           | `String`      | GitHub Username, used for authentication.                            |
+| `role`               | `Role (enum)` | User role (`ADMIN`, `USER`, etc.), used for access control.          |
+| `favoriteChallenges` | `Set<UUID>`   | Set of challenge IDs the user has marked as favorites.               |
+| `bookmarkChallenges` | `Set<UUID>`   | Set of challenge IDs the user has bookmarked.                        |
+| `points`             | `Integer`     | Number of points the user has earned by solving challenges.          |
+
+##### Additional Notes:
+
+- The class is annotated with `@Document(collection = "users")` to map it to a MongoDB collection.
+- `@Indexed(unique = true)` is used on `username` to ensure uniqueness.
+- Lombok is used to automatically generate getters, setters, `toString()`, and other boilerplate code.
+- The `uuid` field is mapped to the MongoDB `_id`.
+- This model supports extended features like filtering, favoriting, and bookmarking challenges.
 
 ##### Spring Boot Actuator
 

--- a/postman/ITA-Challenges.postman_collection.json
+++ b/postman/ITA-Challenges.postman_collection.json
@@ -1089,6 +1089,30 @@
           "response": []
         },
         {
+          "name": "User/profile",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/user/users/shakira",
+              "protocol": "http",
+              "host": [
+                "{{ip}}"
+              ],
+              "port": "{{user_port}}",
+              "path": [
+                "itachallenge",
+                "api",
+                "v1",
+                "user",
+                "users",
+                "shakira"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "User/bookmarks",
           "request": {
             "method": "GET",


### PR DESCRIPTION
## Summary

This PR matches **Taiga task #749** and documents the changes introduced in **PR #977** for the `itachallenge-user` microservice (`1.5.2-RELEASE`), completing the documentation updates required by **User Story #705** and **Task #747**.

It updates the project documentation and Postman collection to reflect the new `points` field in `UserDocument`, ensuring that API references, examples, and descriptions remain accurate and consistent.

Once PR #977 is merged into develop, this PR will need to be rebased to avoid conflict.  

---

## Checklist Alignment
✅ Adds model documentation for the updated `UserDocument`  
✅ Updates Wiki endpoint descriptions for accuracy  
✅ Extends Postman Collection with a `GET /users/{githubUsername}` request  
✅ Keeps all documentation assets synchronized with release `1.5.2`  

---

## Context & Changes

### Before
- The `UserDocument` model description in README lacked the new `points` field.  
- The Wiki “Available Endpoints” section contained outdated endpoint information.  
- The Postman User Collection did not include a request for fetching a user by GitHub username.  

### After
- **README:**  
  Added a dedicated **Model section** describing `UserDocument`, including its new `points` field.  

- **Wiki:**  
  Corrected the description of the following endpoint in the *Available Endpoints* section:  
  ```java
  @Get /users/{githubUsername}
  userService.getUser(githubUsername)
  → Devuelve el perfil completo del usuario correspondiente a gitHubUsername
  ```

- **Postman Collection:**  
  Added a new request to the **User Collection**:  
  ```
  GET /users/{gitHubUsername}
  ```
  (name: *User/profile*) to facilitate testing of the updated endpoint.

## Changelog

As this is a documentation task, it doesn't trigger any verison update. 

---

## How to Test

- Open the **Postman User Collection** and verify the new `GET /users/{gitHubUsername}` request returns the full user profile.  This request must be teste against the version in branch feature/#747_add_field_points_to_UserDocument, or any branch in which the latests has been merged. 

```json
{
    "uuid": "3bb7ca0b-32d7-49bd-8daf-ffb9402bda59",
    "username": "aurelien-darbellay",
    "role": "USER",
    "favoriteChallenges": null,
    "bookmarkChallenges": null,
    "points": 0
}
```

- Check the **README** and **Wiki** to confirm:
  - The `points` field appears in the `UserDocument` model section.  
  - The endpoint descriptions match the current service behavior.  

---

## PR Author Self-check

- [x] I verified that documentation updates match the code implementation  
- [x] The PR has a clear and focused purpose (documentation alignment)  
- [x] Title, description, and changelog are filled in correctly  
- [x] No merge conflicts or unrelated changes  
- [x] All automated checks (SonarCloud, etc.) have passed  
- [x] I ran SonarLint locally and confirmed no warnings or errors  

---

## Future Considerations
- Ensure Postman collections stay versioned alongside microservice releases.  
