### PR TITLE
PR 1/2 - refactor(user) : refactor api error response(#741)

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -13,6 +13,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @Setter
 public class APIErrorResponse {
+    @JsonProperty("timestamp")
+    private Instant timestamp;
+
+    @JsonProperty("status")
+    private int status;
 
     @JsonProperty("error")
     private String error;
@@ -20,20 +25,14 @@ public class APIErrorResponse {
     @JsonProperty("message")
     private String message;
 
-    @JsonProperty("timestamp")
-    private Instant timestamp;
-
-    @JsonProperty("status")
-    private int status;
-
     @JsonProperty("path")
     private String path;
 
-    public APIErrorResponse(String error, String message, HttpStatus status, String path){
-        this.error = error;
-        this.message = message;
+    public APIErrorResponse(HttpStatus status, String error, String message, String path){
         this.timestamp = Instant.now();
         this.status = status.value();
+        this.error = error;
+        this.message = message;
         this.path = path;
 
     }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -1,27 +1,42 @@
 package com.itachallenge.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.Instant;
 
-@AllArgsConstructor
+import org.springframework.http.HttpStatus;
+
 @NoArgsConstructor
 @Getter
 @Setter
 public class APIErrorResponse {
 
     @JsonProperty("error")
-    String error;
+    private String error;
 
     @JsonProperty("message")
-    String message;
+    private String message;
 
     @JsonProperty("timestamp")
-    Instant timestamp;
+    private Instant timestamp;
+
+    @JsonProperty("status")
+    private int status;
+
+    @JsonProperty("path")
+    private String path;
+
+    public APIErrorResponse(String error, String message, HttpStatus status, String path){
+        this.error = error;
+        this.message = message;
+        this.timestamp = Instant.now();
+        this.status = status.value();
+        this.path = path;
+
+    }
 
 }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -12,7 +12,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import jakarta.validation.ConstraintViolationException;
 
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -94,9 +93,9 @@ public class UserGlobalExceptionHandler {
         } else {
             status = HttpStatus.SERVICE_UNAVAILABLE; // 503
         }
-
+        String path = "path unavailable - WIP";
         return ResponseEntity.status(status).body(
-                new APIErrorResponse("GitHub API error", ex.getMessage(), Instant.now())
+                new APIErrorResponse("GitHub API error", ex.getMessage(), status, path)
         );
     }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -95,7 +95,7 @@ public class UserGlobalExceptionHandler {
         }
         String path = "path unavailable - WIP";
         return ResponseEntity.status(status).body(
-                new APIErrorResponse("GitHub API error", ex.getMessage(), status, path)
+                new APIErrorResponse(status, "GitHub API error", ex.getMessage(),  path)
         );
     }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -13,8 +13,8 @@ class APIErrorResponseTest {
 
     @Test
     void testConstructorAndGetters() {
-        Instant now = Instant.now();
-        APIErrorResponse errorResponse = new APIErrorResponse("Some error", "Something went wrong", HttpStatus.NOT_FOUND, "http://localhost:8762/api/v1/user");
+
+        APIErrorResponse errorResponse = new APIErrorResponse(HttpStatus.NOT_FOUND, "Some error", "Something went wrong", "http://localhost:8762/api/v1/user");
 
         assertEquals("Some error", errorResponse.getError());
         assertEquals("Something went wrong", errorResponse.getMessage());

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -18,7 +18,9 @@ class APIErrorResponseTest {
 
         assertEquals("Some error", errorResponse.getError());
         assertEquals("Something went wrong", errorResponse.getMessage());
-        assertEquals(now, errorResponse.getTimestamp());
+        assertNotNull(errorResponse.getTimestamp());
+        assertEquals(HttpStatus.NOT_FOUND.value(), errorResponse.getStatus());
+        assertEquals("http://localhost:8762/api/v1/user", errorResponse.getPath());
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -4,14 +4,17 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
+import org.springframework.http.HttpStatus;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class APIErrorResponseTest {
 
     @Test
     void testConstructorAndGetters() {
         Instant now = Instant.now();
-        APIErrorResponse errorResponse = new APIErrorResponse("Some error", "Something went wrong", now);
+        APIErrorResponse errorResponse = new APIErrorResponse("Some error", "Something went wrong", HttpStatus.NOT_FOUND, "http://localhost:8762/api/v1/user");
 
         assertEquals("Some error", errorResponse.getError());
         assertEquals("Something went wrong", errorResponse.getMessage());
@@ -25,9 +28,13 @@ class APIErrorResponseTest {
         errorResponse.setError("Another error");
         errorResponse.setMessage("Different message");
         errorResponse.setTimestamp(now);
+        errorResponse.setStatus(404);
+        errorResponse.setPath("http://localhost:8762/api/v1/user");
 
         assertEquals("Another error", errorResponse.getError());
         assertEquals("Different message", errorResponse.getMessage());
-        assertEquals(now, errorResponse.getTimestamp());
+        assertNotNull(errorResponse.getTimestamp());
+        assertEquals(404, errorResponse.getStatus());
+        assertEquals("http://localhost:8762/api/v1/user", errorResponse.getPath());
     }
 }


### PR DESCRIPTION
NOTE :   I quited Timestamp from the parameters of the constructor, and shouldn't have done so. 

**Future consideration**: the APIErrorResponse should be refactorized to be harmonized with the APIErrorResponse in Challenge microservice which is much more consistent (#996). An issue had been created in Taiga for that purpose.

----------------------------------------------------------------------

This PR depended on #960 (update(user): Integrate validation in user creation endpoint ([#650](https://tree.taiga.io/project/luisvi-ita-challenges/task/650)) ). I started working on my branch while it hadn't been merged yet and then did a rebase on origin/develop.

This PR is the firstpart of 2 which are derived from the following tasks :
[#741](https://tree.taiga.io/project/luisvi-ita-challenges/task/741)PR1/2 - Refactorize ErrorResponseApi DTO adding fields as :httpStatus, path
[#743](https://tree.taiga.io/project/luisvi-ita-challenges/task/743)PR2/2 - Implement ErrorResponseApi DTO in the most used UserExceptionHandlers 


**GOAL**
 Standardize the User Global Exception Handler by implementing ApiErrorResponse in all  exception handlers  so that they return the same response structure

**CHANGES**
Added 2 new fields : httpsStatus , path (keeping the existing fields :  timestamp; error, message)

**TESTS**
The 2 existing tests have been updated to include both new fields.

**CHANGELOG**
Changelog has not been updated as no new functionality has been added.



DEFINITION OF DONE

✅ ApiErrorResponse updated
✅ Tests : add new fields in dto tests and tests passing


### 📋 PR Author Self-check
✅ I tested my changes locally and verified they work as expected
✅ The PR has a clear and focused purpose (only one feature, fix or refactor)
✅ Title, description, and changelog (if needed) are filled in correctly
✅ There are no leftover merge conflicts or unrelated changes from previous branches
✅ All automated checks (like SonarCloud) have passed
✅ I responded to all previous review comments and only resolved those I truly addressed
✅ I ran SonarLint locally on the modified files and confirmed there are no warnings or errors