### PR TITLE
PR 2/3 - refactor(challenge): update validation annotations in dtos (#770 & #798)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeCreateDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ChallengeCreateDto.java
@@ -1,14 +1,15 @@
 package com.itachallenge.challenge.dto;
 
-import com.itachallenge.challenge.document.TagDocument;
 import com.itachallenge.challenge.enums.DifficultyLevel;
 import com.itachallenge.challenge.enums.Topic;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 @AllArgsConstructor
@@ -17,23 +18,23 @@ import java.util.UUID;
 @Setter
 public class ChallengeCreateDto {
 
-    @NotEmpty(message = "cannot be empty")
+    @NotEmpty(message = "{challenge.title.notEmpty}")
     private String challengeTitle;
 
-    @NotEmpty(message = "cannot be empty")
+    @NotEmpty(message = "{challenge.description.notEmpty}")
     private String description;
 
     private DifficultyLevel level;
 
-    @NotEmpty(message = "cannot be empty")
+    @NotEmpty(message = "{challenge.language.notEmpty}")
     private String language;
 
-    @NotEmpty(message = "cannot be empty")
+    @NotEmpty(message = "{challenge.solution.notEmpty}")
     private String solution;
 
-    @NotNull(message = "cannot be empty")
+    @NotNull(message = "{challenge.topic.notNull}")
     private Topic topic;
 
-    @NotEmpty(message = "The tags list cannot be empty")
+    @NotEmpty(message = "{challenge.tags.notEmpty}")
     private List<UUID> tags;
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ResourceDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/ResourceDto.java
@@ -9,9 +9,9 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.stereotype.Component;
-import java.util.Objects;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Component
@@ -24,35 +24,35 @@ import java.util.UUID;
 public class ResourceDto {
 
     @JsonProperty(value = "resourceId", index = 0)
-    @NotNull(message = "cannot be null")
+    @NotNull(message = "{resource.id.notNull}")
     private UUID resourceId;
 
     @JsonProperty(value = "title", index = 1)
-    @NotEmpty(message = "cannot be empty")
+    @NotEmpty(message = "{resource.title.notEmpty}")
     private String title;
 
     @JsonProperty(value = "description", index = 2)
-    @NotEmpty(message = "cannot be empty")
+    @NotEmpty(message = "{resource.description.notEmpty}")
     private String description;
 
     @JsonProperty(value = "url", index = 3)
-    @NotEmpty(message = "cannot be empty")
+    @NotEmpty(message = "{resource.url.notEmpty}")
     private String url;
 
     @JsonProperty(value = "topic", index = 4)
-    @NotNull(message = "cannot be empty")
+    @NotNull(message = "{resource.topic.notNull}")
     private Topic topic;
 
     @JsonProperty(value = "contentType", index = 5)
-    @NotNull(message = "cannot be null")
+    @NotNull(message = "{resource.contentType.notNull}")
     private ResourceContentType contentType;
 
     @JsonProperty(value = "challengeIds", index = 6)
-    @NotNull(message = "cannot be empty")
+    @NotNull(message = "{resource.challengeIds.notNull}")
     private List<UUID> challengeIds;
 
     @JsonProperty(value = "associationType", index = 7)
-    @NotNull(message = "cannot be empty")
+    @NotNull(message = "{resource.associationType.notNull}")
     private AssociationType associationType;
 
     @Override

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/SolutionDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/SolutionDto.java
@@ -1,17 +1,12 @@
 package com.itachallenge.challenge.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.itachallenge.challenge.annotations.ValidGenericPattern;
 import com.itachallenge.challenge.annotations.ValidUUID;
-import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Unwrapped;
 
 import java.util.UUID;
 
@@ -27,15 +22,15 @@ public class SolutionDto {
     private UUID uuid;
 
     //@ValidGenericPattern(pattern = STRING_PATTERN, message = "Solution text cannot be empty")
-    @NotEmpty(message = "cannot be empty")
+    @NotEmpty(message = "{solution.text.notEmpty}")
     @JsonProperty(value = "solution_text", index = 1)
     private String solutionText;
 
-    @ValidUUID(message = "Invalid UUID")
+    @ValidUUID(message = "{solution.languageId.invalid}")
     @JsonProperty(value = "uuid_language", index = 2)
     private UUID idLanguage;
 
-    @ValidUUID(message = "Invalid UUID")
+    @ValidUUID(message = "{solution.challengeId.invalid}")
     @JsonProperty(value = "uuid_challenge", index = 3)
     private UUID idChallenge;
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -832,13 +832,13 @@ class ChallengeControllerTest {
 
         String baseJson = """
         {
-            "challengeTitle": "Title",
-            "description": "Description",
-            "level": "%s",
-            "language": "Java",
-            "solution": "valid solution",
-            "topic": "%s",
-            "tags": {}
+        "challengeTitle": "Title",
+        "description": "Description",
+        "level": "%s",
+        "language": "Java",
+        "solution": "valid solution",
+        "topic": "%s",
+        "tags": {}
         }
         """;
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -831,16 +831,16 @@ class ChallengeControllerTest {
     private static Stream<Arguments> provideInvalidEnumValues() {
 
         String baseJson = """
-            {
-            "challengeTitle": "Title",
-            "description": "Description",
-            "level": "%s",
-            "language": "Java",
-            "solution": "valid solution",
-            "topic": "%s",
-            "tags": {}
-            }
-            """;
+        {
+          "challengeTitle": "Title",
+          "description": "Description",
+          "level": "%s",
+          "language": "Java",
+          "solution": "valid solution",
+          "topic": "%s",
+          "tags": {}
+        }
+        """;
 
         return Stream.of(
                 Arguments.of(String.format(baseJson, "invalidLevel", "ALL")),

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -710,7 +710,7 @@ class ChallengeControllerTest {
                 .timesFavorite(5)
                 .build();
 
-        ChallengeDto[] challengeArray = new ChallengeDto[]{challenge};
+        ChallengeDto[] challengeArray = new ChallengeDto[] { challenge };
         GenericResultDto<ChallengeDto> resultDto = new GenericResultDto<>(0, 10, 1, challengeArray);
 
 
@@ -806,7 +806,7 @@ class ChallengeControllerTest {
 
     @ParameterizedTest
     @MethodSource("provideInvalidEnumValues")
-    void updateChallengeInvalidEnumValue_returnsBadRequest_test(String jsonBody) {
+    void updateChallengeInvalidEnumValue_returnsBadRequest_test(String jsonBody){
 
         webTestClient.put()
                 .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -831,16 +831,16 @@ class ChallengeControllerTest {
     private static Stream<Arguments> provideInvalidEnumValues() {
 
         String baseJson = """
-{
-    "challengeTitle": "Title",
-    "description": "Description",
-    "level": "%s",
-    "language": "Java",
-    "solution": "valid solution",
-    "topic": "%s",
-    "tags": {}
-}
-""";
+            {
+            "challengeTitle": "Title",
+            "description": "Description",
+            "level": "%s",
+            "language": "Java",
+            "solution": "valid solution",
+            "topic": "%s",
+            "tags": {}
+            }
+            """;
 
         return Stream.of(
                 Arguments.of(String.format(baseJson, "invalidLevel", "ALL")),

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -90,7 +90,7 @@ class ChallengeControllerTest {
 
 
     @BeforeEach
-    void setup() {
+    void setup(){
         tags = List.of(UUID.randomUUID());
         challengeId = String.valueOf(UUID.randomUUID());
         formData = new ChallengeCreateDto("títol", "descripció",
@@ -527,7 +527,6 @@ class ChallengeControllerTest {
         verify(challengeJwtFacade, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
         verify(challengeService, times(1)).addChallenge(any(ChallengeCreateDto.class));
     }
-
     @Test
     void addChallenge_test_invalidLevel_statusBadRequest() {
         String invalidFormData = """
@@ -560,7 +559,6 @@ class ChallengeControllerTest {
                 .jsonPath("$.application_name").isEqualTo("itachallenge-challenge")
                 .jsonPath("$.version").isEqualTo(expectedVersion);
     }
-
     @Test
     void deleteOneChallenge_success() {
         String id = "existing_id";
@@ -833,16 +831,16 @@ class ChallengeControllerTest {
     private static Stream<Arguments> provideInvalidEnumValues() {
 
         String baseJson = """
-                {
-                  "challengeTitle": "Title",
-                  "description": "Description",
-                  "level": "%s",
-                  "language": "Java",
-                  "solution": "valid solution",
-                  "topic": "%s",
-                  "tags": {}
-                }
-                """;
+        {
+            "challengeTitle": "Title",
+            "description": "Description",
+            "level": "%s",
+            "language": "Java",
+            "solution": "valid solution",
+            "topic": "%s",
+            "tags": {}
+        }
+        """;
 
         return Stream.of(
                 Arguments.of(String.format(baseJson, "invalidLevel", "ALL")),
@@ -959,16 +957,16 @@ class ChallengeControllerTest {
     @Test
     void addChallenge_emptyTags_statusBadRequest() {
         String challengeWithEmptyTags = """
-                    {
-                         "challengeTitle": "title",
-                         "description": "description",
-                         "level": "EASY",
-                         "language": "Java",
-                         "solution": "solution",
-                         "topic": "ALL",
-                         "tags": []
-                     }
-                """;
+                {
+                    "challengeTitle": "title",
+                    "description": "description",
+                    "level": "EASY",
+                    "language": "Java",
+                    "solution": "solution",
+                    "topic": "ALL",
+                    "tags": []
+                }
+            """;
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/challenge/challenges")

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -775,7 +775,7 @@ class ChallengeControllerTest {
         verify(challengeService, times(1)).updateChallenge(anyString(), any(ChallengeCreateDto.class));
     }
 
-    @Test
+   @Test
     void updateChallenge_MissingAuthHeader_Returns400() {
         when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(null)).thenThrow(new JwtException("Missing auth header"));
 
@@ -832,16 +832,16 @@ class ChallengeControllerTest {
 
         String baseJson = """
         {
-        "challengeTitle": "Title",
-        "description": "Description",
-        "level": "%s",
-        "language": "Java",
-        "solution": "valid solution",
-        "topic": "%s",
-        "tags": {}
+          "challengeTitle": "Title",
+          "description": "Description",
+          "level": "%s",
+          "language": "Java",
+          "solution": "valid solution",
+          "topic": "%s",
+          "tags": {}
         }
         """;
-
+        
         return Stream.of(
                 Arguments.of(String.format(baseJson, "invalidLevel", "ALL")),
                 Arguments.of(String.format(baseJson, "EASY", "invalidTopic"))
@@ -958,16 +958,16 @@ class ChallengeControllerTest {
     void addChallenge_emptyTags_statusBadRequest() {
         String challengeWithEmptyTags = """
                 {
-                    "challengeTitle": "title",
-                    "description": "description",
-                    "level": "EASY",
-                    "language": "Java",
-                    "solution": "solution",
-                    "topic": "ALL",
-                    "tags": []
-                }
+                     "challengeTitle": "title",
+                     "description": "description",
+                     "level": "EASY",
+                     "language": "Java",
+                     "solution": "solution",
+                     "topic": "ALL",
+                     "tags": []
+                 }
             """;
-
+        
         webTestClient.post()
                 .uri("/itachallenge/api/v1/challenge/challenges")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -841,7 +841,7 @@ class ChallengeControllerTest {
           "tags": {}
         }
         """;
-        
+
         return Stream.of(
                 Arguments.of(String.format(baseJson, "invalidLevel", "ALL")),
                 Arguments.of(String.format(baseJson, "EASY", "invalidTopic"))
@@ -967,7 +967,7 @@ class ChallengeControllerTest {
                      "tags": []
                  }
             """;
-        
+
         webTestClient.post()
                 .uri("/itachallenge/api/v1/challenge/challenges")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -106,7 +106,7 @@ class ChallengeControllerTest {
 
     }
 
-            private boolean isValidUUID(String id) {
+        private boolean isValidUUID(String id) {
             try {
                 UUID.fromString(id);
                 return true;

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -831,16 +831,16 @@ class ChallengeControllerTest {
     private static Stream<Arguments> provideInvalidEnumValues() {
 
         String baseJson = """
-        {
-          "challengeTitle": "Title",
-          "description": "Description",
-          "level": "%s",
-          "language": "Java",
-          "solution": "valid solution",
-          "topic": "%s",
-          "tags": {}
-        }
-        """;
+{
+    "challengeTitle": "Title",
+    "description": "Description",
+    "level": "%s",
+    "language": "Java",
+    "solution": "valid solution",
+    "topic": "%s",
+    "tags": {}
+}
+""";
 
         return Stream.of(
                 Arguments.of(String.format(baseJson, "invalidLevel", "ALL")),

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -106,14 +106,14 @@ class ChallengeControllerTest {
 
     }
 
-    private boolean isValidUUID(String id) {
-        try {
-            UUID.fromString(id);
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
+            private boolean isValidUUID(String id) {
+            try {
+                UUID.fromString(id);
+                return true;
+            } catch (IllegalArgumentException e) {
+                return false;
+            }
         }
-    }
 
 
     @Test

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -8,7 +8,6 @@ import com.itachallenge.challenge.enums.Topic;
 import com.itachallenge.challenge.exception.*;
 import com.itachallenge.challenge.repository.ChallengeRepository;
 import com.itachallenge.challenge.service.*;
-import com.itachallenge.challenge.service.IChallengeJwtFacade;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.core.env.Environment;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.http.HttpStatus;
@@ -36,7 +36,8 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -85,9 +86,11 @@ class ChallengeControllerTest {
     private String challengeId;
     private ChallengeCreateDto formData;
     private ChallengeDto createdChallenge;
+    private ResourceBundleMessageSource messageSource;
+
 
     @BeforeEach
-    void setup(){
+    void setup() {
         tags = List.of(UUID.randomUUID());
         challengeId = String.valueOf(UUID.randomUUID());
         formData = new ChallengeCreateDto("títol", "descripció",
@@ -97,17 +100,20 @@ class ChallengeControllerTest {
         when(challengeService.getRelatedChallenges(argThat(id -> !isValidUUID(id))))
                 .thenReturn(Mono.error(new BadUUIDException("Invalid ID format. Please indicate the correct format.")));
 
+        messageSource = new ResourceBundleMessageSource();
+        messageSource.setBasename("messages");
+        messageSource.setDefaultEncoding("UTF-8");
 
     }
 
-        private boolean isValidUUID(String id) {
-            try {
-                UUID.fromString(id);
-                return true;
-            } catch (IllegalArgumentException e) {
-                return false;
-            }
+    private boolean isValidUUID(String id) {
+        try {
+            UUID.fromString(id);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
         }
+    }
 
 
     @Test
@@ -357,6 +363,9 @@ class ChallengeControllerTest {
         solutionDto.setIdChallenge(UUID.randomUUID()); // Set challenge ID to a valid UUID
         solutionDto.setIdLanguage(UUID.randomUUID()); // Set language ID to a valid UUID
 
+        String expectedMessage = messageSource.getMessage(
+                "solution.text.notEmpty", null, Locale.getDefault()
+        );
         // Act & Assert
         webTestClient.post()
                 .uri("/itachallenge/api/v1/challenge/solution")
@@ -365,7 +374,7 @@ class ChallengeControllerTest {
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody()
-                .jsonPath("$.message").isEqualTo("solutionText: 'cannot be empty'");
+                .jsonPath("$.message").isEqualTo("solutionText: '" + expectedMessage + "'");
     }
 
     @Test
@@ -376,6 +385,9 @@ class ChallengeControllerTest {
         solutionDto.setIdChallenge(UUID.randomUUID()); // Set challenge ID to a valid UUID
         solutionDto.setIdLanguage(UUID.randomUUID()); // Set language ID to a valid UUID
 
+        String expectedMessage = messageSource.getMessage(
+                "solution.text.notEmpty", null, Locale.getDefault()
+        );
         // Act & Assert
         webTestClient.post()
                 .uri("/itachallenge/api/v1/challenge/solution")
@@ -384,7 +396,7 @@ class ChallengeControllerTest {
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody()
-                .jsonPath("$.message").isEqualTo("solutionText: 'cannot be empty'");
+                .jsonPath("$.message").isEqualTo("solutionText: '" + expectedMessage + "'");
     }
 
     @Test
@@ -395,6 +407,9 @@ class ChallengeControllerTest {
         solutionDto.setIdChallenge(null); // Set challenge ID to null
         solutionDto.setIdLanguage(UUID.randomUUID()); // Set language ID to a valid UUID
 
+        String expectedMessage = messageSource.getMessage(
+                "solution.challengeId.invalid", null, Locale.getDefault()
+        );
         // Act & Assert
         webTestClient.post()
                 .uri("/itachallenge/api/v1/challenge/solution")
@@ -403,7 +418,7 @@ class ChallengeControllerTest {
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody()
-                .jsonPath("$.message").isEqualTo("idChallenge: 'Invalid UUID'");
+                .jsonPath("$.message").isEqualTo("idChallenge: '" + expectedMessage + "'");
     }
 
     @Test
@@ -414,6 +429,9 @@ class ChallengeControllerTest {
         solutionDto.setIdChallenge(UUID.randomUUID()); // Set challenge ID to a valid UUID
         solutionDto.setIdLanguage(null); // Set challenge ID to null
 
+        String expectedMessage = messageSource.getMessage(
+                "solution.languageId.invalid", null, Locale.getDefault()
+        );
         // Act & Assert
         webTestClient.post()
                 .uri("/itachallenge/api/v1/challenge/solution")
@@ -422,7 +440,7 @@ class ChallengeControllerTest {
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody()
-                .jsonPath("$.message").isEqualTo("idLanguage: 'Invalid UUID'");
+                .jsonPath("$.message").isEqualTo("idLanguage: '" + expectedMessage + "'");
     }
 
     @Test
@@ -509,6 +527,7 @@ class ChallengeControllerTest {
         verify(challengeJwtFacade, times(1)).getUserUuIdFromAuthenticationHeader(authHeader);
         verify(challengeService, times(1)).addChallenge(any(ChallengeCreateDto.class));
     }
+
     @Test
     void addChallenge_test_invalidLevel_statusBadRequest() {
         String invalidFormData = """
@@ -541,6 +560,7 @@ class ChallengeControllerTest {
                 .jsonPath("$.application_name").isEqualTo("itachallenge-challenge")
                 .jsonPath("$.version").isEqualTo(expectedVersion);
     }
+
     @Test
     void deleteOneChallenge_success() {
         String id = "existing_id";
@@ -692,7 +712,7 @@ class ChallengeControllerTest {
                 .timesFavorite(5)
                 .build();
 
-        ChallengeDto[] challengeArray = new ChallengeDto[] { challenge };
+        ChallengeDto[] challengeArray = new ChallengeDto[]{challenge};
         GenericResultDto<ChallengeDto> resultDto = new GenericResultDto<>(0, 10, 1, challengeArray);
 
 
@@ -757,7 +777,7 @@ class ChallengeControllerTest {
         verify(challengeService, times(1)).updateChallenge(anyString(), any(ChallengeCreateDto.class));
     }
 
-   @Test
+    @Test
     void updateChallenge_MissingAuthHeader_Returns400() {
         when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(null)).thenThrow(new JwtException("Missing auth header"));
 
@@ -788,7 +808,7 @@ class ChallengeControllerTest {
 
     @ParameterizedTest
     @MethodSource("provideInvalidEnumValues")
-    void updateChallengeInvalidEnumValue_returnsBadRequest_test(String jsonBody){
+    void updateChallengeInvalidEnumValue_returnsBadRequest_test(String jsonBody) {
 
         webTestClient.put()
                 .uri("/itachallenge/api/v1/challenge/challenge/" + challengeId + "/update")
@@ -813,16 +833,16 @@ class ChallengeControllerTest {
     private static Stream<Arguments> provideInvalidEnumValues() {
 
         String baseJson = """
-        {
-          "challengeTitle": "Title",
-          "description": "Description",
-          "level": "%s",
-          "language": "Java",
-          "solution": "valid solution",
-          "topic": "%s",
-          "tags": {}
-        }
-        """;
+                {
+                  "challengeTitle": "Title",
+                  "description": "Description",
+                  "level": "%s",
+                  "language": "Java",
+                  "solution": "valid solution",
+                  "topic": "%s",
+                  "tags": {}
+                }
+                """;
 
         return Stream.of(
                 Arguments.of(String.format(baseJson, "invalidLevel", "ALL")),
@@ -939,16 +959,16 @@ class ChallengeControllerTest {
     @Test
     void addChallenge_emptyTags_statusBadRequest() {
         String challengeWithEmptyTags = """
-                {
-                     "challengeTitle": "title",
-                     "description": "description",
-                     "level": "EASY",
-                     "language": "Java",
-                     "solution": "solution",
-                     "topic": "ALL",
-                     "tags": []
-                 }
-            """;
+                    {
+                         "challengeTitle": "title",
+                         "description": "description",
+                         "level": "EASY",
+                         "language": "Java",
+                         "solution": "solution",
+                         "topic": "ALL",
+                         "tags": []
+                     }
+                """;
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/challenge/challenges")

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/ChallengeCreateDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/ChallengeCreateDtoTest.java
@@ -1,0 +1,111 @@
+package com.itachallenge.challenge.dto;
+
+import com.itachallenge.challenge.enums.Topic;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
+import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChallengeCreateDtoTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        Locale.setDefault(Locale.ENGLISH);
+        ValidatorFactory factory = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(
+                        new ResourceBundleMessageInterpolator(
+                                new PlatformResourceBundleLocator("messages")
+                        )
+                )
+                .buildValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("Should fail validation when required string fields are empty")
+    void shouldFailWhenStringFieldsEmpty() {
+        ChallengeCreateDto dto = ChallengeCreateDto.builder()
+                .challengeTitle("")
+                .description("")
+                .language("")
+                .solution("")
+                .topic(null)
+                .tags(Collections.emptyList())
+                .build();
+
+        Set<ConstraintViolation<ChallengeCreateDto>> violations = validator.validate(dto);
+
+        assertThat(violations).isNotEmpty()
+                .anyMatch(v -> v.getMessage().equals("The challenge title cannot be empty."))
+                .anyMatch(v -> v.getMessage().equals("The description cannot be empty."))
+                .anyMatch(v -> v.getMessage().equals("The language field cannot be empty."))
+                .anyMatch(v -> v.getMessage().equals("The solution text cannot be empty."))
+                .anyMatch(v -> v.getMessage().equals("The topic must be provided."))
+                .anyMatch(v -> v.getMessage().equals("At least one tag must be provided for the challenge."));
+    }
+
+    @Test
+    @DisplayName("Should fail validation when topic is null")
+    void shouldFailWhenTopicIsNull() {
+        ChallengeCreateDto dto = ChallengeCreateDto.builder()
+                .challengeTitle("Challenge 1")
+                .description("Description")
+                .language("Java")
+                .solution("System.out.println(\"Hello\");")
+                .topic(null)
+                .tags(List.of(UUID.randomUUID()))
+                .build();
+
+        Set<ConstraintViolation<ChallengeCreateDto>> violations = validator.validate(dto);
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals("The topic must be provided."));
+    }
+
+    @Test
+    @DisplayName("Should fail validation when tags list is empty")
+    void shouldFailWhenTagsListEmpty() {
+        ChallengeCreateDto dto = ChallengeCreateDto.builder()
+                .challengeTitle("Challenge 1")
+                .description("Description")
+                .language("Java")
+                .solution("System.out.println(\"Hello\");")
+                .topic(com.itachallenge.challenge.enums.Topic.DEBUGGING)
+                .tags(Collections.emptyList())
+                .build();
+
+        Set<ConstraintViolation<ChallengeCreateDto>> violations = validator.validate(dto);
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals("At least one tag must be provided for the challenge."));
+    }
+
+    @Test
+    @DisplayName("Should pass validation when all fields are valid")
+    void shouldPassWhenValid() {
+        ChallengeCreateDto dto = ChallengeCreateDto.builder()
+                .challengeTitle("Valid Challenge")
+                .description("A proper description")
+                .language("Java")
+                .solution("System.out.println(\"Hello World\");")
+                .topic(Topic.DEBUGGING)
+                .tags(List.of(UUID.randomUUID()))
+                .build();
+
+        Set<ConstraintViolation<ChallengeCreateDto>> violations = validator.validate(dto);
+
+        assertThat(violations).isEmpty();
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/ResourceDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/ResourceDtoTest.java
@@ -6,22 +6,48 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenge.challenge.enums.AssociationType;
 import com.itachallenge.challenge.enums.ResourceContentType;
 import com.itachallenge.challenge.enums.Topic;
-import jakarta.validation.*;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
+import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Set;
-import java.util.UUID;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 class ResourceDtoTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        Locale.setDefault(Locale.ENGLISH);
+        ValidatorFactory factory = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(
+                        new ResourceBundleMessageInterpolator(
+                                new PlatformResourceBundleLocator("messages")
+                        )
+                )
+                .buildValidatorFactory();
+        validator = factory.getValidator();
+    }
+
 
     @Test
     void rightSerializationTest() throws Exception {
@@ -66,19 +92,19 @@ class ResourceDtoTest {
     @Test
     void rightDeserializationTest() throws Exception {
         String jsonContent = """
-    {
-        "resourceId": "123e4567-e89b-12d3-a456-426614174000",
-        "title": "DEBUGGING FOR THE FIRST TIME",
-        "description": "A guide on how to start debugging",
-        "url": "https://youtubetutorial.com/debugging",
-        "topic": "DEBUGGING", 
-        "contentType": "BLOG",
-        "challengeIds": [
-            "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-            "550e8400-e29b-41d4-a716-446655440000"
-        ]
-    }
-    """;
+                {
+                    "resourceId": "123e4567-e89b-12d3-a456-426614174000",
+                    "title": "DEBUGGING FOR THE FIRST TIME",
+                    "description": "A guide on how to start debugging",
+                    "url": "https://youtubetutorial.com/debugging",
+                    "topic": "DEBUGGING", 
+                    "contentType": "BLOG",
+                    "challengeIds": [
+                        "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                        "550e8400-e29b-41d4-a716-446655440000"
+                    ]
+                }
+                """;
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
@@ -173,9 +199,6 @@ class ResourceDtoTest {
                 .build();
 
 
-        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-        Validator validator = factory.getValidator();
-
         Set<ConstraintViolation<ResourceDto>> violations = validator.validate(invalidResource);
 
         assertFalse("ResourceDto invalid", violations.isEmpty());
@@ -226,6 +249,111 @@ class ResourceDtoTest {
         Assertions.assertFalse(jsonContent.contains("\"associationType\":null"), " associationType should not be here");
     }
 
+    @Test
+    @DisplayName("Should fail validation when all required fields are missing or empty")
+    void shouldFailWhenFieldsMissingOrEmpty() {
+        ResourceDto dto = ResourceDto.builder()
+                .resourceId(null)
+                .title("")
+                .description("")
+                .url("")
+                .topic(null)
+                .contentType(null)
+                .challengeIds(null)
+                .associationType(null)
+                .build();
+
+        Set<ConstraintViolation<ResourceDto>> violations = validator.validate(dto);
+
+        assertThat(violations).isNotEmpty()
+                .anyMatch(v -> v.getMessage().equals("The resource ID cannot be null."))
+                .anyMatch(v -> v.getMessage().equals("The resource title cannot be empty."))
+                .anyMatch(v -> v.getMessage().equals("The resource description cannot be empty."))
+                .anyMatch(v -> v.getMessage().equals("The resource URL cannot be empty."))
+                .anyMatch(v -> v.getMessage().equals("The topic must be specified."))
+                .anyMatch(v -> v.getMessage().equals("The content type must be specified."))
+                .anyMatch(v -> v.getMessage().equals("The list of associated challenge IDs cannot be null."))
+                .anyMatch(v -> v.getMessage().equals("The association type must be specified."));
+    }
+
+    @Test
+    @DisplayName("Should fail validation when topic is null")
+    void shouldFailWhenTopicNull() {
+        ResourceDto dto = ResourceDto.builder()
+                .resourceId(UUID.randomUUID())
+                .title("Resource title")
+                .description("Resource description")
+                .url("https://example.com")
+                .topic(null)
+                .contentType(ResourceContentType.VIDEO)
+                .challengeIds(List.of(UUID.randomUUID()))
+                .associationType(AssociationType.ALLSAMETOPIC)
+                .build();
+
+        Set<ConstraintViolation<ResourceDto>> violations = validator.validate(dto);
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals("The topic must be specified."));
+    }
+
+    @Test
+    @DisplayName("Should fail validation when contentType is null")
+    void shouldFailWhenContentTypeNull() {
+        ResourceDto dto = ResourceDto.builder()
+                .resourceId(UUID.randomUUID())
+                .title("Title")
+                .description("Description")
+                .url("https://example.com")
+                .topic(Topic.DEBUGGING)
+                .contentType(null)
+                .challengeIds(List.of(UUID.randomUUID()))
+                .associationType(AssociationType.ALLSAMETOPIC)
+                .build();
+
+        Set<ConstraintViolation<ResourceDto>> violations = validator.validate(dto);
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals("The content type must be specified."));
+    }
+
+    @Test
+    @DisplayName("Should fail validation when challengeIds list is null")
+    void shouldFailWhenChallengeIdsNull() {
+        ResourceDto dto = ResourceDto.builder()
+                .resourceId(UUID.randomUUID())
+                .title("Title")
+                .description("Description")
+                .url("https://example.com")
+                .topic(Topic.DEBUGGING)
+                .contentType(ResourceContentType.VIDEO)
+                .challengeIds(null)
+                .associationType(AssociationType.ALLSAMETOPIC)
+                .build();
+
+        Set<ConstraintViolation<ResourceDto>> violations = validator.validate(dto);
+
+        assertThat(violations)
+                .anyMatch(v -> v.getMessage().equals("The list of associated challenge IDs cannot be null."));
+    }
+
+    @Test
+    @DisplayName("Should pass validation when all fields are valid")
+    void shouldPassWhenValid() {
+        ResourceDto dto = ResourceDto.builder()
+                .resourceId(UUID.randomUUID())
+                .title("Intro to Algorithms")
+                .description("Comprehensive guide to algorithmic problem-solving.")
+                .url("https://example.com/resource")
+                .topic(Topic.DEBUGGING)
+                .contentType(ResourceContentType.VIDEO)
+                .challengeIds(List.of(UUID.randomUUID()))
+                .associationType(AssociationType.ALLSAMETOPIC)
+                .build();
+
+        Set<ConstraintViolation<ResourceDto>> violations = validator.validate(dto);
+
+        assertThat(violations).isEmpty();
+    }
 
 
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/ResourceDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/ResourceDtoTest.java
@@ -92,19 +92,19 @@ class ResourceDtoTest {
     @Test
     void rightDeserializationTest() throws Exception {
         String jsonContent = """
-                {
-                    "resourceId": "123e4567-e89b-12d3-a456-426614174000",
-                    "title": "DEBUGGING FOR THE FIRST TIME",
-                    "description": "A guide on how to start debugging",
-                    "url": "https://youtubetutorial.com/debugging",
-                    "topic": "DEBUGGING", 
-                    "contentType": "BLOG",
-                    "challengeIds": [
-                        "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-                        "550e8400-e29b-41d4-a716-446655440000"
-                    ]
-                }
-                """;
+    {
+        "resourceId": "123e4567-e89b-12d3-a456-426614174000",
+        "title": "DEBUGGING FOR THE FIRST TIME",
+        "description": "A guide on how to start debugging",
+        "url": "https://youtubetutorial.com/debugging",
+        "topic": "DEBUGGING", 
+        "contentType": "BLOG",
+        "challengeIds": [
+            "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            "550e8400-e29b-41d4-a716-446655440000"
+        ]
+    }
+    """;
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/SolutionDtoTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/dto/SolutionDtoTest.java
@@ -1,0 +1,83 @@
+package com.itachallenge.challenge.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
+import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SolutionDtoTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        // ✅ Force locale for predictable message interpolation
+        Locale.setDefault(Locale.ENGLISH);
+
+        // ✅ Create a Validator that explicitly loads messages.properties
+        ValidatorFactory factory = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(
+                        new ResourceBundleMessageInterpolator(
+                                new PlatformResourceBundleLocator("messages")
+                        )
+                )
+                .buildValidatorFactory();
+
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("Should fail validation when solutionText is empty")
+    void shouldFailWhenSolutionTextEmpty() {
+        SolutionDto dto = new SolutionDto(
+                UUID.randomUUID(),
+                "", // invalid: empty
+                UUID.randomUUID()
+        );
+
+        Set<ConstraintViolation<SolutionDto>> violations = validator.validate(dto);
+
+        assertThat(violations).isNotEmpty()
+                .anyMatch(v -> v.getMessage().equals("The solution text cannot be empty."));
+    }
+
+    @Test
+    @DisplayName("Should fail when language or challenge UUIDs are invalid")
+    void shouldFailForInvalidUUIDs() {
+        // Simulate invalid UUIDs (null)
+        SolutionDto dto = new SolutionDto(null, "some text", null);
+
+        Set<ConstraintViolation<SolutionDto>> violations = validator.validate(dto);
+
+        assertThat(violations).isNotEmpty()
+                .anyMatch(v -> v.getMessage().equals("The language ID must be a valid UUID."))
+                .anyMatch(v -> v.getMessage().equals("The challenge ID must be a valid UUID."));
+    }
+
+    @Test
+    @DisplayName("Should pass validation for a valid SolutionDto")
+    void shouldPassWhenValid() {
+        SolutionDto dto = new SolutionDto(
+                UUID.randomUUID(),
+                "Valid solution text",
+                UUID.randomUUID()
+        );
+        dto.setIdChallenge(UUID.randomUUID());
+
+        Set<ConstraintViolation<SolutionDto>> violations = validator.validate(dto);
+
+        assertThat(violations).isEmpty();
+    }
+}


### PR DESCRIPTION
## PR Description

### Summary
This PR implements **Task 770 – Update validation annotations to use message keys from `messages.properties`** as part of the broader User Story *“Improve Error Messages in the Challenge Microservice.”*

It builds on task 796 (PR #1010 ) and task 734 (PR #997). Task 734 previously built on a Task 731, but the overall strategy for error handling has been redesigned, and the current git pipeline rebased on feature/add-error-core which develops a error handling module that can be used in all microservices. 

It updates validation annotations in the `itachallenge-challenge` microservice so that they now reference message keys defined in `messages.properties`, replacing hardcoded or inline message strings.  
This ensures consistent, maintainable, and easily localizable validation feedback across all DTOs.
Only the DTOs that already include validation annotations have been updated. For consistency, the whole microservice should be reviewed so that the all DTOs that deserve validation are validated. 

This is the third of a group of 4 PRs: (Task 731, #996); (Task 734, #997); (Task 770, #998); (Task 756, #999)

### Checklist Alignment
✅ Replaces all hardcoded validation messages with message keys from `messages.properties`  
✅ Ensures message keys exist and are correctly defined in the centralized message file  
✅ Maintains existing validation behavior in controllers using `@Valid`  
✅ Adds self-contained unit tests validating message resolution and constraint behavior  

### Context & Changes

**Before**
Validation annotations used inline message text, e.g.:
```java
@NotEmpty(message = "cannot be empty")
@NotNull(message = "cannot be null")
```
### After

Validation annotations now reference centralized message keys:

```java
@NotEmpty(message = "{challenge.title.notEmpty}")
@NotNull(message = "{resource.id.notNull}")
```
### Scope of Changes

**Updated DTOs:**
- `SolutionDto`
- `ChallengeCreateDto`
- `ResourceDto`

**Updated Tests:**
- `SolutionDto` (created)
- `ChallengeCreateDto`(created)
- `ResourceDto`(enriched)
- `ChallengeControllerTest` (modification to adapt to new messages in SolutionDto)

### Validation Behavior

DTO-level unit tests confirm that message interpolation works correctly **outside the Spring context**.

---

### Impact for API Consumers

✅ No breaking changes in endpoint structure or payloads.  
✅ Only the source of validation messages changed — responses remain semantically identical.  
🌍 Validation messages are now ready for localization (e.g. `messages_es.properties`, `messages_ca.properties`).  

---

### Changelog

No version bump, since no behaviour change is expected. All changes in the PR chain will be bundled into one version bump in the end. 

---

### How to Test

Run unit tests:
- `SolutionDtoValidationTest`
- `ChallengeCreateDtoTest`
- `ResourceDtoTest`

✅ All should pass successfully, confirming correct message resolution.

---

### PR Author Self-Check

- [x] I verified that all annotations reference keys from `messages.properties`  
- [x] I confirmed no hardcoded validation messages remain in the relevant Dtos  
- [x] I tested locally that validation still triggers correctly in controllers  
- [x] SonarLint and all automated checks pass without warnings  

---

### Future Considerations

- Extend this message resolution strategy to handle **ConstraintViolationException** (e.g. for `@RequestParam`, `@PathVariable`, and `@RequestHeader`).  
- Review all microservice DTOs and validation annotations for naming consistency.  
- Add coverage for **@ModelAttribute** filters to ensure unified validation behavior.  
- Define a **cross-microservice validation strategy** to standardize error message handling, localization, and response formatting.  

Each field’s validation message now maps to a corresponding key in `messages.properties`.
