### PR TITLE
PR2/2 - Refactor(user) : refactor user global handler using api error response #743

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -13,6 +13,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @Setter
 public class APIErrorResponse {
+    @JsonProperty("timestamp")
+    private Instant timestamp;
+
+    @JsonProperty("status")
+    private int status;
 
     @JsonProperty("error")
     private String error;
@@ -20,20 +25,14 @@ public class APIErrorResponse {
     @JsonProperty("message")
     private String message;
 
-    @JsonProperty("timestamp")
-    private Instant timestamp;
-
-    @JsonProperty("status")
-    private int status;
-
     @JsonProperty("path")
     private String path;
 
-    public APIErrorResponse(String error, String message, HttpStatus status, String path){
-        this.error = error;
-        this.message = message;
+    public APIErrorResponse(HttpStatus status, String error, String message, String path){
         this.timestamp = Instant.now();
         this.status = status.value();
+        this.error = error;
+        this.message = message;
         this.path = path;
 
     }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -1,27 +1,42 @@
 package com.itachallenge.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.Instant;
 
-@AllArgsConstructor
+import org.springframework.http.HttpStatus;
+
 @NoArgsConstructor
 @Getter
 @Setter
 public class APIErrorResponse {
 
     @JsonProperty("error")
-    String error;
+    private String error;
 
     @JsonProperty("message")
-    String message;
+    private String message;
 
     @JsonProperty("timestamp")
-    Instant timestamp;
+    private Instant timestamp;
+
+    @JsonProperty("status")
+    private int status;
+
+    @JsonProperty("path")
+    private String path;
+
+    public APIErrorResponse(String error, String message, HttpStatus status, String path){
+        this.error = error;
+        this.message = message;
+        this.timestamp = Instant.now();
+        this.status = status.value();
+        this.path = path;
+
+    }
 
 }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -12,7 +12,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import jakarta.validation.ConstraintViolationException;
 
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -94,9 +93,9 @@ public class UserGlobalExceptionHandler {
         } else {
             status = HttpStatus.SERVICE_UNAVAILABLE; // 503
         }
-
+        String path = "path unavailable - WIP";
         return ResponseEntity.status(status).body(
-                new APIErrorResponse("GitHub API error", ex.getMessage(), Instant.now())
+                new APIErrorResponse("GitHub API error", ex.getMessage(), status, path)
         );
     }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -80,7 +80,7 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
     }
 
-    /// ******** TO BE REFACTORIZED USING ApiErrorResponse ************
+    // ******** TO BE REFACTORIZED USING ApiErrorResponse ************
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<String> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid parameter format.");

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package com.itachallenge.user.exception;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +9,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ServerWebExchange;
 
 import jakarta.validation.ConstraintViolationException;
 
@@ -21,68 +21,68 @@ import java.util.Map;
 public class UserGlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<APIErrorResponse> handleAny(Exception e, HttpServletRequest request) {
+    public ResponseEntity<APIErrorResponse> handleAny(Exception e, ServerWebExchange exchange) {
         log.error("Unexpected error happened: {}", e.getMessage(), e);
         APIErrorResponse errorResponse = new APIErrorResponse(
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 "Internal Server Error",
                 "An unexpected error occurred. Please try again later.",
-                request.getRequestURI()
+                exchange.getRequest().getPath().value()
                 );
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<APIErrorResponse> handleIllegalArgument(IllegalArgumentException e, HttpServletRequest request) {
+    public ResponseEntity<APIErrorResponse> handleIllegalArgument(IllegalArgumentException e, ServerWebExchange exchange) {
         log.error("Illegal argument: {}", e.getMessage(), e);
         APIErrorResponse errorResponse = new APIErrorResponse(
                 HttpStatus.BAD_REQUEST,
                 "Illegal argument",
                 "Invalid input provided. Please check your request.",
-                request.getRequestURI()
+                exchange.getRequest().getPath().value()
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<APIErrorResponse> handleValidationExceptions(ConstraintViolationException e, HttpServletRequest request) {
+    public ResponseEntity<APIErrorResponse> handleValidationExceptions(ConstraintViolationException e, ServerWebExchange exchange) {
         log.error("Validation error: {}", e.getMessage(), e);
         APIErrorResponse errorResponse = new APIErrorResponse(
                 HttpStatus.BAD_REQUEST,
                 "Validation failed",
                 "Validation failed for one or more fields. Please check your request.",
-                request.getRequestURI()
+                exchange.getRequest().getPath().value()
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<APIErrorResponse> handleBadRequestException(BadRequestException e, HttpServletRequest request) {
+    public ResponseEntity<APIErrorResponse> handleBadRequestException(BadRequestException e, ServerWebExchange exchange) {
         log.error("Bad Request : {}" , e.getMessage(), e);
        APIErrorResponse errorResponse = new APIErrorResponse(
                HttpStatus.BAD_REQUEST,
                "Bad Request",
-               "Invalid input provided. Please check your request.",
-               request.getRequestURI()
+               e.getMessage(),
+               exchange.getRequest().getPath().value()
        );
        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<APIErrorResponse> handleNotFoundException(NotFoundException e, HttpServletRequest request) {
+    public ResponseEntity<APIErrorResponse> handleNotFoundException(NotFoundException e, ServerWebExchange exchange) {
         log.error("Not Found : {}" , e.getMessage(), e);
         APIErrorResponse errorResponse = new APIErrorResponse(
                 HttpStatus.NOT_FOUND,
                 "Not found",
-                "The requested resource was not found.",
-                request.getRequestURI()
+                e.getMessage(),
+                exchange.getRequest().getPath().value()
         );
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
     }
 
     /// ******** TO BE REFACTORIZED USING ApiErrorResponse ************
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<String> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+    public ResponseEntity<String> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid parameter format.");
     }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -22,7 +22,7 @@ public class UserGlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<APIErrorResponse> handleAny(Exception e, HttpServletRequest request) {
-        log.error("Unexpected error happened: {}", e.getMessage());
+        log.error("Unexpected error happened: {}", e.getMessage(), e);
         APIErrorResponse errorResponse = new APIErrorResponse(
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 "Internal Server Error",
@@ -33,8 +33,15 @@ public class UserGlobalExceptionHandler {
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    public ResponseEntity<APIErrorResponse> handleIllegalArgument(IllegalArgumentException e, HttpServletRequest request) {
+        log.error("Illegal argument: {}", e.getMessage(), e);
+        APIErrorResponse errorResponse = new APIErrorResponse(
+                HttpStatus.BAD_REQUEST,
+                "Illegal argument",
+                "Invalid input provided. Please check your request.",
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.itachallenge.user.exception;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +21,15 @@ import java.util.Map;
 public class UserGlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleAny(Exception e) {
+    public ResponseEntity<APIErrorResponse> handleAny(Exception e, HttpServletRequest request) {
         log.error("Unexpected error happened: {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Unexpected error happened.");
+        APIErrorResponse errorResponse = new APIErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Internal Server Error",
+                "An unexpected error occurred. Please try again later.",
+                request.getRequestURI()
+                );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -69,8 +69,15 @@ public class UserGlobalExceptionHandler {
     }
 
     @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<String> handleNotFoundException(NotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    public ResponseEntity<APIErrorResponse> handleNotFoundException(NotFoundException e, HttpServletRequest request) {
+        log.error("Not Found : {}" , e.getMessage(), e);
+        APIErrorResponse errorResponse = new APIErrorResponse(
+                HttpStatus.NOT_FOUND,
+                "Not found",
+                "The requested resource was not found.",
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
     }
 
     /// ******** TO BE REFACTORIZED USING ApiErrorResponse ************

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -54,12 +54,18 @@ public class UserGlobalExceptionHandler {
                 request.getRequestURI()
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
-
     }
 
     @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<String> handleBadRequestException(BadRequestException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    public ResponseEntity<APIErrorResponse> handleBadRequestException(BadRequestException e, HttpServletRequest request) {
+        log.error("Bad Request : {}" , e.getMessage(), e);
+       APIErrorResponse errorResponse = new APIErrorResponse(
+               HttpStatus.BAD_REQUEST,
+               "Bad Request",
+               "Invalid input provided. Please check your request.",
+               request.getRequestURI()
+       );
+       return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     @ExceptionHandler(NotFoundException.class)

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -95,7 +95,7 @@ public class UserGlobalExceptionHandler {
         }
         String path = "path unavailable - WIP";
         return ResponseEntity.status(status).body(
-                new APIErrorResponse("GitHub API error", ex.getMessage(), status, path)
+                new APIErrorResponse(status, "GitHub API error", ex.getMessage(),  path)
         );
     }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -45,8 +45,16 @@ public class UserGlobalExceptionHandler {
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<String> handleValidationExceptions(ConstraintViolationException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    public ResponseEntity<APIErrorResponse> handleValidationExceptions(ConstraintViolationException e, HttpServletRequest request) {
+        log.error("Validation error: {}", e.getMessage(), e);
+        APIErrorResponse errorResponse = new APIErrorResponse(
+                HttpStatus.BAD_REQUEST,
+                "Validation failed",
+                "Validation failed for one or more fields. Please check your request.",
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -57,15 +57,22 @@ public class UserGlobalExceptionHandler {
 
     }
 
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<String> handleBadRequestException(BadRequestException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<String> handleNotFoundException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    /// ******** TO BE REFACTORIZED USING ApiErrorResponse ************
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<String> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid parameter format.");
     }
 
-    @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<String> handleBadRequestException(BadRequestException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
-    }
 
     @ExceptionHandler(BadUUIDException.class)
     public ResponseEntity<String> handleBadUUIDException(BadUUIDException e) {
@@ -77,10 +84,6 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Database error: " + e.getMessage());
     }
 
-    @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<String> handleNotFoundException(NotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-    }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -212,7 +212,7 @@ class UserControllerTest {
                 .expectBody()
                 .jsonPath("$.status").isEqualTo(404)
                 .jsonPath("$.error").isEqualTo("Not found")
-                .jsonPath("$.message").isEqualTo("User not found");        ;
+                .jsonPath("$.message").isEqualTo("User not found");
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -20,7 +20,6 @@ import reactor.core.publisher.Mono;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 class UserControllerTest {
@@ -644,8 +643,8 @@ class UserControllerTest {
                 .hasSize(2)
                 .value(list -> {
                     
-                    Assertions.assertEquals(sol1.getUserId(), list.get(0).getUserId());
-                    Assertions.assertEquals(sol1.getChallengeId(), list.get(0).getChallengeId());
+                    Assertions.assertEquals(sol1.getUserId(), list.getFirst().getUserId());
+                    Assertions.assertEquals(sol1.getChallengeId(), list.getFirst().getChallengeId());
                     Assertions.assertEquals(sol1.getLanguageId(), list.get(0).getLanguageId());
                     Assertions.assertEquals(sol1.getSolutionText(), list.get(0).getSolutionText());
                     

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -89,7 +89,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + githubUsername)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(404)
+                .jsonPath("$.error").isEqualTo("Not found")
+                .jsonPath("$.message").isEqualTo("User not found");
 
         verify(userService, times(1)).getUser(githubUsername);
     }
@@ -103,7 +106,11 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + githubUsername)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+                .expectBody()
+                        .jsonPath("$.status").isEqualTo(500)
+                        .jsonPath("$.error").isEqualTo("Internal Server Error")
+                        .jsonPath("$.message").isEqualTo("An unexpected error occurred. Please try again later.");
+
 
         verify(userService, times(1)).getUser(githubUsername);
     }
@@ -183,7 +190,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(404)
+                .jsonPath("$.error").isEqualTo("Not found")
+                .jsonPath("$.message").isEqualTo("User not found");
 
         verify(userService, times(1)).addChallengeToFavorites(userId, challengeId);
     }
@@ -199,7 +209,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(404)
+                .jsonPath("$.error").isEqualTo("Not found")
+                .jsonPath("$.message").isEqualTo("User not found");        ;
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }
@@ -247,7 +260,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(500)
+                .jsonPath("$.error").isEqualTo("Internal Server Error")
+                .jsonPath("$.message").isEqualTo("An unexpected error occurred. Please try again later.");
 
         verify(userService, times(1)).addChallengeToFavorites(userId, challengeId);
     }
@@ -263,7 +279,11 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+                .expectBody()
+                        .jsonPath("$.status").isEqualTo(500)
+                        .jsonPath("$.error").isEqualTo("Internal Server Error")
+                        .jsonPath("$.message").isEqualTo("An unexpected error occurred. Please try again later.")
+                        .jsonPath("$.path").isEqualTo("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId);
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }
@@ -343,7 +363,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(404)
+                .jsonPath("$.error").isEqualTo("Not found")
+                .jsonPath("$.message").isEqualTo("User not found");
 
         verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
@@ -359,7 +382,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(404)
+                .jsonPath("$.error").isEqualTo("Not found")
+                .jsonPath("$.message").isEqualTo("User not found");
 
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
     }
@@ -407,7 +433,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(500)
+                .jsonPath("$.error").isEqualTo("Internal Server Error")
+                .jsonPath("$.message").isEqualTo("An unexpected error occurred. Please try again later.");
 
         verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
@@ -423,7 +452,12 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(500)
+                .jsonPath("$.error").isEqualTo("Internal Server Error")
+                .jsonPath("$.message").isEqualTo("An unexpected error occurred. Please try again later.");
+
+
 
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
     }
@@ -459,7 +493,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/favorites", userId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(404)
+                .jsonPath("$.error").isEqualTo("Not found")
+                .jsonPath("$.message").isEqualTo("User not found");
 
         verify(userService, times(1)).getUserFavorites(userId.toString());
     }
@@ -493,7 +530,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/favorites", userId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(500)
+                .jsonPath("$.error").isEqualTo("Internal Server Error")
+                .jsonPath("$.message").isEqualTo("An unexpected error occurred. Please try again later.");
 
         verify(userService, times(1)).getUserFavorites(userId.toString());
     }
@@ -529,7 +569,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(404)
+                .jsonPath("$.error").isEqualTo("Not found")
+                .jsonPath("$.message").isEqualTo("User not found");
 
         verify(userService, times(1)).getUserBookmarks(userId.toString());
     }
@@ -563,7 +606,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(500)
+                .jsonPath("$.error").isEqualTo("Internal Server Error")
+                .jsonPath("$.message").isEqualTo("An unexpected error occurred. Please try again later.");
 
         verify(userService, times(1)).getUserBookmarks(userId.toString());
     }
@@ -625,9 +671,11 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class)
-                .isEqualTo("Solutions not found");
-        
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(404)
+                .jsonPath("$.error").isEqualTo("Not found")
+                .jsonPath("$.message").isEqualTo("Solutions not found");
+
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
     
@@ -661,9 +709,11 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class)
-                .isEqualTo("Unexpected error happened.");
-        
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(500)
+                .jsonPath("$.error").isEqualTo("Internal Server Error")
+                .jsonPath("$.message").isEqualTo("An unexpected error occurred. Please try again later.");
+
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -13,8 +13,8 @@ class APIErrorResponseTest {
 
     @Test
     void testConstructorAndGetters() {
-        Instant now = Instant.now();
-        APIErrorResponse errorResponse = new APIErrorResponse("Some error", "Something went wrong", HttpStatus.NOT_FOUND, "http://localhost:8762/api/v1/user");
+
+        APIErrorResponse errorResponse = new APIErrorResponse(HttpStatus.NOT_FOUND, "Some error", "Something went wrong", "http://localhost:8762/api/v1/user");
 
         assertEquals("Some error", errorResponse.getError());
         assertEquals("Something went wrong", errorResponse.getMessage());

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -18,7 +18,9 @@ class APIErrorResponseTest {
 
         assertEquals("Some error", errorResponse.getError());
         assertEquals("Something went wrong", errorResponse.getMessage());
-        assertEquals(now, errorResponse.getTimestamp());
+        assertNotNull(errorResponse.getTimestamp());
+        assertEquals(HttpStatus.NOT_FOUND.value(), errorResponse.getStatus());
+        assertEquals("http://localhost:8762/api/v1/user", errorResponse.getPath());
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -4,14 +4,17 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
+import org.springframework.http.HttpStatus;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class APIErrorResponseTest {
 
     @Test
     void testConstructorAndGetters() {
         Instant now = Instant.now();
-        APIErrorResponse errorResponse = new APIErrorResponse("Some error", "Something went wrong", now);
+        APIErrorResponse errorResponse = new APIErrorResponse("Some error", "Something went wrong", HttpStatus.NOT_FOUND, "http://localhost:8762/api/v1/user");
 
         assertEquals("Some error", errorResponse.getError());
         assertEquals("Something went wrong", errorResponse.getMessage());
@@ -25,9 +28,13 @@ class APIErrorResponseTest {
         errorResponse.setError("Another error");
         errorResponse.setMessage("Different message");
         errorResponse.setTimestamp(now);
+        errorResponse.setStatus(404);
+        errorResponse.setPath("http://localhost:8762/api/v1/user");
 
         assertEquals("Another error", errorResponse.getError());
         assertEquals("Different message", errorResponse.getMessage());
-        assertEquals(now, errorResponse.getTimestamp());
+        assertNotNull(errorResponse.getTimestamp());
+        assertEquals(404, errorResponse.getStatus());
+        assertEquals("http://localhost:8762/api/v1/user", errorResponse.getPath());
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -29,14 +29,14 @@ class UserGlobalExceptionHandlerTest {
         exceptionHandler = new UserGlobalExceptionHandler();
     }
 
-    private ServerWebExchange mockExchange(String path){
+    private ServerWebExchange mockExchange(){
         ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
         ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
         RequestPath requestPath = Mockito.mock(RequestPath.class);
 
         when(exchange.getRequest()).thenReturn(request);
         when(request.getPath()).thenReturn(requestPath);
-        when(requestPath.value()).thenReturn(path);
+        when(requestPath.value()).thenReturn("/api/v1/user/123");
 
         return exchange;
     }
@@ -45,7 +45,7 @@ class UserGlobalExceptionHandlerTest {
     void testHandleAny() {
         Exception exception = new Exception("Unexpected Error");
 
-        ServerWebExchange exchange = mockExchange("/api/v1/user/123");
+        ServerWebExchange exchange = mockExchange();
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleAny(exception, exchange);
         APIErrorResponse body = response.getBody();
@@ -65,7 +65,7 @@ class UserGlobalExceptionHandlerTest {
     void testHandleIllegalArgument() {
         IllegalArgumentException exception = new IllegalArgumentException("Invalid argument");
 
-        ServerWebExchange exchange = mockExchange("/api/v1/user/123");
+        ServerWebExchange exchange = mockExchange();
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleIllegalArgument(exception, exchange);
         APIErrorResponse body = response.getBody();
@@ -83,7 +83,7 @@ class UserGlobalExceptionHandlerTest {
     void testHandleValidationExceptions() {
         ConstraintViolationException exception = new ConstraintViolationException("Validation failed", null);
 
-        ServerWebExchange exchange = mockExchange("/api/v1/user/123");
+        ServerWebExchange exchange = mockExchange();
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleValidationExceptions(exception, exchange);
         APIErrorResponse body = response.getBody();
@@ -110,7 +110,7 @@ class UserGlobalExceptionHandlerTest {
     void testHandleBadRequestException() {
         BadRequestException exception = new BadRequestException("Bad request error");
 
-        ServerWebExchange exchange = mockExchange("/api/v1/user/123");
+        ServerWebExchange exchange = mockExchange();
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleBadRequestException(exception, exchange);
         APIErrorResponse body = response.getBody();
@@ -137,7 +137,7 @@ class UserGlobalExceptionHandlerTest {
     void testHandleNotFoundException() {
         NotFoundException exception = new NotFoundException("Resource not found");
 
-        ServerWebExchange exchange = mockExchange("/api/v1/user/123");
+        ServerWebExchange exchange = mockExchange();
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleNotFoundException(exception, exchange);
         APIErrorResponse body = response.getBody();

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -67,10 +67,19 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleValidationExceptions() {
         ConstraintViolationException exception = new ConstraintViolationException("Validation failed", null);
-        ResponseEntity<String> response = exceptionHandler.handleValidationExceptions(exception);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/api/v1/user/123");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleValidationExceptions(exception, request);
+        APIErrorResponse body = response.getBody();
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("Validation failed", response.getBody());
+        assertNotNull(body);
+        assertNotNull(body.getTimestamp());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), body.getStatus());
+        assertEquals("Validation failed", body.getError());
+        assertEquals("Validation failed for one or more fields. Please check your request.", body.getMessage());
+        assertEquals("/api/v1/user/123", body.getPath());
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -49,10 +49,19 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleIllegalArgument() {
         IllegalArgumentException exception = new IllegalArgumentException("Invalid argument");
-        ResponseEntity<String> response = exceptionHandler.handleIllegalArgument(exception);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/api/v1/user/123");
 
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertEquals("Invalid argument", response.getBody());
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleIllegalArgument(exception, request);
+        APIErrorResponse body = response.getBody();
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(body);
+        assertNotNull(body.getTimestamp());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), body.getStatus());
+        assertEquals("Illegal argument", body.getError());
+        assertEquals("Invalid input provided. Please check your request.", body.getMessage());
+        assertEquals("/api/v1/user/123", body.getPath());
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -1,17 +1,18 @@
 package com.itachallenge.user.exception;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 
 import java.util.Objects;
@@ -28,11 +29,22 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleAny() {
         Exception exception = new Exception("Unexpected Error");
-        ResponseEntity<String> response = exceptionHandler.handleAny(exception);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/api/v1/user/123");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleAny(exception, request);
+        APIErrorResponse body = response.getBody();
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        assertTrue(Objects.requireNonNull(response.getBody()).contains("Unexpected error happened."));
+        assertNotNull(body);
+        assertNotNull(body.getTimestamp());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), body.getStatus());
+        assertEquals("Internal Server Error", body.getError());
+        assertEquals("An unexpected error occurred. Please try again later.", body.getMessage());
+        assertEquals("/api/v1/user/123", body.getPath());
+
     }
+
 
     @Test
     void testHandleIllegalArgument() {

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -2,7 +2,6 @@ package com.itachallenge.user.exception;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
@@ -16,10 +15,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
-
-import java.util.Objects;
 
 class UserGlobalExceptionHandlerTest {
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.user.exception;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
@@ -17,6 +18,8 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 
 import jakarta.validation.ConstraintViolationException;
 
+import java.util.Objects;
+
 class UserGlobalExceptionHandlerTest {
 
     private UserGlobalExceptionHandler exceptionHandler;
@@ -26,17 +29,23 @@ class UserGlobalExceptionHandlerTest {
         exceptionHandler = new UserGlobalExceptionHandler();
     }
 
-    @Test
-    void testHandleAny() {
-        Exception exception = new Exception("Unexpected Error");
-
+    private ServerWebExchange mockExchange(String path){
         ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
         ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
         RequestPath requestPath = Mockito.mock(RequestPath.class);
 
-        Mockito.when(exchange.getRequest()).thenReturn(request);
-        Mockito.when(request.getPath()).thenReturn(requestPath);
-        Mockito.when(requestPath.value()).thenReturn("/api/v1/user/123");
+        when(exchange.getRequest()).thenReturn(request);
+        when(request.getPath()).thenReturn(requestPath);
+        when(requestPath.value()).thenReturn(path);
+
+        return exchange;
+    }
+
+    @Test
+    void testHandleAny() {
+        Exception exception = new Exception("Unexpected Error");
+
+        ServerWebExchange exchange = mockExchange("/api/v1/user/123");
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleAny(exception, exchange);
         APIErrorResponse body = response.getBody();
@@ -56,13 +65,7 @@ class UserGlobalExceptionHandlerTest {
     void testHandleIllegalArgument() {
         IllegalArgumentException exception = new IllegalArgumentException("Invalid argument");
 
-        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
-        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
-        RequestPath requestPath = Mockito.mock(RequestPath.class);
-
-        Mockito.when(exchange.getRequest()).thenReturn(request);
-        Mockito.when(request.getPath()).thenReturn(requestPath);
-        Mockito.when(requestPath.value()).thenReturn("/api/v1/user/123");
+        ServerWebExchange exchange = mockExchange("/api/v1/user/123");
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleIllegalArgument(exception, exchange);
         APIErrorResponse body = response.getBody();
@@ -80,13 +83,7 @@ class UserGlobalExceptionHandlerTest {
     void testHandleValidationExceptions() {
         ConstraintViolationException exception = new ConstraintViolationException("Validation failed", null);
 
-        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
-        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
-        RequestPath requestPath = Mockito.mock(RequestPath.class);
-
-        Mockito.when(exchange.getRequest()).thenReturn(request);
-        Mockito.when(request.getPath()).thenReturn(requestPath);
-        Mockito.when(requestPath.value()).thenReturn("/api/v1/user/123");
+        ServerWebExchange exchange = mockExchange("/api/v1/user/123");
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleValidationExceptions(exception, exchange);
         APIErrorResponse body = response.getBody();
@@ -113,13 +110,7 @@ class UserGlobalExceptionHandlerTest {
     void testHandleBadRequestException() {
         BadRequestException exception = new BadRequestException("Bad request error");
 
-        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
-        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
-        RequestPath requestPath = Mockito.mock(RequestPath.class);
-
-        Mockito.when(exchange.getRequest()).thenReturn(request);
-        Mockito.when(request.getPath()).thenReturn(requestPath);
-        Mockito.when(requestPath.value()).thenReturn("/api/v1/user/123");
+        ServerWebExchange exchange = mockExchange("/api/v1/user/123");
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleBadRequestException(exception, exchange);
         APIErrorResponse body = response.getBody();
@@ -146,13 +137,7 @@ class UserGlobalExceptionHandlerTest {
     void testHandleNotFoundException() {
         NotFoundException exception = new NotFoundException("Resource not found");
 
-        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
-        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
-        RequestPath requestPath = Mockito.mock(RequestPath.class);
-
-        Mockito.when(exchange.getRequest()).thenReturn(request);
-        Mockito.when(request.getPath()).thenReturn(requestPath);
-        Mockito.when(requestPath.value()).thenReturn("/api/v1/user/123");
+        ServerWebExchange exchange = mockExchange("/api/v1/user/123");
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleNotFoundException(exception, exchange);
         APIErrorResponse body = response.getBody();
@@ -193,7 +178,7 @@ class UserGlobalExceptionHandlerTest {
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
 
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
-        assertEquals("GitHub API error", response.getBody().getError());
+        assertEquals("GitHub API error", Objects.requireNonNull(response.getBody()).getError());
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -94,10 +94,19 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleBadRequestException() {
         BadRequestException exception = new BadRequestException("Bad request error");
-        ResponseEntity<String> response = exceptionHandler.handleBadRequestException(exception);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/api/v1/user/123");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleBadRequestException(exception, request);
+        APIErrorResponse body = response.getBody();
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("Bad request error", response.getBody());
+        assertNotNull(body);
+        assertNotNull(body.getTimestamp());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), body.getStatus());
+        assertEquals("Bad Request", body.getError());
+        assertEquals("Invalid input provided. Please check your request.", body.getMessage());
+        assertEquals("/api/v1/user/123", body.getPath());
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.user.exception;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
@@ -121,11 +122,18 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleNotFoundException() {
         NotFoundException exception = new NotFoundException("Resource not found");
-        ResponseEntity<String> response = exceptionHandler.handleNotFoundException(exception);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/api/v1/user/123");
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleNotFoundException(exception, request);
+        APIErrorResponse body = response.getBody();
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertEquals("Resource not found", response.getBody());
-    }
+        assertNotNull(body);
+        assertNotNull(body.getTimestamp());
+        assertEquals(HttpStatus.NOT_FOUND.value(), body.getStatus());
+        assertEquals("Not found", body.getError());
+        assertEquals("The requested resource was not found.", body.getMessage());
+        assertEquals("/api/v1/user/123", body.getPath());    }
 
     @Test
     void testHandleUnmodifiableSolutionException(){

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -11,7 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.RequestPath;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
@@ -30,10 +33,16 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleAny() {
         Exception exception = new Exception("Unexpected Error");
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        Mockito.when(request.getRequestURI()).thenReturn("/api/v1/user/123");
 
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleAny(exception, request);
+        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
+        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
+        RequestPath requestPath = Mockito.mock(RequestPath.class);
+
+        Mockito.when(exchange.getRequest()).thenReturn(request);
+        Mockito.when(request.getPath()).thenReturn(requestPath);
+        Mockito.when(requestPath.value()).thenReturn("/api/v1/user/123");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleAny(exception, exchange);
         APIErrorResponse body = response.getBody();
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
@@ -50,10 +59,16 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleIllegalArgument() {
         IllegalArgumentException exception = new IllegalArgumentException("Invalid argument");
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        Mockito.when(request.getRequestURI()).thenReturn("/api/v1/user/123");
 
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleIllegalArgument(exception, request);
+        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
+        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
+        RequestPath requestPath = Mockito.mock(RequestPath.class);
+
+        Mockito.when(exchange.getRequest()).thenReturn(request);
+        Mockito.when(request.getPath()).thenReturn(requestPath);
+        Mockito.when(requestPath.value()).thenReturn("/api/v1/user/123");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleIllegalArgument(exception, exchange);
         APIErrorResponse body = response.getBody();
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
@@ -68,10 +83,16 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleValidationExceptions() {
         ConstraintViolationException exception = new ConstraintViolationException("Validation failed", null);
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        Mockito.when(request.getRequestURI()).thenReturn("/api/v1/user/123");
 
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleValidationExceptions(exception, request);
+        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
+        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
+        RequestPath requestPath = Mockito.mock(RequestPath.class);
+
+        Mockito.when(exchange.getRequest()).thenReturn(request);
+        Mockito.when(request.getPath()).thenReturn(requestPath);
+        Mockito.when(requestPath.value()).thenReturn("/api/v1/user/123");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleValidationExceptions(exception, exchange);
         APIErrorResponse body = response.getBody();
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
@@ -95,10 +116,16 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleBadRequestException() {
         BadRequestException exception = new BadRequestException("Bad request error");
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        Mockito.when(request.getRequestURI()).thenReturn("/api/v1/user/123");
 
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleBadRequestException(exception, request);
+        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
+        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
+        RequestPath requestPath = Mockito.mock(RequestPath.class);
+
+        Mockito.when(exchange.getRequest()).thenReturn(request);
+        Mockito.when(request.getPath()).thenReturn(requestPath);
+        Mockito.when(requestPath.value()).thenReturn("/api/v1/user/123");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleBadRequestException(exception, exchange);
         APIErrorResponse body = response.getBody();
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
@@ -106,7 +133,7 @@ class UserGlobalExceptionHandlerTest {
         assertNotNull(body.getTimestamp());
         assertEquals(HttpStatus.BAD_REQUEST.value(), body.getStatus());
         assertEquals("Bad Request", body.getError());
-        assertEquals("Invalid input provided. Please check your request.", body.getMessage());
+        assertEquals("Bad request error", body.getMessage());
         assertEquals("/api/v1/user/123", body.getPath());
     }
 
@@ -122,9 +149,16 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleNotFoundException() {
         NotFoundException exception = new NotFoundException("Resource not found");
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        when(request.getRequestURI()).thenReturn("/api/v1/user/123");
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleNotFoundException(exception, request);
+
+        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
+        ServerHttpRequest request = Mockito.mock(ServerHttpRequest.class);
+        RequestPath requestPath = Mockito.mock(RequestPath.class);
+
+        Mockito.when(exchange.getRequest()).thenReturn(request);
+        Mockito.when(request.getPath()).thenReturn(requestPath);
+        Mockito.when(requestPath.value()).thenReturn("/api/v1/user/123");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleNotFoundException(exception, exchange);
         APIErrorResponse body = response.getBody();
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -132,7 +166,7 @@ class UserGlobalExceptionHandlerTest {
         assertNotNull(body.getTimestamp());
         assertEquals(HttpStatus.NOT_FOUND.value(), body.getStatus());
         assertEquals("Not found", body.getError());
-        assertEquals("The requested resource was not found.", body.getMessage());
+        assertEquals("Resource not found", body.getMessage());
         assertEquals("/api/v1/user/123", body.getPath());    }
 
     @Test


### PR DESCRIPTION
This PR is the second part of 2 which are derived from the following Taiga tasks :
 #981 PR1/2 - Refactorize ErrorResponseApi DTO adding fields as :httpStatus, path : link toTaiga : [741](https://tree.taiga.io/project/luisvi-ita-challenges/t/741)
 PR2/2 - Implement ErrorResponseApi DTO in the most used UserExceptionHandlers : link to Taiga : [743](https://tree.taiga.io/project/luisvi-ita-challenges/task/743)

**GOAL**
Standardize the User Global Exception Handler by implementing ApiErrorResponse in all exception handlers so that they return the same response structure

**CHANGES**
In-scope : 5 handlers and their tests 

- [x] handleAny(Exception e)
- [x] handleIllegalArgument(IllegalArgumentException e)
- [x] handleValidationExceptions(ConstraintViolationException ex)
- [x] handleBadRequestException(BadRequestException e)
- [x] handleNotFoundException(NotFoundException e)

Consequently, some of the UserController tests were not passing anymore as they were expecting a String as response and now receive a json format. 
In all tests, I replaced  : expectBody(String.class) by the following expectBody().jsonPath()  as in the following example

<img width="854" height="314" alt="imagen" src="https://github.com/user-attachments/assets/64b8e85c-06a8-41b3-ac97-cbc7ee9a0f7e" />

16 userController tests have been changed : 
- addToBookmarks_WhenUnexpectedError_Returns500()
- addToBookmarks_WhenUserNotExists_Returns404()
- addToFavorites_WhenUnexpectedError_Returns500()
- addToFavorites_WhenUserNotExists_Returns404()
- deleteFromBookmarks_WhenUnexpectedError_Returns500()
- deleteFromBookmarks_WhenUserNotExists_Returns404()
- deleteFromFavorites_WhenUnexpectedError_Returns500()
- deleteFromFavorites_WhenUserNotExists_Returns404()
- getAllSolutions_returns404IfNotFound()     
- getAllSolutions_returns500IfUnexpectedError()
- getUserBookmarks_returns404IfUserNotFound()
- getUserBookmarks_returns500IfUnexpectedError()
- getUserFavorites_returns404IfUserNotFound()
- getUserFavorites_returns500IfUnexpectedError()
- getUser_WhenServiceReturnsError_Returns500()
- getUser_WhenUserNotExists_Returns404()

**CHANGELOG**
Changelog has not been updated as no new functionality has been added.


**DEFINITION OF DONE**
✅5 handlers refactored  and return  ApiErrorResponse
✅Units tests updated and green

### 📋 PR Author Self-check
✅ I tested my changes locally and verified they work as expected
✅ The PR has a clear and focused purpose
✅ Title, description, and changelog are filled in correctly
✅ No merge conflicts or unrelated changes
✅ All automated checks (SonarCloud, etc.) have passed
✅ I ran SonarLint locally and confirmed no warnings or errors
