### PR TITLE
refactor(challenge): replace @Autowired annotations with @RequiredArgsConstructor (#716)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -12,9 +12,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +29,7 @@ import java.util.Optional;
 
 @RestController
 @Validated
+@RequiredArgsConstructor
 @RequestMapping(value = "/itachallenge/api/v1/challenge")
 public class ChallengeController {
 
@@ -43,14 +44,11 @@ public class ChallengeController {
 
     private static final Logger log = LoggerFactory.getLogger(ChallengeController.class);
 
-    @Autowired
     private final PropertiesConfig config;
 
-    @Autowired
-    private DiscoveryClient discoveryClient;
+    private final DiscoveryClient discoveryClient;
 
-    @Autowired
-    private IChallengeService challengeService;
+    private final IChallengeService challengeService;
 
     private final IChallengeJwtFacade challengeJwtFacade;
 
@@ -59,11 +57,6 @@ public class ChallengeController {
 
     @Value("${spring.application.name}")
     private String appName;
-
-    public ChallengeController(PropertiesConfig config, IChallengeJwtFacade challengeJwtFacade) {
-        this.challengeJwtFacade = challengeJwtFacade;
-        this.config = config;
-    }
 
     @GetMapping(value = "/test")
     public String test() {

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/TagController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/TagController.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -21,11 +21,11 @@ import java.util.UUID;
 
 @RestController
 @Validated
+@RequiredArgsConstructor
 @RequestMapping(value = "/itachallenge/api/v1/tags")
 public class TagController {
 
-    @Autowired
-    private ITagService tagService;
+    private final ITagService tagService;
 
     @GetMapping("/{languageId}")
     @Operation(


### PR DESCRIPTION
## Summary

This PR addresses [task 716](https://tree.taiga.io/project/luisvi-ita-challenges/task/716)

It comes from [the technical debt of this task](https://tree.taiga.io/project/luisvi-ita-challenges/issue/641), which this PR addresses specifically for the challenge microservice. The rest of the microservices, as well as the test refactors, are out of scope for this PR.

The goal is to remove all @Autowired annotations from the ChallengeController.java and TagController.java classes (both in the controller package of the Challenge microservice), and instead use constructor injection via Lombok’s @RequiredArgsConstructor to simplify the code where no additional constructor logic is needed.


### Changes

- Removed 3 @Autowired annotations from ChallengeController.java and use @RequiredArgsConstructor instead
- Removed 1 @Autowired annotation from TagController.java and use @RequiredArgsConstructor instead
- Marked the dependencies as final


### Justification for this Refactor

- Improves code quality and testability: Dependencies are injected via the constructor, making unit testing easier without needing to load the full Spring context.

- Enhances readability: Dependencies are explicitly declared and made mandatory.

- Promotes immutability: Dependencies can now be marked as final, enforcing best practices.


### Notes

- No new tests were needed and and all existing tests pass

- Following [Taiga's guidelines](https://tree.taiga.io/project/luisvi-ita-challenges/wiki/guidehow-to-update-changelog-version),the changelog was not updated since this is a refactor and doesn't require it.


### PR author self-check

- [x] I tested my changes locally and verified they work as expected
- [x] The PR has a clear and focused purpose
- [x] Title and description are filled in correctly. No changelog edit needed since it's a refactor
- [x] There are no leftover merge conflicts or unrelated changes from previous branches
- [x] All automated checks (like SonarCloud) have passed
- [x] All existing tests pass and no new ones were needed