### PR TITLE
docs(Postman): update ChallengeStatus values with new put solution requests (#753)

### DIFF
--- a/postman/ITA-Challenges.postman_collection.json
+++ b/postman/ITA-Challenges.postman_collection.json
@@ -552,6 +552,10 @@
                   "value": "660e1b18-0c0a-4262-a28a-85de9df6ac5f"
                 },
                 {
+                  "key": "status",
+                  "value": "SUBMITTED_COMPLETE"
+                },
+                {
                   "key": "offset",
                   "value": "1"
                 },
@@ -954,38 +958,6 @@
       "name": "User",
       "item": [
         {
-          "name": "User/solution",
-          "request": {
-            "method": "PUT",
-            "header": [],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n\"uuid_challenge\": \"dcacb291-b4aa-4029-8e9b-284c8ca80296\",\n\"uuid_language\": \"660e1b18-0c0a-4262-a28a-85de9df6ac5f\",\n\"uuid_user\": \"c3a92f9d-5d10-4f76-8c0b-6d884c549b1c\",\n\"status\": \"ENDED\",\n\"solution_text\": \"ANOTHER SOLUTION\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/user/solution",
-              "protocol": "http",
-              "host": [
-                "{{ip}}"
-              ],
-              "port": "{{user_port}}",
-              "path": [
-                "itachallenge",
-                "api",
-                "v1",
-                "user",
-                "solution"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
           "name": "User/bookmark",
           "request": {
             "method": "PUT",
@@ -1140,13 +1112,77 @@
           "response": []
         },
         {
+          "name": "User/solution - SUBMITTED_COMPLETE",
+          "request": {
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n\"uuid_challenge\": \"8cd0fbc2-d940-4d41-ab95-7749f0382f6a\",\n\"uuid_language\": \"660e1b18-0c0a-4262-a28a-85de9df6ac5f\",\n\"uuid_user\": \"c3a92f9d-5d10-4f76-8c0b-6d884c549b1c\",\n\"status\": \"SUBMITTED_COMPLETE\",\n\"solution_text\": \"ANOTHER SOLUTION\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/user/solution",
+              "protocol": "http",
+              "host": [
+                "{{ip}}"
+              ],
+              "port": "{{user_port}}",
+              "path": [
+                "itachallenge",
+                "api",
+                "v1",
+                "user",
+                "solution"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "User/solution - IN_PROGRESS",
           "request": {
             "method": "PUT",
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"uuid_challenge\": \"dcacb291-b4aa-4029-8e9b-284c8ca80296\",\n  \"uuid_language\": \"660e1b18-0c0a-4262-a28a-85de9df6ac5f\",\n  \"uuid_user\": \"c3a92f9d-5d10-4f76-8c0b-6d884c549b1c\",\n  \"status\": \"IN_PROGRESS\",\n  \"solution_text\": \"This is a solution still in progress.\"\n}",
+              "raw": "{\n  \"uuid_challenge\": \"2044f0b7-ccef-429b-a8d3-7a2168a5dafe\",\n  \"uuid_language\": \"660e1b18-0c0a-4262-a28a-85de9df6ac5f\",\n  \"uuid_user\": \"c3a92f9d-5d10-4f76-8c0b-6d884c549b1c\",\n  \"status\": \"IN_PROGRESS\",\n  \"solution_text\": \"This is a solution still in progress.\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/user/solution",
+              "protocol": "http",
+              "host": [
+                "{{ip}}"
+              ],
+              "port": "{{user_port}}",
+              "path": [
+                "itachallenge",
+                "api",
+                "v1",
+                "user",
+                "solution"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "User/solution - SUBMITTED_INCOMPLETE",
+          "request": {
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"uuid_challenge\": \"6e237137-3567-4585-9a21-5a6d4f5f037b\",\n  \"uuid_language\": \"660e1b18-0c0a-4262-a28a-85de9df6ac5f\",\n  \"uuid_user\": \"7a8d03f6-5489-417d-a736-777be159eab5\",\n  \"status\": \"SUBMITTED_INCOMPLETE\",\n  \"solution_text\": \"Partial solution submitted\"\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION
**Summary**
The Ita-challenge postman collection needs to be actualized in order to easily make PUT request for solutions and users to change status, following the Taiga User Story 703 and PR #984 changes.

This PR should only be merged after #984.

**Objective**
Update the Postman collection to reflect the new ChallengeStatus enum states, allowing solution submission flows to be tested correctly.

**Changes made**
PUT requests in the User/solution collection are updated to include the new values:

SUBMITTED_COMPLETE

SUBMITTED_INCOMPLETE

IN_PROGRESS

Obsolete references to the ENDED status are removed.

The uuid_challenge, uuid_language, and uuid_user fields are parameterized to facilitate testing with different data.

The URL structure with environment variables ({{ip}}, {{user_port}}) is maintained for compatibility between local and development environments.

**Validation**
The updated requests allow for successful testing of submission flows from Postman, aligned with the business logic implemented in previous PR #984 

The JSON bodies are verified to be well-formatted and the status field is verified to accept the new values defined in the backend.

**PR Author Self-check**
✅ I tested my changes locally and verified they work as expected
✅ The PR has a clear and focused purpose 
✅ Title, description, and changelog are filled in correctly
✅ No merge conflicts or unrelated changes
✅ All automated checks (SonarCloud, etc.) have passed
✅ I ran SonarLint locally and confirmed no warnings or errors

**Demonstration**

A solution con be set to IN_PROGRESS
<img width="900" height="748" alt="Screenshot 2025-10-09 180920" src="https://github.com/user-attachments/assets/93dedad7-b258-45ce-93e0-436c6fb0689e" />


A solution now can be submitted incomplete
<img width="913" height="749" alt="Screenshot 2025-10-09 180959" src="https://github.com/user-attachments/assets/027b4a14-9f19-448e-b98b-bcc008b507f9" />



Behaviour when the challenge has been submitted
<img width="909" height="651" alt="Screenshot 2025-10-09 181045" src="https://github.com/user-attachments/assets/a1f08979-af38-4313-925e-5b9802356001" />


