### PR TITLE
PR1/3 - feat(user): add method addPointsToUser to UserService (#763)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by users ENDED is replaced with SUBMITTED_COMPLETE and SUBMITTED_INCOMPLETE has to be added to better reflect the status 
   in which challenges can be set (Taiga user story [#703])
   
+### [itachallenge-user-2.2.0-RELEASE] - 2025-10-03
+
+### Added
+- `addPointsToUser` method added to `UserService` interface.
+- `addPoints` and `addPointsToUser` implemented in `UserServiceImpl`.
+- Unit tests added to `UserServiceImplTest` covering:
+  - Adding points to users with and without existing values.
+  - Handling `null` values for `pointsToAdd`.
+
 ### [itachallenge-user-2.1.0-RELEASE] - 2025-10-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-3.1.0-RELEASE] - 2025-10-03
+
+### Added
+- `addPointsToUser` method added to `UserService` interface.
+- `addPoints` and `addPointsToUser` implemented in `UserServiceImpl`.
+- Unit tests added to `UserServiceImplTest` covering:
+    - Adding points to users with and without existing values.
+    - Handling `null` values for `pointsToAdd`.
+
+
 ### [itachallenge-user-3.0.0-RELEASE] - 2025-10-09
 
 ### Changed
@@ -15,15 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - this changes will break the communication between back and frontend, it is required to adjust the type of answer that can be submitted
   by users ENDED is replaced with SUBMITTED_COMPLETE and SUBMITTED_INCOMPLETE has to be added to better reflect the status 
   in which challenges can be set (Taiga user story [#703])
-  
-### [itachallenge-user-2.2.0-RELEASE] - 2025-10-03
 
-### Added
-- `addPointsToUser` method added to `UserService` interface.
-- `addPoints` and `addPointsToUser` implemented in `UserServiceImpl`.
-- Unit tests added to `UserServiceImplTest` covering:
-  - Adding points to users with and without existing values.
-  - Handling `null` values for `pointsToAdd`.
 
 ### [itachallenge-user-2.1.0-RELEASE] - 2025-10-03
 

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,8 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=3.0.0-RELEASE
-MICROSERVICE_VERSION_itachallenge-user=2.2.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=3.1.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.0-RELEASE

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -3,6 +3,7 @@ MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
 MICROSERVICE_VERSION_itachallenge-user=3.0.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=2.2.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.0-RELEASE

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
@@ -20,6 +20,8 @@ public interface UserService {
     Mono<Boolean> deleteChallengeFromBookmarks(String userId, String challengeId);
 
     Mono<Set<UUID>> getUserBookmarks(String userId);
-    
+
     Mono<UserDocument> getUserById(String userId);
+
+    Mono<Boolean> addPointsToUser(String userId, Integer pointsToAdd);
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @Service
-public class UserServiceImpl implements UserService {
+public class UserServiceImpl implements com.itachallenge.user.service.UserService {
 
     private final UserRepository userRepository;
 
@@ -168,11 +168,29 @@ public class UserServiceImpl implements UserService {
                                 .map(user -> Optional.ofNullable(user.getBookmarkChallenges()).orElseGet(HashSet::new))
                 );
     }
-    
+
     @Override
     public Mono<UserDocument> getUserById(String userId) {
         return userRepository.findById(UUID.fromString(userId))
                 .switchIfEmpty(Mono.error(new NotFoundException("User not found")));
     }
-    
+
+    @Override
+    public Mono<Boolean> addPointsToUser(String userId, Integer pointsToAdd) {
+        return parseAndValidateUUID(userId)
+                .flatMap(userUuid -> userRepository.findById(userUuid)
+                        .switchIfEmpty(Mono.error(new NotFoundException("User not found")))
+                        .flatMap(user -> addPoints(user, pointsToAdd))
+                );
+    }
+
+    private Mono<Boolean> addPoints(UserDocument user, Integer pointsToAdd) {
+        if(pointsToAdd == null) {
+            return Mono.error(new IllegalArgumentException("Points to add cannot be null"));
+        }
+        Integer userPoints = Optional.ofNullable(user.getPoints()).orElse(0);
+        user.setPoints(userPoints + pointsToAdd);
+        return userRepository.save(user).thenReturn(true);
+    }
+
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @Service
-public class UserServiceImpl implements com.itachallenge.user.service.UserService {
+public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -28,7 +28,7 @@ class UserServiceImplTest {
     private UserRepository userRepository;
 
     @InjectMocks
-    private UserServiceImpl userService;
+    private com.itachallenge.user.service.UserServiceImpl userService;
 
     private AutoCloseable mocks;
 
@@ -791,7 +791,7 @@ class UserServiceImplTest {
                                 error.getMessage().equals("Invalid ID format"))
                 .verify();
     }
-    
+
     @Test
     @DisplayName("getUserById returns the user when the user exists")
     void getUserById_ShouldReturnUser_WhenUserExists() {
@@ -799,20 +799,20 @@ class UserServiceImplTest {
         UUID userId=UUID.randomUUID();
         UserDocument existingUser = new UserDocument(userId, username, Role.ADMIN, null, null, 0);
         when(userRepository.findById(userId)).thenReturn(Mono.just(existingUser));
-        
+
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectNext(existingUser)
                 .verifyComplete();
-        
+
         verify(userRepository, times(1)).findById(userId);
     }
-    
+
     @Test
     @DisplayName("getUserById throws NotFoundException when the user does not exist")
     void getUserById_ShouldReturnNotFoundException_WhenUserDoesNotExist() {
         UUID userId=UUID.randomUUID();
         when(userRepository.findById(userId)).thenReturn(Mono.empty());
-        
+
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectErrorSatisfies(error -> {
                     assertInstanceOf(NotFoundException.class, error);
@@ -820,5 +820,81 @@ class UserServiceImplTest {
                 })
                 .verify();
         verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should add points when user exists and has existing points")
+    void addPointsToUser_ShouldAddPoints_WhenUserExistsWithPoints() {
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+        user.setPoints(10);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(userRepository.save(user)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), 5))
+                .expectNext(true)
+                .verifyComplete();
+
+        assertEquals(15, user.getPoints());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should initialize points when user has no points")
+    void addPointsToUser_ShouldAddPoints_WhenUserHasNoPoints() {
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+        user.setPoints(null);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(userRepository.save(user)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), 7))
+                .expectNext(true)
+                .verifyComplete();
+
+        assertEquals(7, user.getPoints());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should throw NotFoundException when user does not exist")
+    void addPointsToUser_ShouldThrowNotFoundException_WhenUserNotFound() {
+        UUID userId = UUID.randomUUID();
+
+        when(userRepository.findById(userId)).thenReturn(Mono.empty());
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), 5))
+                .expectErrorSatisfies(error -> {
+                    assertInstanceOf(NotFoundException.class, error);
+                    assertEquals("User not found", error.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should throw IllegalArgumentException when pointsToAdd is null")
+    void addPointsToUser_ShouldThrowIllegalArgumentException_WhenPointsIsNull() {
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), null))
+                .expectErrorSatisfies(error -> {
+                    assertInstanceOf(IllegalArgumentException.class, error);
+                    assertEquals("Points to add cannot be null", error.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(0)).save(any());
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -28,7 +28,7 @@ class UserServiceImplTest {
     private UserRepository userRepository;
 
     @InjectMocks
-    private com.itachallenge.user.service.UserServiceImpl userService;
+    private UserServiceImpl userService;
 
     private AutoCloseable mocks;
 


### PR DESCRIPTION
## 📌 Summary
This PR introduces functionality for managing user points within the service layer, fulfilling the requirements of User Story [#763](https://tree.taiga.io/project/luisvi-ita-challenges/task/763).  

It focuses exclusively on user point management and does not affect existing challenge-related functionality.

---

## 🧩 Checklist Alignment
This PR completes the **Core Feature** for User Story [#763](https://tree.taiga.io/project/luisvi-ita-challenges/task/763) – User Point Management.  

---

## 🔄 Context & Changes

**Before:**  
- The system had no mechanism to increment or validate user points in the service layer.

**After:**  
- ➕ **UserService**: Added `addPointsToUser(String userId, Integer pointsToAdd)` method.  
- ⚙️ **UserServiceImpl**: Implemented `addPoints(UserDocument user, Integer pointsToAdd)` and `addPointsToUser(String userId, Integer pointsToAdd)`.  
- 🛡️ **Validation**: Handles `null` values for `pointsToAdd` with appropriate exceptions.  
- 🧪 **Testing**: Added unit tests in `UserServiceImplTest` covering:  
  - Adding points to users with and without existing points.  
  - Handling `null` values for `pointsToAdd`.  
  - Behavior when the user is not found.  

**Comments**
- Despite points being 0 by default, we kept a safety check in the addPointsToUser method to deal with potential future problematic cases. 

---

## 📈 Impact for API Consumers
- No breaking changes.  
- Adds safe, validated support for user point management.  

---

## 📚 Changelog and .env.CI.dev
Updated version to 2.1.0 

---

## ⚠️ Technical Debt
The literal `"User not found"` is duplicated in multiple locations inside `UserServiceImpl`.  
✅ Recommendation: extract into a `private static final String USER_NOT_FOUND_MESSAGE = "User not found";` constant for maintainability.  

<img width="594" height="89" alt="Captura de pantalla 2025-10-03 142915" src="https://github.com/user-attachments/assets/bb8febae-1b18-42e8-bbdc-fef0dc41867b" />

---

## 🧪 How to Test
1. Run unit tests in `UserServiceImplTest`.  
2. Verify:  
   - Points are added correctly for users with and without existing values.  
   - `null` input for `pointsToAdd` triggers expected exception.  
   - Non-existent users trigger the expected exception.  
3. Confirm no regression failures in unrelated tests.  

---

## ✍️ PR Author Self-check
- [x] I tested my changes locally and verified they work as expected  
- [x] The PR has a clear and focused purpose (only user point management)  
- [x] Title, description, and changelog are filled in correctly  
- [x] There are no leftover merge conflicts or unrelated changes  
- [x] All automated checks (SonarCloud, etc.) have passed  
- [x] I responded to all previous review comments and only resolved those I truly addressed  
- [x] I ran SonarLint locally on the modified files and confirmed there are no warnings or errors  
