### PR TITLE
PR2/3 feat(user): Add points awarding logic on challenge completion (#764)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-user-2.3.0-RELEASE] - 2025-10-03
+### [itachallenge-user-2.2.1-RELEASE] - 2025-10-03
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added user/create endpoint to add an alumnee without role validation. (Taiga [#618], PR [#953])
 
-
-
 ### [itachallenge-challenge-2.4.1-RELEASE] - 2025-07-21
 
 ### Refactored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-2.3.0-RELEASE] - 2025-10-03
+
+### Changed
+
+- Added method awardPointsForSolvedChallenge to UserSolutionServiceImpl that awards points to users when they solved a
+  challenge (Taiga [#764], PR [#989])
+  - created constant to store the number of points that should be added
+  - injected UserService dependency to UserSolutionService
+
 ### [itachallenge-user-2.2.0-RELEASE] - 2025-10-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added user/create endpoint to add an alumnee without role validation. (Taiga [#618], PR [#953])
 
+
+
 ### [itachallenge-challenge-2.4.1-RELEASE] - 2025-07-21
 
 ### Refactored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-2.2.0-RELEASE] - 2025-10-03
+
+### Added
+- `addPointsToUser` method added to `UserService` interface.
+- `addPoints` and `addPointsToUser` implemented in `UserServiceImpl`.
+- Unit tests added to `UserServiceImplTest` covering:
+  - Adding points to users with and without existing values.
+  - Handling `null` values for `pointsToAdd`.
+
 ### [itachallenge-user-2.1.0-RELEASE] - 2025-10-03
 
 ### Added

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=2.2.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=2.3.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.0-RELEASE

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=2.1.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=2.2.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.0-RELEASE

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=2.3.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=2.2.1-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.0-RELEASE

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
@@ -20,7 +20,7 @@ public interface UserService {
     Mono<Boolean> deleteChallengeFromBookmarks(String userId, String challengeId);
 
     Mono<Set<UUID>> getUserBookmarks(String userId);
-
+    
     Mono<UserDocument> getUserById(String userId);
 
     Mono<Boolean> addPointsToUser(String userId, Integer pointsToAdd);

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
@@ -20,6 +20,8 @@ public interface UserService {
     Mono<Boolean> deleteChallengeFromBookmarks(String userId, String challengeId);
 
     Mono<Set<UUID>> getUserBookmarks(String userId);
-    
+
     Mono<UserDocument> getUserById(String userId);
+
+    Mono<Boolean> addPointsToUser(String userId, Integer pointsToAdd);
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @Service
-public class UserServiceImpl implements UserService {
+public class UserServiceImpl implements com.itachallenge.user.service.UserService {
 
     private final UserRepository userRepository;
 
@@ -168,11 +168,29 @@ public class UserServiceImpl implements UserService {
                                 .map(user -> Optional.ofNullable(user.getBookmarkChallenges()).orElseGet(HashSet::new))
                 );
     }
-    
+
     @Override
     public Mono<UserDocument> getUserById(String userId) {
         return userRepository.findById(UUID.fromString(userId))
                 .switchIfEmpty(Mono.error(new NotFoundException("User not found")));
     }
-    
+
+    @Override
+    public Mono<Boolean> addPointsToUser(String userId, Integer pointsToAdd) {
+        return parseAndValidateUUID(userId)
+                .flatMap(userUuid -> userRepository.findById(userUuid)
+                        .switchIfEmpty(Mono.error(new NotFoundException("User not found")))
+                        .flatMap(user -> addPoints(user, pointsToAdd))
+                );
+    }
+
+    private Mono<Boolean> addPoints(UserDocument user, Integer pointsToAdd) {
+        if(pointsToAdd == null) {
+            return Mono.error(new IllegalArgumentException("Points to add cannot be null"));
+        }
+        Integer userPoints = Optional.ofNullable(user.getPoints()).orElse(0);
+        user.setPoints(userPoints + pointsToAdd);
+        return userRepository.save(user).thenReturn(true);
+    }
+
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -168,7 +168,7 @@ public class UserServiceImpl implements UserService {
                                 .map(user -> Optional.ofNullable(user.getBookmarkChallenges()).orElseGet(HashSet::new))
                 );
     }
-
+    
     @Override
     public Mono<UserDocument> getUserById(String userId) {
         return userRepository.findById(UUID.fromString(userId))

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -5,7 +5,7 @@ import com.itachallenge.user.exception.BadUUIDException;
 import com.itachallenge.user.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Mono;S
 
 import java.util.HashSet;
 import java.util.Optional;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @Service
-public class UserServiceImpl implements com.itachallenge.user.service.UserService {
+public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -5,7 +5,7 @@ import com.itachallenge.user.exception.BadUUIDException;
 import com.itachallenge.user.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Mono;S
+import reactor.core.publisher.Mono;
 
 import java.util.HashSet;
 import java.util.Optional;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -21,10 +21,14 @@ import java.util.UUID;
 public class UserSolutionServiceImpl implements IUserSolutionService {
 
     private static final Logger log = LoggerFactory.getLogger(UserSolutionServiceImpl.class);
+    private final UserService userService;
     private final IUserSolutionRepository userSolutionRepository;
     private final IChallengeService challengeService;
 
-    public UserSolutionServiceImpl(IUserSolutionRepository userSolutionRepository, IChallengeService challengeService) {
+    static final Integer POINTS_PER_SOLVED_CHALLENGE = 5;
+
+    public UserSolutionServiceImpl(UserServiceImpl userService, IUserSolutionRepository userSolutionRepository, IChallengeService challengeService) {
+        this.userService = userService;
         this.userSolutionRepository = userSolutionRepository;
         this.challengeService = challengeService;
     }
@@ -122,4 +126,11 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
             return Mono.error(new BadRequestException("The 'userId' parameter must be a valid UUID: " + userId));
         }
     }
+
+    public Mono<UserSolutionDocument> awardsPointsForSolvedChallenge(UserSolutionDocument document) {
+        if (document.getStatus() != ChallengeStatus.ENDED) return Mono.just(document);
+        return userService.addPointsToUser(document.getUserId().toString(), POINTS_PER_SOLVED_CHALLENGE)
+                .thenReturn(document);
+    }
 }
+

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -130,6 +130,14 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
     public Mono<UserSolutionDocument> awardsPointsForSolvedChallenge(UserSolutionDocument document) {
         if (document.getStatus() != ChallengeStatus.ENDED) return Mono.just(document);
         return userService.addPointsToUser(document.getUserId().toString(), POINTS_PER_SOLVED_CHALLENGE)
+                .doOnNext(success -> {
+                    if (Boolean.TRUE.equals(success)) {
+                        log.info("Awarded {} points to user {}", POINTS_PER_SOLVED_CHALLENGE, document.getUserId());
+                    } else {
+                        log.warn("Failed to award points to user {}", document.getUserId());
+                    }
+                })
+                .doOnError(error -> log.error("Error awarding points to user {}: {}", document.getUserId(), error.getMessage()))
                 .thenReturn(document);
     }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -27,7 +27,7 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
 
     static final Integer POINTS_PER_SOLVED_CHALLENGE = 5;
 
-    public UserSolutionServiceImpl(UserServiceImpl userService, IUserSolutionRepository userSolutionRepository, IChallengeService challengeService) {
+    public UserSolutionServiceImpl(UserService userService, IUserSolutionRepository userSolutionRepository, IChallengeService challengeService) {
         this.userService = userService;
         this.userSolutionRepository = userSolutionRepository;
         this.challengeService = challengeService;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -28,7 +28,7 @@ class UserServiceImplTest {
     private UserRepository userRepository;
 
     @InjectMocks
-    private UserServiceImpl userService;
+    private com.itachallenge.user.service.UserServiceImpl userService;
 
     private AutoCloseable mocks;
 
@@ -791,7 +791,7 @@ class UserServiceImplTest {
                                 error.getMessage().equals("Invalid ID format"))
                 .verify();
     }
-    
+
     @Test
     @DisplayName("getUserById returns the user when the user exists")
     void getUserById_ShouldReturnUser_WhenUserExists() {
@@ -799,20 +799,20 @@ class UserServiceImplTest {
         UUID userId=UUID.randomUUID();
         UserDocument existingUser = new UserDocument(userId, username, Role.ADMIN, null, null, 0);
         when(userRepository.findById(userId)).thenReturn(Mono.just(existingUser));
-        
+
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectNext(existingUser)
                 .verifyComplete();
-        
+
         verify(userRepository, times(1)).findById(userId);
     }
-    
+
     @Test
     @DisplayName("getUserById throws NotFoundException when the user does not exist")
     void getUserById_ShouldReturnNotFoundException_WhenUserDoesNotExist() {
         UUID userId=UUID.randomUUID();
         when(userRepository.findById(userId)).thenReturn(Mono.empty());
-        
+
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectErrorSatisfies(error -> {
                     assertInstanceOf(NotFoundException.class, error);
@@ -820,5 +820,81 @@ class UserServiceImplTest {
                 })
                 .verify();
         verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should add points when user exists and has existing points")
+    void addPointsToUser_ShouldAddPoints_WhenUserExistsWithPoints() {
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+        user.setPoints(10);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(userRepository.save(user)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), 5))
+                .expectNext(true)
+                .verifyComplete();
+
+        assertEquals(15, user.getPoints());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should initialize points when user has no points")
+    void addPointsToUser_ShouldAddPoints_WhenUserHasNoPoints() {
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+        user.setPoints(null);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(userRepository.save(user)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), 7))
+                .expectNext(true)
+                .verifyComplete();
+
+        assertEquals(7, user.getPoints());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should throw NotFoundException when user does not exist")
+    void addPointsToUser_ShouldThrowNotFoundException_WhenUserNotFound() {
+        UUID userId = UUID.randomUUID();
+
+        when(userRepository.findById(userId)).thenReturn(Mono.empty());
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), 5))
+                .expectErrorSatisfies(error -> {
+                    assertInstanceOf(NotFoundException.class, error);
+                    assertEquals("User not found", error.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should throw IllegalArgumentException when pointsToAdd is null")
+    void addPointsToUser_ShouldThrowIllegalArgumentException_WhenPointsIsNull() {
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), null))
+                .expectErrorSatisfies(error -> {
+                    assertInstanceOf(IllegalArgumentException.class, error);
+                    assertEquals("Points to add cannot be null", error.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(0)).save(any());
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -799,7 +799,7 @@ class UserServiceImplTest {
         UUID userId=UUID.randomUUID();
         UserDocument existingUser = new UserDocument(userId, username, Role.ADMIN, null, null, 0);
         when(userRepository.findById(userId)).thenReturn(Mono.just(existingUser));
-
+    
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectNext(existingUser)
                 .verifyComplete();

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -28,7 +28,7 @@ class UserServiceImplTest {
     private UserRepository userRepository;
 
     @InjectMocks
-    private com.itachallenge.user.service.UserServiceImpl userService;
+    private UserServiceImpl userService;
 
     private AutoCloseable mocks;
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -799,7 +799,7 @@ class UserServiceImplTest {
         UUID userId=UUID.randomUUID();
         UserDocument existingUser = new UserDocument(userId, username, Role.ADMIN, null, null, 0);
         when(userRepository.findById(userId)).thenReturn(Mono.just(existingUser));
-    
+        
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectNext(existingUser)
                 .verifyComplete();

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -791,7 +791,7 @@ class UserServiceImplTest {
                                 error.getMessage().equals("Invalid ID format"))
                 .verify();
     }
-
+    
     @Test
     @DisplayName("getUserById returns the user when the user exists")
     void getUserById_ShouldReturnUser_WhenUserExists() {
@@ -803,16 +803,16 @@ class UserServiceImplTest {
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectNext(existingUser)
                 .verifyComplete();
-
+        
         verify(userRepository, times(1)).findById(userId);
     }
-
+    
     @Test
     @DisplayName("getUserById throws NotFoundException when the user does not exist")
     void getUserById_ShouldReturnNotFoundException_WhenUserDoesNotExist() {
         UUID userId=UUID.randomUUID();
         when(userRepository.findById(userId)).thenReturn(Mono.empty());
-
+        
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectErrorSatisfies(error -> {
                     assertInstanceOf(NotFoundException.class, error);

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -1,5 +1,9 @@
 package com.itachallenge.user.service;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.itachallenge.user.document.SolutionAttemptDocument;
 import com.itachallenge.user.document.UserSolutionDocument;
 import com.itachallenge.user.document.enums.ChallengeStatus;
@@ -14,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -334,6 +339,58 @@ class UserSolutionServiceImplTest {
                 .verifyComplete();
 
         verify(userService).addPointsToUser(userUuid.toString(), POINTS_PER_SOLVED_CHALLENGE); // assuming POINTS_PER_SOLVED_CHALLENGE = 10
+    }
+
+    @Test
+    @DisplayName("awardsPointsForSolvedChallenge logs INFO when addPointsToUser returns true")
+    void awardsPointsForSolvedChallenge_logsInfoWhenTrue() {
+        UserSolutionDocument doc = UserSolutionDocument.builder()
+                .userId(userUuid)
+                .status(ChallengeStatus.ENDED)
+                .build();
+
+        when(userService.addPointsToUser(anyString(), anyInt()))
+                .thenReturn(Mono.just(true));
+
+        Logger logger = (Logger) LoggerFactory.getLogger(UserSolutionServiceImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        StepVerifier.create(userSolutionService.awardsPointsForSolvedChallenge(doc))
+                .expectNext(doc)
+                .verifyComplete();
+
+        assertTrue(appender.list.stream()
+                        .anyMatch(e -> e.getLevel() == Level.INFO &&
+                                e.getFormattedMessage().contains("Awarded ")),
+                "Expected INFO log for awarded points");
+    }
+
+    @Test
+    @DisplayName("awardsPointsForSolvedChallenge logs WARN when addPointsToUser returns false")
+    void awardsPointsForSolvedChallenge_logsWarnWhenFalse() {
+        UserSolutionDocument doc = UserSolutionDocument.builder()
+                .userId(userUuid)
+                .status(ChallengeStatus.ENDED)
+                .build();
+
+        when(userService.addPointsToUser(anyString(), anyInt()))
+                .thenReturn(Mono.just(false));
+
+        Logger logger = (Logger) LoggerFactory.getLogger(UserSolutionServiceImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        StepVerifier.create(userSolutionService.awardsPointsForSolvedChallenge(doc))
+                .expectNext(doc)
+                .verifyComplete();
+
+        assertTrue(appender.list.stream()
+                        .anyMatch(e -> e.getLevel() == Level.WARN &&
+                                e.getFormattedMessage().contains("Failed to award")),
+                "Expected WARN log for failed awarding");
     }
 
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.user.service;
 
 import com.itachallenge.user.document.SolutionAttemptDocument;
 import com.itachallenge.user.document.UserSolutionDocument;
+import com.itachallenge.user.document.enums.ChallengeStatus;
 import com.itachallenge.user.dto.SubmitSolutionResponseDto;
 import com.itachallenge.user.dto.UserSolutionRequestDto;
 import com.itachallenge.user.exception.BadRequestException;
@@ -23,6 +24,7 @@ import reactor.test.StepVerifier;
 
 import java.util.UUID;
 
+import static com.itachallenge.user.service.UserSolutionServiceImpl.POINTS_PER_SOLVED_CHALLENGE;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -36,6 +38,9 @@ class UserSolutionServiceImplTest {
 
     @Mock
     private IChallengeService challengeService;
+
+    @Mock
+    private UserServiceImpl userService;
 
     @MockBean
     private ExternalGithubService externalGithubService;
@@ -287,4 +292,48 @@ class UserSolutionServiceImplTest {
         verify(userSolutionRepository).save(any(UserSolutionDocument.class));
         verifyNoInteractions(challengeService);
     }
+
+
+    @Test
+    @DisplayName("awardsPointsForSolvedChallenge returns document unchanged if status is not ENDED")
+    void awardsPointsForSolvedChallenge_notEnded() {
+        UserSolutionDocument doc = UserSolutionDocument.builder()
+                .userId(userUuid)
+                .challengeId(challengeUuid)
+                .languageId(languageUuid)
+                .status(ChallengeStatus.IN_PROGRESS)  // not ENDED
+                .build();
+
+        Mono<UserSolutionDocument> result = userSolutionService.awardsPointsForSolvedChallenge(doc);
+
+        StepVerifier.create(result)
+                .assertNext(returnedDoc -> assertEquals(doc, returnedDoc))
+                .verifyComplete();
+
+        // userService should NOT be called
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    @DisplayName("awardsPointsForSolvedChallenge calls userService when status is ENDED")
+    void awardsPointsForSolvedChallenge_ended() {
+        UserSolutionDocument doc = UserSolutionDocument.builder()
+                .userId(userUuid)
+                .challengeId(challengeUuid)
+                .languageId(languageUuid)
+                .status(ChallengeStatus.ENDED)
+                .build();
+
+        when(userService.addPointsToUser(eq(userUuid.toString()), anyInt()))
+                .thenReturn(Mono.empty());
+
+        Mono<UserSolutionDocument> result = userSolutionService.awardsPointsForSolvedChallenge(doc);
+
+        StepVerifier.create(result)
+                .assertNext(returnedDoc -> assertEquals(doc, returnedDoc))
+                .verifyComplete();
+
+        verify(userService).addPointsToUser(userUuid.toString(), POINTS_PER_SOLVED_CHALLENGE); // assuming POINTS_PER_SOLVED_CHALLENGE = 10
+    }
+
 }


### PR DESCRIPTION
# Pull Request Description

### 🎯 Prerequisite and observations
This task depends on the completion of **task 763** (PR #988).

Also, it will generate conflict with PR #983, which changes the enum ChallengeStatus. The recommended workflow is: (1) merge #983 into develop, (2) then rebase the branch "feature/764_add_method_awardsPointsForSolvedChallenge_to_UserSolutionServiceImpl", (3) then adapt to the new instances of ChallengeStatus (ChallengeStatus.ENDED --> ChallengeStatus.SUBMITTED_COMPLETE). 

---

### 🔧 Scope of Work
This PR introduces logic to award points to a user when they complete a challenge, by extending the `UserSolutionService` implementation.

Key changes include:

1. **Dependency Injection**
   - Added `UserService` as a dependency in `UserSolutionServiceImpl` to allow updating user points.

2. **Constant for Awarded Points**
   - Defined a constant in `UserSolutionServiceImpl` to store the number of points that should be awarded upon challenge completion.

3. **New Method: `awardsPointsForSolvedChallenge`**
   - Checks if a `UserSolutionDocument` represents a completed challenge (`status == ENDED`).
   - If completed, calls `userService.addPointsToUser` with the `userId` and the constant for awarded points.
   - Returns a `Mono<UserSolutionDocument>`, making it suitable for use in the `addSolution` reactive pipeline.

4. **Unit Tests**
   - Extended `UserSolutionServiceImplTest` to cover both cases:
     - Solution not completed → returns the document unchanged, no interaction with `userService`.
     - Solution completed → calls `userService.addPointsToUser`, returns the document unchanged.
   - Ensured both branches of logic are verified with `StepVerifier`.

---

### Files modified

- UserSolutionServiceImpl
- UserSolutionServiceImplTest
- Changelog
- .env.CI.dev

---

### ✅ Benefits
- Automates user point awarding upon challenge completion.
- Keeps business rules consistent by storing the awarded points in a single constant.
- Ensures reactive flow remains non-blocking and integrates seamlessly with existing pipelines.
- Strengthens test coverage for new logic, keeping SonarQube happy.

---

### ✅ Version and Changelog
- This PR represents a patch to the app, an internal modification with no behaviour change. Accordingly, the changelog has been updated from 2.2.0 to 2.2.1. 
---

### ✅ Author Self-check

- [x] I tested my changes locally and verified they work as expected  
- [x] The PR has a clear and focused purpose (only one feature, fix or refactor)  
- [x] Title, description, and changelog (if needed) are filled in correctly  
- [x] There are no leftover merge conflicts or unrelated changes from previous branches  
- [x] All automated checks (like SonarCloud) have passed  
- [x] I responded to all previous review comments and only resolved those I truly addressed  
- [x] I ran SonarLint locally on the modified files and confirmed there are no warnings or errors  



