### PR TITLE
PR3/3 - feat(user): use awardPointsForSolvedChallenge to updates score (#765)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-user-2.3.0-RELEASE] - 2025-10-03
+### [itachallenge-user-2.2.1-RELEASE] - 2025-10-03
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added user/create endpoint to add an alumnee without role validation. (Taiga [#618], PR [#953])
 
-
-
 ### [itachallenge-challenge-2.4.1-RELEASE] - 2025-07-21
 
 ### Refactored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-2.3.0-RELEASE] - 2025-10-03
+
+### Changed
+
+- Added method awardPointsForSolvedChallenge to UserSolutionServiceImpl that awards points to users when they solved a
+  challenge (Taiga [#764], PR [#989])
+  - created constant to store the number of points that should be added
+  - injected UserService dependency to UserSolutionService
+
 ### [itachallenge-user-2.2.0-RELEASE] - 2025-10-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added user/create endpoint to add an alumnee without role validation. (Taiga [#618], PR [#953])
 
+
+
 ### [itachallenge-challenge-2.4.1-RELEASE] - 2025-07-21
 
 ### Refactored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-2.2.0-RELEASE] - 2025-10-03
+
+### Added
+- `addPointsToUser` method added to `UserService` interface.
+- `addPoints` and `addPointsToUser` implemented in `UserServiceImpl`.
+- Unit tests added to `UserServiceImplTest` covering:
+  - Adding points to users with and without existing values.
+  - Handling `null` values for `pointsToAdd`.
+
 ### [itachallenge-user-2.1.0-RELEASE] - 2025-10-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-2.3.0-RELEASE] - 2025-10-05
+
+### Added
+
+- Modified the reactive pipeline in `addSolution(...)` to include point-awarding logic via `awardsPointsForSolvedChallenge`.
+- Added logging to track success, failure, and errors during point assignment.
+- Added unit tests to verify behavior when challenge status is `ENDED` or not.
+
 ### [itachallenge-user-2.2.1-RELEASE] - 2025-10-03
 
 ### Changed

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=2.2.1-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=2.3.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.0-RELEASE

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=2.2.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=2.3.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.0-RELEASE

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=2.1.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=2.2.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.0-RELEASE

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=2.3.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=2.2.1-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.0-RELEASE

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
@@ -20,7 +20,7 @@ public interface UserService {
     Mono<Boolean> deleteChallengeFromBookmarks(String userId, String challengeId);
 
     Mono<Set<UUID>> getUserBookmarks(String userId);
-
+    
     Mono<UserDocument> getUserById(String userId);
 
     Mono<Boolean> addPointsToUser(String userId, Integer pointsToAdd);

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
@@ -20,6 +20,8 @@ public interface UserService {
     Mono<Boolean> deleteChallengeFromBookmarks(String userId, String challengeId);
 
     Mono<Set<UUID>> getUserBookmarks(String userId);
-    
+
     Mono<UserDocument> getUserById(String userId);
+
+    Mono<Boolean> addPointsToUser(String userId, Integer pointsToAdd);
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @Service
-public class UserServiceImpl implements UserService {
+public class UserServiceImpl implements com.itachallenge.user.service.UserService {
 
     private final UserRepository userRepository;
 
@@ -168,11 +168,29 @@ public class UserServiceImpl implements UserService {
                                 .map(user -> Optional.ofNullable(user.getBookmarkChallenges()).orElseGet(HashSet::new))
                 );
     }
-    
+
     @Override
     public Mono<UserDocument> getUserById(String userId) {
         return userRepository.findById(UUID.fromString(userId))
                 .switchIfEmpty(Mono.error(new NotFoundException("User not found")));
     }
-    
+
+    @Override
+    public Mono<Boolean> addPointsToUser(String userId, Integer pointsToAdd) {
+        return parseAndValidateUUID(userId)
+                .flatMap(userUuid -> userRepository.findById(userUuid)
+                        .switchIfEmpty(Mono.error(new NotFoundException("User not found")))
+                        .flatMap(user -> addPoints(user, pointsToAdd))
+                );
+    }
+
+    private Mono<Boolean> addPoints(UserDocument user, Integer pointsToAdd) {
+        if(pointsToAdd == null) {
+            return Mono.error(new IllegalArgumentException("Points to add cannot be null"));
+        }
+        Integer userPoints = Optional.ofNullable(user.getPoints()).orElse(0);
+        user.setPoints(userPoints + pointsToAdd);
+        return userRepository.save(user).thenReturn(true);
+    }
+
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -168,7 +168,7 @@ public class UserServiceImpl implements UserService {
                                 .map(user -> Optional.ofNullable(user.getBookmarkChallenges()).orElseGet(HashSet::new))
                 );
     }
-
+    
     @Override
     public Mono<UserDocument> getUserById(String userId) {
         return userRepository.findById(UUID.fromString(userId))

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -5,7 +5,7 @@ import com.itachallenge.user.exception.BadUUIDException;
 import com.itachallenge.user.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Mono;S
 
 import java.util.HashSet;
 import java.util.Optional;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @Service
-public class UserServiceImpl implements com.itachallenge.user.service.UserService {
+public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -5,7 +5,7 @@ import com.itachallenge.user.exception.BadUUIDException;
 import com.itachallenge.user.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Mono;S
+import reactor.core.publisher.Mono;
 
 import java.util.HashSet;
 import java.util.Optional;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -51,6 +51,7 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
                 .build();
 
         return saveValidSolution(userUuid, challengeUuid, languageUuid, challengeStatus, solutionAttempt)
+                .flatMap(this::awardsPointsForSolvedChallenge)
                 .flatMap(this::buildSubmitSolutionResponse)
                 .doOnSuccess(response -> log.info("PUT request successfully processed for challenge {} and user {}.", challengeUuid, userUuid))
                 .doOnError(error -> log.error("PUT operation failed: {} for challenge {} and user {}.", error.getMessage(), challengeUuid, userUuid));

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -21,10 +21,14 @@ import java.util.UUID;
 public class UserSolutionServiceImpl implements IUserSolutionService {
 
     private static final Logger log = LoggerFactory.getLogger(UserSolutionServiceImpl.class);
+    private final UserService userService;
     private final IUserSolutionRepository userSolutionRepository;
     private final IChallengeService challengeService;
 
-    public UserSolutionServiceImpl(IUserSolutionRepository userSolutionRepository, IChallengeService challengeService) {
+    static final Integer POINTS_PER_SOLVED_CHALLENGE = 5;
+
+    public UserSolutionServiceImpl(UserServiceImpl userService, IUserSolutionRepository userSolutionRepository, IChallengeService challengeService) {
+        this.userService = userService;
         this.userSolutionRepository = userSolutionRepository;
         this.challengeService = challengeService;
     }
@@ -122,4 +126,11 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
             return Mono.error(new BadRequestException("The 'userId' parameter must be a valid UUID: " + userId));
         }
     }
+
+    public Mono<UserSolutionDocument> awardsPointsForSolvedChallenge(UserSolutionDocument document) {
+        if (document.getStatus() != ChallengeStatus.ENDED) return Mono.just(document);
+        return userService.addPointsToUser(document.getUserId().toString(), POINTS_PER_SOLVED_CHALLENGE)
+                .thenReturn(document);
+    }
 }
+

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -130,6 +130,14 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
     public Mono<UserSolutionDocument> awardsPointsForSolvedChallenge(UserSolutionDocument document) {
         if (document.getStatus() != ChallengeStatus.ENDED) return Mono.just(document);
         return userService.addPointsToUser(document.getUserId().toString(), POINTS_PER_SOLVED_CHALLENGE)
+                .doOnNext(success -> {
+                    if (Boolean.TRUE.equals(success)) {
+                        log.info("Awarded {} points to user {}", POINTS_PER_SOLVED_CHALLENGE, document.getUserId());
+                    } else {
+                        log.warn("Failed to award points to user {}", document.getUserId());
+                    }
+                })
+                .doOnError(error -> log.error("Error awarding points to user {}: {}", document.getUserId(), error.getMessage()))
                 .thenReturn(document);
     }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -27,7 +27,7 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
 
     static final Integer POINTS_PER_SOLVED_CHALLENGE = 5;
 
-    public UserSolutionServiceImpl(UserServiceImpl userService, IUserSolutionRepository userSolutionRepository, IChallengeService challengeService) {
+    public UserSolutionServiceImpl(UserService userService, IUserSolutionRepository userSolutionRepository, IChallengeService challengeService) {
         this.userService = userService;
         this.userSolutionRepository = userSolutionRepository;
         this.challengeService = challengeService;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -28,7 +28,7 @@ class UserServiceImplTest {
     private UserRepository userRepository;
 
     @InjectMocks
-    private UserServiceImpl userService;
+    private com.itachallenge.user.service.UserServiceImpl userService;
 
     private AutoCloseable mocks;
 
@@ -791,7 +791,7 @@ class UserServiceImplTest {
                                 error.getMessage().equals("Invalid ID format"))
                 .verify();
     }
-    
+
     @Test
     @DisplayName("getUserById returns the user when the user exists")
     void getUserById_ShouldReturnUser_WhenUserExists() {
@@ -799,20 +799,20 @@ class UserServiceImplTest {
         UUID userId=UUID.randomUUID();
         UserDocument existingUser = new UserDocument(userId, username, Role.ADMIN, null, null, 0);
         when(userRepository.findById(userId)).thenReturn(Mono.just(existingUser));
-        
+
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectNext(existingUser)
                 .verifyComplete();
-        
+
         verify(userRepository, times(1)).findById(userId);
     }
-    
+
     @Test
     @DisplayName("getUserById throws NotFoundException when the user does not exist")
     void getUserById_ShouldReturnNotFoundException_WhenUserDoesNotExist() {
         UUID userId=UUID.randomUUID();
         when(userRepository.findById(userId)).thenReturn(Mono.empty());
-        
+
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectErrorSatisfies(error -> {
                     assertInstanceOf(NotFoundException.class, error);
@@ -820,5 +820,81 @@ class UserServiceImplTest {
                 })
                 .verify();
         verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should add points when user exists and has existing points")
+    void addPointsToUser_ShouldAddPoints_WhenUserExistsWithPoints() {
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+        user.setPoints(10);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(userRepository.save(user)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), 5))
+                .expectNext(true)
+                .verifyComplete();
+
+        assertEquals(15, user.getPoints());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should initialize points when user has no points")
+    void addPointsToUser_ShouldAddPoints_WhenUserHasNoPoints() {
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+        user.setPoints(null);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(userRepository.save(user)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), 7))
+                .expectNext(true)
+                .verifyComplete();
+
+        assertEquals(7, user.getPoints());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should throw NotFoundException when user does not exist")
+    void addPointsToUser_ShouldThrowNotFoundException_WhenUserNotFound() {
+        UUID userId = UUID.randomUUID();
+
+        when(userRepository.findById(userId)).thenReturn(Mono.empty());
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), 5))
+                .expectErrorSatisfies(error -> {
+                    assertInstanceOf(NotFoundException.class, error);
+                    assertEquals("User not found", error.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("addPointsToUser should throw IllegalArgumentException when pointsToAdd is null")
+    void addPointsToUser_ShouldThrowIllegalArgumentException_WhenPointsIsNull() {
+        UUID userId = UUID.randomUUID();
+        UserDocument user = new UserDocument();
+        user.setUuid(userId);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(userService.addPointsToUser(userId.toString(), null))
+                .expectErrorSatisfies(error -> {
+                    assertInstanceOf(IllegalArgumentException.class, error);
+                    assertEquals("Points to add cannot be null", error.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(0)).save(any());
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -799,7 +799,7 @@ class UserServiceImplTest {
         UUID userId=UUID.randomUUID();
         UserDocument existingUser = new UserDocument(userId, username, Role.ADMIN, null, null, 0);
         when(userRepository.findById(userId)).thenReturn(Mono.just(existingUser));
-
+    
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectNext(existingUser)
                 .verifyComplete();

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -28,7 +28,7 @@ class UserServiceImplTest {
     private UserRepository userRepository;
 
     @InjectMocks
-    private com.itachallenge.user.service.UserServiceImpl userService;
+    private UserServiceImpl userService;
 
     private AutoCloseable mocks;
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -799,7 +799,7 @@ class UserServiceImplTest {
         UUID userId=UUID.randomUUID();
         UserDocument existingUser = new UserDocument(userId, username, Role.ADMIN, null, null, 0);
         when(userRepository.findById(userId)).thenReturn(Mono.just(existingUser));
-    
+        
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectNext(existingUser)
                 .verifyComplete();

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -791,7 +791,7 @@ class UserServiceImplTest {
                                 error.getMessage().equals("Invalid ID format"))
                 .verify();
     }
-
+    
     @Test
     @DisplayName("getUserById returns the user when the user exists")
     void getUserById_ShouldReturnUser_WhenUserExists() {
@@ -803,16 +803,16 @@ class UserServiceImplTest {
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectNext(existingUser)
                 .verifyComplete();
-
+        
         verify(userRepository, times(1)).findById(userId);
     }
-
+    
     @Test
     @DisplayName("getUserById throws NotFoundException when the user does not exist")
     void getUserById_ShouldReturnNotFoundException_WhenUserDoesNotExist() {
         UUID userId=UUID.randomUUID();
         when(userRepository.findById(userId)).thenReturn(Mono.empty());
-
+        
         StepVerifier.create(userService.getUserById(userId.toString()))
                 .expectErrorSatisfies(error -> {
                     assertInstanceOf(NotFoundException.class, error);

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -1,5 +1,9 @@
 package com.itachallenge.user.service;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.itachallenge.user.document.SolutionAttemptDocument;
 import com.itachallenge.user.document.UserSolutionDocument;
 import com.itachallenge.user.document.enums.ChallengeStatus;
@@ -14,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -334,6 +339,58 @@ class UserSolutionServiceImplTest {
                 .verifyComplete();
 
         verify(userService).addPointsToUser(userUuid.toString(), POINTS_PER_SOLVED_CHALLENGE); // assuming POINTS_PER_SOLVED_CHALLENGE = 10
+    }
+
+    @Test
+    @DisplayName("awardsPointsForSolvedChallenge logs INFO when addPointsToUser returns true")
+    void awardsPointsForSolvedChallenge_logsInfoWhenTrue() {
+        UserSolutionDocument doc = UserSolutionDocument.builder()
+                .userId(userUuid)
+                .status(ChallengeStatus.ENDED)
+                .build();
+
+        when(userService.addPointsToUser(anyString(), anyInt()))
+                .thenReturn(Mono.just(true));
+
+        Logger logger = (Logger) LoggerFactory.getLogger(UserSolutionServiceImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        StepVerifier.create(userSolutionService.awardsPointsForSolvedChallenge(doc))
+                .expectNext(doc)
+                .verifyComplete();
+
+        assertTrue(appender.list.stream()
+                        .anyMatch(e -> e.getLevel() == Level.INFO &&
+                                e.getFormattedMessage().contains("Awarded ")),
+                "Expected INFO log for awarded points");
+    }
+
+    @Test
+    @DisplayName("awardsPointsForSolvedChallenge logs WARN when addPointsToUser returns false")
+    void awardsPointsForSolvedChallenge_logsWarnWhenFalse() {
+        UserSolutionDocument doc = UserSolutionDocument.builder()
+                .userId(userUuid)
+                .status(ChallengeStatus.ENDED)
+                .build();
+
+        when(userService.addPointsToUser(anyString(), anyInt()))
+                .thenReturn(Mono.just(false));
+
+        Logger logger = (Logger) LoggerFactory.getLogger(UserSolutionServiceImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        StepVerifier.create(userSolutionService.awardsPointsForSolvedChallenge(doc))
+                .expectNext(doc)
+                .verifyComplete();
+
+        assertTrue(appender.list.stream()
+                        .anyMatch(e -> e.getLevel() == Level.WARN &&
+                                e.getFormattedMessage().contains("Failed to award")),
+                "Expected WARN log for failed awarding");
     }
 
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.user.service;
 
 import com.itachallenge.user.document.SolutionAttemptDocument;
 import com.itachallenge.user.document.UserSolutionDocument;
+import com.itachallenge.user.document.enums.ChallengeStatus;
 import com.itachallenge.user.dto.SubmitSolutionResponseDto;
 import com.itachallenge.user.dto.UserSolutionRequestDto;
 import com.itachallenge.user.exception.BadRequestException;
@@ -23,6 +24,7 @@ import reactor.test.StepVerifier;
 
 import java.util.UUID;
 
+import static com.itachallenge.user.service.UserSolutionServiceImpl.POINTS_PER_SOLVED_CHALLENGE;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -36,6 +38,9 @@ class UserSolutionServiceImplTest {
 
     @Mock
     private IChallengeService challengeService;
+
+    @Mock
+    private UserServiceImpl userService;
 
     @MockBean
     private ExternalGithubService externalGithubService;
@@ -287,4 +292,48 @@ class UserSolutionServiceImplTest {
         verify(userSolutionRepository).save(any(UserSolutionDocument.class));
         verifyNoInteractions(challengeService);
     }
+
+
+    @Test
+    @DisplayName("awardsPointsForSolvedChallenge returns document unchanged if status is not ENDED")
+    void awardsPointsForSolvedChallenge_notEnded() {
+        UserSolutionDocument doc = UserSolutionDocument.builder()
+                .userId(userUuid)
+                .challengeId(challengeUuid)
+                .languageId(languageUuid)
+                .status(ChallengeStatus.IN_PROGRESS)  // not ENDED
+                .build();
+
+        Mono<UserSolutionDocument> result = userSolutionService.awardsPointsForSolvedChallenge(doc);
+
+        StepVerifier.create(result)
+                .assertNext(returnedDoc -> assertEquals(doc, returnedDoc))
+                .verifyComplete();
+
+        // userService should NOT be called
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    @DisplayName("awardsPointsForSolvedChallenge calls userService when status is ENDED")
+    void awardsPointsForSolvedChallenge_ended() {
+        UserSolutionDocument doc = UserSolutionDocument.builder()
+                .userId(userUuid)
+                .challengeId(challengeUuid)
+                .languageId(languageUuid)
+                .status(ChallengeStatus.ENDED)
+                .build();
+
+        when(userService.addPointsToUser(eq(userUuid.toString()), anyInt()))
+                .thenReturn(Mono.empty());
+
+        Mono<UserSolutionDocument> result = userSolutionService.awardsPointsForSolvedChallenge(doc);
+
+        StepVerifier.create(result)
+                .assertNext(returnedDoc -> assertEquals(doc, returnedDoc))
+                .verifyComplete();
+
+        verify(userService).addPointsToUser(userUuid.toString(), POINTS_PER_SOLVED_CHALLENGE); // assuming POINTS_PER_SOLVED_CHALLENGE = 10
+    }
+
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -83,6 +83,9 @@ class UserSolutionServiceImplTest {
         when(userSolutionRepository.save(any(UserSolutionDocument.class)))
                 .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
 
+        when(userService.addPointsToUser(userUuid.toString(), POINTS_PER_SOLVED_CHALLENGE))
+                .thenReturn(Mono.just(true));
+
         when(challengeService.addChallengeToSolved(challengeUuid.toString()))
                 .thenReturn(Mono.just(new com.itachallenge.user.dto.SolvedDto(true, 5)));
 
@@ -391,6 +394,71 @@ class UserSolutionServiceImplTest {
                         .anyMatch(e -> e.getLevel() == Level.WARN &&
                                 e.getFormattedMessage().contains("Failed to award")),
                 "Expected WARN log for failed awarding");
+    }
+
+    @Test
+    @DisplayName("addSolution awards points when status is ENDED")
+    void addSolutionAwardsPointsWhenEnded() {
+        UserSolutionRequestDto request = UserSolutionRequestDto.builder()
+                .userId(userUuid.toString())
+                .challengeId(challengeUuid.toString())
+                .languageId(languageUuid.toString())
+                .status("ENDED")
+                .solutionText(solutionText)
+                .build();
+
+        when(userSolutionRepository.findByUserIdAndChallengeIdAndLanguageId(userUuid, challengeUuid, languageUuid))
+                .thenReturn(Mono.empty());
+
+        when(userSolutionRepository.save(any(UserSolutionDocument.class)))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        when(userService.addPointsToUser(userUuid.toString(), POINTS_PER_SOLVED_CHALLENGE))
+                .thenReturn(Mono.just(true));
+
+        when(challengeService.addChallengeToSolved(challengeUuid.toString()))
+                .thenReturn(Mono.just(new com.itachallenge.user.dto.SolvedDto(true, 3)));
+
+        StepVerifier.create(userSolutionService.addSolution(request))
+                .assertNext(dto -> {
+                    assertEquals(solutionText, dto.getSolutionText());
+                    assertTrue(dto.getIsSolved());
+                    assertEquals(3, dto.getTimesSolved());
+                    assertEquals("ENDED", dto.getStatus());
+                })
+                .verifyComplete();
+
+        verify(userService).addPointsToUser(userUuid.toString(), POINTS_PER_SOLVED_CHALLENGE);
+        verify(challengeService).addChallengeToSolved(challengeUuid.toString());
+    }
+
+    @Test
+    @DisplayName("addSolution does not award points when status is IN_PROGRESS")
+    void addSolutionDoesNotAwardPointsWhenNotEnded() {
+        UserSolutionRequestDto request = UserSolutionRequestDto.builder()
+                .userId(userUuid.toString())
+                .challengeId(challengeUuid.toString())
+                .languageId(languageUuid.toString())
+                .status("IN_PROGRESS")
+                .solutionText(solutionText)
+                .build();
+
+        when(userSolutionRepository.findByUserIdAndChallengeIdAndLanguageId(userUuid, challengeUuid, languageUuid))
+                .thenReturn(Mono.empty());
+
+        when(userSolutionRepository.save(any(UserSolutionDocument.class)))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(userSolutionService.addSolution(request))
+                .assertNext(dto -> {
+                    assertEquals(solutionText, dto.getSolutionText());
+                    assertFalse(dto.getIsSolved());
+                    assertEquals("IN_PROGRESS", dto.getStatus());
+                })
+                .verifyComplete();
+
+        verifyNoInteractions(userService);
+        verifyNoInteractions(challengeService);
     }
 
 }


### PR DESCRIPTION
## Summary

This PR matches Taiga task [#765](https://tree.taiga.io/project/luisvi-ita-challenges/task/765) and integrates point-awarding logic into the solution submission pipeline, completing the **third and final part of User Story [#762](https://tree.taiga.io/project/luisvi-ita-challenges/us/762?milestone=479773)** and extends the Taiga task [#764](https://tree.taiga.io/project/luisvi-ita-challenges/task/764)

It ensures that users receive points when submitting a solution with status `ENDED`, without affecting other challenge-related flows.

---

## Checklist Alignment

✅ Completes the final Core Feature for **User Story #762 – User Point Management**  
✅ Ensures reactive integration of point logic into the solution flow  
✅ Adds test coverage and logging for traceability

---

## Context & Changes

### Before
- The solution submission pipeline did not include any logic for awarding points based on challenge completion.

### After
- `UserSolutionServiceImpl`: Added `flatMap(this::awardsPointsForSolvedChallenge)` to the reactive pipeline in `addSolution(...)`.
- Testing: Added unit tests covering on `UserSolutionServiceImplTest`:
  - Point assignment when status is `ENDED`.
  - No point assignment when status is not `ENDED`.

### Files modified
- `UserSolutionServiceImple`
- `UserSolutionServiceImplTest`
- `Changelog`
- `.env.CI.dev`

---

## Impact for API Consumers

- No breaking changes  
- Point logic is internal to the service layer  

---

## Changelog

- Version bumped to `2.1.1` (patch release)
- CHANGELOG.md updated to reflect:
  - Pipeline modification
  - Logging additions
  - New unit tests

---

## How to Test

Run unit tests in `UserSolutionServiceImplTest`.  
Verify:
- ✅ Points are awarded when submitting a solution with status `ENDED`
- ✅ No points are awarded for other statuses
- ✅ Logs are emitted correctly for success, failure, and errors
- ✅ No regression in unrelated solution flows

---

## PR Author Self-check

- [x] I tested my changes locally and verified they work as expected  
- [x] The PR has a clear and focused purpose (point logic integration)  
- [x] Title, description, and changelog are filled in correctly  
- [x] No merge conflicts or unrelated changes  
- [x] All automated checks (SonarCloud, etc.) have passed  
- [x] I ran SonarLint locally and confirmed no warnings or errors

---

#  Future Considerations

- The method `awardsPointsForSolvedChallenge(...)` currently checks for status `ENDED`.  
Once **[PR #983](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/983)** is merged, this condition must be updated to check for `SUBMITTED_COMPLETE` instead, to align with the new challenge status flow.

---

# Technical debt

A new field of type AwardedPointsDto — containing the properties Integer pointsAdded and String message — should be added to both the UserSolutionDocument and the SubmitSolutionResponseDto classes. This will allow the system to capture and transmit information about the points awarded to a user when a challenge is successfully completed. By including this field in the database document and the response DTO, the backend can record the outcome of the points-awarding process and ensure that the front-end receives clear feedback (for example, how many points were added and an accompanying message) whenever a solution is submitted.