### PR TITLE
refactor(challenge): remove or replace @Autowired annotations (#719)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/LanguageServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/LanguageServiceImpl.java
@@ -7,7 +7,6 @@ import com.itachallenge.challenge.helper.DocumentToDtoConverter;
 import com.itachallenge.challenge.repository.LanguageRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -15,14 +14,12 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-
 @Service
 @RequiredArgsConstructor
 public class LanguageServiceImpl implements ILanguageService {
 
     private static final String LANGUAGE_NOT_FOUND = "Language with id %s not found";
 
-    @Autowired
     private final DocumentToDtoConverter<LanguageDocument, LanguageDto> languageConverter = new DocumentToDtoConverter<>();
 
     @NonNull
@@ -49,14 +46,4 @@ public class LanguageServiceImpl implements ILanguageService {
         return languageRepository.findFirstByLanguageName(languageName);
     }
 
-
 }
-
-
-
-
-
-
-
-
-

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/TagServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/service/TagServiceImpl.java
@@ -7,9 +7,9 @@ import com.itachallenge.challenge.exception.BadRequestException;
 import com.itachallenge.challenge.exception.TagNotFoundException;
 import com.itachallenge.challenge.helper.DocumentToDtoConverter;
 import com.itachallenge.challenge.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -21,15 +21,13 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class TagServiceImpl implements ITagService {
 
     private static final Logger log = LoggerFactory.getLogger(TagServiceImpl.class);
 
-    @Autowired
-    TagRepository tagRepository;
-
-    @Autowired
-    private DocumentToDtoConverter<TagDocument, TagDto> tagConverter = new DocumentToDtoConverter<>();
+    private final TagRepository tagRepository;
+    private final DocumentToDtoConverter<TagDocument, TagDto> tagConverter;
 
     @Cacheable(value = "tagsByLanguage")
     @Override


### PR DESCRIPTION
## Summary

This PR addresses [task 719](https://tree.taiga.io/project/luisvi-ita-challenges/task/719)

It comes from [the technical debt of this task](https://tree.taiga.io/project/luisvi-ita-challenges/issue/641), which this PR addresses specifically for the challenge microservice. The rest of the microservices, as well as the test refactors, are out of scope for this PR.

The goal is to remove all @Autowired annotations from the LanguageServiceImpl.java and TagServiceImpl.java classes (both part of the Challenge microservice), and to use constructor injection via Lombok’s @RequiredArgsConstructor.


### Changes

- LanguageServiceImpl.java:
   - Removed 1 @Autowired annotation. No additional changes were made as the @Autowired was redundant, there was already a @RequiredArgsConstructor in the class. 

- TagServiceImpl.java:
   - Removed 2 @Autowired annotations and used @requiredargsconstructor instead
   - I removed the ''= new DocumentToDtoConverter<>()"" instantiation from TagServiceImpl to allow the converter to be injected via the constructor. This change enables proper dependency injection, making the class easier to test. Specifically, it allows us to mock and verify interactions with the converter in unit tests. Keeping the direct instantiation was bypassing the mock, causing test failures due to unverified method calls
   - Marked the dependencies as final


### Justification for the Refactor

- Improves code quality and testability: Dependencies are injected via the constructor, making unit testing easier without needing to load the full Spring context.

- Enhances readability: Dependencies are explicitly declared and made mandatory.

- Promotes immutability: Dependencies can now be marked as final, enforcing best practices.

 
### Notes

- No new tests were needed and and all existing tests pass

- Following [Taiga's guidelines](https://tree.taiga.io/project/luisvi-ita-challenges/wiki/guidehow-to-update-changelog-version),the changelog was not updated since this is a refactor and doesn't require it.


### PR author self-check

- [x] I tested my changes locally and verified they work as expected
- [x] The PR has a clear and focused purpose
- [x] Title and description are filled in correctly. No changelog edit needed since it's a refactor
- [x] There are no leftover merge conflicts or unrelated changes from previous branches
- [x] All automated checks (like SonarCloud) have passed
- [x] All existing tests pass and no new ones were needed