### PR TITLE
PR 2.4/2 - refactor(user) - 1 user exception handler (#791)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-2.0.1-RELEASE] - 2025-10-03
+
+### Changed
+- Improved stability of GitHub connection error handling.
+  - Before: The system guessed the error status (503/504) by comparing the text of the exception message (ex.getMessage()), which was unreliable and fragile.
+  - After: The system now accurately determines the status (HTTP 503 or HTTP 504) by inspecting the underlying network exception cause (e.g., TimeoutException or ConnectException), ensuring the correct error code is returned to the client. (Taiga [#744], PR [#991])
+
 ### [itachallenge-user-2.1.0-RELEASE] - 2025-10-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-2.1.0-RELEASE] - 2025-10-06
 
+### Added
+- Standardized Error Response: All API error responses now use the standardized APIErrorResponse DTO format, including explicit 'status' and 'path' fields. (Taiga [#766], PR [#992])
+
+### [itachallenge-user-2.0.1-RELEASE] - 2025-10-03
+
+### Changed
+- Improved stability of GitHub connection error handling.
+ - Before: The system guessed the error status (503/504) by comparing the text of the exception message (ex.getMessage()), which was unreliable and fragile.
+ - After: The system now accurately determines the status (HTTP 503 or HTTP 504) by inspecting the underlying network exception cause (e.g., TimeoutException or ConnectException), ensuring the correct error code is returned to the client. (Taiga [#744], PR [#991])
 
 ### [itachallenge-user-2.1.0-RELEASE] - 2025-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-user-2.1.0-RELEASE] - 2025-10-06
+### [itachallenge-user-2.2.0-RELEASE] - 2025-10-20
 
-### Added
-- Standardized Error Response: All API error responses now use the standardized APIErrorResponse DTO format, including explicit 'status' and 'path' fields. (Taiga [#766], PR [#992])
+### Changed
+- Standardized Error Handler: The GithubUnavailableException handler is updated to use the final standardized APIErrorResponse DTO and the reactive WebFlux architecture. (Taiga [#791], PR [1008])
 
 ### [itachallenge-user-2.0.1-RELEASE] - 2025-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-user-2.1.0-RELEASE] - 2025-10-06
 
-### Added 
-- Standardized Error Response: All API error responses now use the standardized APIErrorResponse DTO format, including explicit 'status' and 'path' fields. (Taiga [#766], PR [#992])
-
-
-### [itachallenge-user-2.0.1-RELEASE] - 2025-10-03
-
-### Changed
-- Improved stability of GitHub connection error handling.
-  - Before: The system guessed the error status (503/504) by comparing the text of the exception message (ex.getMessage()), which was unreliable and fragile.
-  - After: The system now accurately determines the status (HTTP 503 or HTTP 504) by inspecting the underlying network exception cause (e.g., TimeoutException or ConnectException), ensuring the correct error code is returned to the client. (Taiga [#744], PR [#991])
 
 ### [itachallenge-user-2.1.0-RELEASE] - 2025-10-03
 
@@ -35,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Before: POST /users/create accepted any githubUsername value and returned success (201/ok) even if that wasn't a GitHub username. 
   - After: POST /users/create now calls the GitHub API and rejects the request when the GitHub username does not exist. 
   - Clients that previously relied on creating users with invalid GitHub usernames will now get errors for some requests that used to succeed.
+
+### [itachallenge-challenge-2.4.3-RELEASE] - 2025-09-15
+
+### Added
+- Added the @NotEmpty annotation to the tags field in the ChallengeCreateDto.java DTO to make it a mandatory field. (Taiga [#654], PR [#961])
 
 ### [itachallenge-githubcore-1.0.0-RELEASE] - 2025-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-2.1.0-RELEASE] - 2025-10-06
+
+### Added 
+- Standardized Error Response: All API error responses now use the standardized APIErrorResponse DTO format, including explicit 'status' and 'path' fields. (Taiga [#766], PR [#992])
+
+
 ### [itachallenge-user-2.0.1-RELEASE] - 2025-10-03
 
 ### Changed

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=2.1.0-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=2.2.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.0-RELEASE

--- a/github-core/src/main/java/com/itachallenge/githubcore/exception/GithubUnavailableException.java
+++ b/github-core/src/main/java/com/itachallenge/githubcore/exception/GithubUnavailableException.java
@@ -4,4 +4,8 @@ public class GithubUnavailableException extends RuntimeException {
     public GithubUnavailableException(String message) {
         super(message);
     }
+
+    public GithubUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/itachallenge-user/README.md
+++ b/itachallenge-user/README.md
@@ -125,6 +125,7 @@ The service now provides more reliable status codes for external connection issu
 - Robust GitHub Status Codes:** Errors related to external GitHub service availability are now accurately mapped based on the type of failure, eliminating fragile string comparisons.
   - HTTP 504 (Gateway Timeout): Returned when the connection attempt exceeds the configured time limit.
   - HTTP 503 (Service Unavailable): Returned when a connection is refused or the external service is otherwise unreachable.
+- Standardized Error Response Body (PR 2/2): All API error responses now adhere to the service-wide APIErrorResponse DTO structure. This ensures clients receive a predictable JSON payload with all necessary fields: `timestamp`, `status`, `error`, `message`, and the request `path`.
 
 This change ensures clients receive accurate status codes for better application recovery.
 

--- a/itachallenge-user/README.md
+++ b/itachallenge-user/README.md
@@ -119,6 +119,15 @@ both basic and custom user data.
 - The `uuid` field is mapped to the MongoDB `_id`.
 - This model supports extended features like filtering, favoriting, and bookmarking challenges.
 
+### API Contract: Robust Error Handling
+The service now provides more reliable status codes for external connection issues:
+
+- Robust GitHub Status Codes:** Errors related to external GitHub service availability are now accurately mapped based on the type of failure, eliminating fragile string comparisons.
+  - HTTP 504 (Gateway Timeout): Returned when the connection attempt exceeds the configured time limit.
+  - HTTP 503 (Service Unavailable): Returned when a connection is refused or the external service is otherwise unreachable.
+
+This change ensures clients receive accurate status codes for better application recovery.
+
 ##### Spring Boot Actuator
 
 - http://localhost:8762/actuator/health (debe responder {"status":"UP"})

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -1,12 +1,16 @@
 package com.itachallenge.user.dto;
 
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
 
 import java.time.Instant;
+
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -14,14 +18,37 @@ import java.time.Instant;
 @Setter
 public class APIErrorResponse {
 
-    @JsonProperty("error")
-    String error;
-
-    @JsonProperty("message")
-    String message;
 
     @JsonProperty("timestamp")
-    Instant timestamp;
+    private Instant timestamp;
+
+
+    @JsonProperty("status")
+    private int status;
+
+
+    @JsonProperty("error")
+    private String error;
+
+
+    @JsonProperty("message")
+    private String message;
+
+
+    @JsonProperty("path")
+    private String path;
+
+
+    public APIErrorResponse(HttpStatus status, String error, String message, String path){
+        this.timestamp = Instant.now();
+        this.status = status.value();
+        this.error = error;
+        this.message = message;
+        this.path = path;
+    }
+
 
 }
+
+
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -40,6 +40,3 @@ public class APIErrorResponse {
 
 
 }
-
-
-

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -1,6 +1,5 @@
 package com.itachallenge.user.dto;
 
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,9 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.http.HttpStatus;
 
-
 import java.time.Instant;
-
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -18,26 +15,20 @@ import java.time.Instant;
 @Setter
 public class APIErrorResponse {
 
-
     @JsonProperty("timestamp")
     private Instant timestamp;
-
 
     @JsonProperty("status")
     private int status;
 
-
     @JsonProperty("error")
     private String error;
-
 
     @JsonProperty("message")
     private String message;
 
-
     @JsonProperty("path")
     private String path;
-
 
     public APIErrorResponse(HttpStatus status, String error, String message, String path){
         this.timestamp = Instant.now();

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -1,42 +1,23 @@
 package com.itachallenge.user.dto;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.http.HttpStatus;
 
 import java.time.Instant;
+import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(force = true)
 @Getter
-@Setter
+@Builder
 public class APIErrorResponse {
-
-    @JsonProperty("timestamp")
-    private Instant timestamp;
-
-    @JsonProperty("status")
-    private int status;
-
-    @JsonProperty("error")
-    private String error;
-
-    @JsonProperty("message")
-    private String message;
-
-    @JsonProperty("path")
-    private String path;
-
-    public APIErrorResponse(HttpStatus status, String error, String message, String path){
-        this.timestamp = Instant.now();
-        this.status = status.value();
-        this.error = error;
-        this.message = message;
-        this.path = path;
-    }
-
-
+    private final Instant timestamp;
+    private final int status;
+    private final String error;
+    private final String message;
+    private final String path;
+    private final List<FieldErrorDto> errors;
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/FieldErrorDto.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/FieldErrorDto.java
@@ -1,0 +1,16 @@
+package com.itachallenge.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@Builder
+@AllArgsConstructor
+@Getter
+public class FieldErrorDto {
+    private final String objectName;
+    private final String field;
+    private final String message;
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -15,7 +15,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import jakarta.validation.ConstraintViolationException;
 
 
-import java.time.Instant;
+
 import java.util.HashMap;
 import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,7 +24,7 @@ import jakarta.servlet.http.HttpServletRequest;
 @Slf4j
 @RestControllerAdvice
 public class UserGlobalExceptionHandler {
-
+    public static final String GITHUB_ERROR_SUMMARY = "GitHub API error";
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleAny(Exception e) {
@@ -124,7 +124,7 @@ public class UserGlobalExceptionHandler {
         }
 
 
-        String errorSummary = "GitHub API error";
+        String errorSummary = GITHUB_ERROR_SUMMARY;
 
 
         String requestPath = request.getRequestURI();

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -2,7 +2,10 @@ package com.itachallenge.user.exception;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -11,14 +14,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import jakarta.validation.ConstraintViolationException;
+import org.springframework.web.server.ServerWebExchange;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-import jakarta.servlet.http.HttpServletRequest;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class UserGlobalExceptionHandler {
+
+    private final MessageSource messageSource;
     public static final String GITHUB_ERROR_SUMMARY = "GitHub API error";
 
     @ExceptionHandler(Exception.class)
@@ -63,31 +70,70 @@ public class UserGlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
-        Map<String, String> errors = new HashMap<>();
-        e.getBindingResult().getFieldErrors().forEach(error ->
-                errors.put(error.getField(), error.getDefaultMessage())
-        );
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    public ResponseEntity<APIErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e, ServerWebExchange exchange){
+        log.error("Invalid request: {}", e.getMessage());
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(Instant.now())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .error(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                .message(e.getMessage())
+                .path(exchange.getRequest().getPath().value())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
     @ExceptionHandler(UnmodificableSolutionException.class)
-    public ResponseEntity<String> handleUnmodifiableSolutionException(UnmodificableSolutionException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+    public ResponseEntity<APIErrorResponse> handleUnmodifiableSolutionException(UnmodificableSolutionException e,  ServerWebExchange exchange) {
+        log.error("Resource already exists: {}", e.getMessage());
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(Instant.now())
+                .status(HttpStatus.CONFLICT.value())
+                .error("There's an existing solution with status 'ENDED'.")
+                .message("There's an existing solution with status 'ENDED'.")
+                .path(exchange.getRequest().getPath().value())
+                .build();
+
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
 
     @ExceptionHandler(InternalServerErrorException.class)
-    public ResponseEntity<String> handleInternalServerErrorException(InternalServerErrorException e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+    public ResponseEntity<APIErrorResponse> handleInternalServerErrorException(InternalServerErrorException e, ServerWebExchange exchange) {
+        log.error("Unexpected error happened: {}", e.getMessage());
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(Instant.now())
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .error(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase())
+                .message(e.getMessage())
+                .path(exchange.getRequest().getPath().value())
+                .build();
+
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }
 
     @ExceptionHandler(UsernameAlreadyExistsException.class)
-    public ResponseEntity<String> handleUsernameAlreadyExistsException(UsernameAlreadyExistsException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+    public ResponseEntity<APIErrorResponse> handleUsernameAlreadyExistsException(UsernameAlreadyExistsException e, ServerWebExchange exchange) {
+        log.error("The username already exists: {}", e.getMessage());
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(Instant.now())
+                .status(HttpStatus.CONFLICT.value())
+                .error("The username already exists")
+                .message("The username already exists")
+                .path(exchange.getRequest().getPath().value())
+                .build();
+
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
 
     @ExceptionHandler(GithubUnavailableException.class)
-    public ResponseEntity<APIErrorResponse> handleGithubUnavailable(GithubUnavailableException ex, HttpServletRequest request) {
+    public ResponseEntity<APIErrorResponse> handleGithubUnavailable(GithubUnavailableException ex, ServerWebExchange exchange) {
         HttpStatus status;
         String securedMessage;
 
@@ -104,17 +150,15 @@ public class UserGlobalExceptionHandler {
             securedMessage = "An external service error occurred.";
         }
 
-        String errorSummary = GITHUB_ERROR_SUMMARY;
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(Instant.now())
+                .status(status.value())
+                .error(GITHUB_ERROR_SUMMARY)
+                .message(securedMessage)
+                .path(exchange.getRequest().getPath().value())
+                .build();
 
-        String requestPath = request.getRequestURI();
-
-        APIErrorResponse errorResponse = new APIErrorResponse(
-                status,
-                errorSummary,
-                securedMessage,
-                requestPath
-        );
-        return new ResponseEntity<>(errorResponse, status);
+        return ResponseEntity.status(status).body(response);
     }
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.itachallenge.user.exception;
 
+
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -10,15 +11,20 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+
 import jakarta.validation.ConstraintViolationException;
+
 
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import jakarta.servlet.http.HttpServletRequest;
+
 
 @Slf4j
 @RestControllerAdvice
 public class UserGlobalExceptionHandler {
+
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleAny(Exception e) {
@@ -26,40 +32,48 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Unexpected error happened.");
     }
 
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
+
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<String> handleValidationExceptions(ConstraintViolationException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 
+
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<String> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid parameter format.");
     }
+
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<String> handleBadRequestException(BadRequestException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
+
     @ExceptionHandler(BadUUIDException.class)
     public ResponseEntity<String> handleBadUUIDException(BadUUIDException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("The provided IDs are not valid.");
     }
+
 
     @ExceptionHandler(DatabaseException.class)
     public ResponseEntity<String> handleDatabaseException(DatabaseException e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Database error: " + e.getMessage());
     }
 
+
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<String> handleNotFoundException(NotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
+
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
@@ -70,27 +84,33 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 
+
     @ExceptionHandler(UnmodificableSolutionException.class)
     public ResponseEntity<String> handleUnmodifiableSolutionException(UnmodificableSolutionException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
+
 
     @ExceptionHandler(InternalServerErrorException.class)
     public ResponseEntity<String> handleInternalServerErrorException(InternalServerErrorException e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
     }
 
+
     @ExceptionHandler(UsernameAlreadyExistsException.class)
     public ResponseEntity<String> handleUsernameAlreadyExistsException(UsernameAlreadyExistsException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
 
+
     @ExceptionHandler(GithubUnavailableException.class)
-    public ResponseEntity<APIErrorResponse> handleGithubUnavailable(GithubUnavailableException ex) {
+    public ResponseEntity<APIErrorResponse> handleGithubUnavailable(GithubUnavailableException ex, HttpServletRequest request) {
         HttpStatus status;
         String securedMessage;
 
+
         log.error("GithubUnavailableException occurred: {}", ex.getMessage(), ex);
+
 
         if (ex.getCause() instanceof java.net.SocketTimeoutException) {
             status = HttpStatus.GATEWAY_TIMEOUT;
@@ -103,9 +123,23 @@ public class UserGlobalExceptionHandler {
             securedMessage = "An external service error occurred.";
         }
 
-        return ResponseEntity.status(status).body(
-                new APIErrorResponse("External Service Error", securedMessage, Instant.now())
+
+        String errorSummary = "GitHub API error";
+
+
+        String requestPath = request.getRequestURI();
+
+
+        APIErrorResponse errorResponse = new APIErrorResponse(
+                status,
+                errorSummary,
+                securedMessage,
+                requestPath
         );
+
+
+        return new ResponseEntity<>(errorResponse, status);
     }
+
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -88,15 +88,23 @@ public class UserGlobalExceptionHandler {
     @ExceptionHandler(GithubUnavailableException.class)
     public ResponseEntity<APIErrorResponse> handleGithubUnavailable(GithubUnavailableException ex) {
         HttpStatus status;
+        String securedMessage;
 
-        if ("timeout".equalsIgnoreCase(ex.getMessage())) {
-            status = HttpStatus.GATEWAY_TIMEOUT; // 504
+        log.error("GithubUnavailableException occurred: {}", ex.getMessage(), ex);
+
+        if (ex.getCause() instanceof java.net.SocketTimeoutException) {
+            status = HttpStatus.GATEWAY_TIMEOUT;
+            securedMessage = "The external GitHub service timed out.";
+        } else if (ex.getCause() instanceof java.net.ConnectException) {
+            status = HttpStatus.SERVICE_UNAVAILABLE;
+            securedMessage = "The external GitHub service is currently unavailable.";
         } else {
-            status = HttpStatus.SERVICE_UNAVAILABLE; // 503
+            status = HttpStatus.SERVICE_UNAVAILABLE;
+            securedMessage = "An external service error occurred.";
         }
 
         return ResponseEntity.status(status).body(
-                new APIErrorResponse("GitHub API error", ex.getMessage(), Instant.now())
+                new APIErrorResponse("External Service Error", securedMessage, Instant.now())
         );
     }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.itachallenge.user.exception;
 
-
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -11,15 +10,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-
 import jakarta.validation.ConstraintViolationException;
-
-
 
 import java.util.HashMap;
 import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
-
 
 @Slf4j
 @RestControllerAdvice
@@ -32,48 +27,40 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Unexpected error happened.");
     }
 
-
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
-
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<String> handleValidationExceptions(ConstraintViolationException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 
-
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<String> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid parameter format.");
     }
-
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<String> handleBadRequestException(BadRequestException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
-
     @ExceptionHandler(BadUUIDException.class)
     public ResponseEntity<String> handleBadUUIDException(BadUUIDException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("The provided IDs are not valid.");
     }
-
 
     @ExceptionHandler(DatabaseException.class)
     public ResponseEntity<String> handleDatabaseException(DatabaseException e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Database error: " + e.getMessage());
     }
 
-
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<String> handleNotFoundException(NotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
-
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
@@ -84,33 +71,27 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 
-
     @ExceptionHandler(UnmodificableSolutionException.class)
     public ResponseEntity<String> handleUnmodifiableSolutionException(UnmodificableSolutionException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
-
 
     @ExceptionHandler(InternalServerErrorException.class)
     public ResponseEntity<String> handleInternalServerErrorException(InternalServerErrorException e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
     }
 
-
     @ExceptionHandler(UsernameAlreadyExistsException.class)
     public ResponseEntity<String> handleUsernameAlreadyExistsException(UsernameAlreadyExistsException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
-
 
     @ExceptionHandler(GithubUnavailableException.class)
     public ResponseEntity<APIErrorResponse> handleGithubUnavailable(GithubUnavailableException ex, HttpServletRequest request) {
         HttpStatus status;
         String securedMessage;
 
-
         log.error("GithubUnavailableException occurred: {}", ex.getMessage(), ex);
-
 
         if (ex.getCause() instanceof java.net.SocketTimeoutException) {
             status = HttpStatus.GATEWAY_TIMEOUT;
@@ -123,12 +104,9 @@ public class UserGlobalExceptionHandler {
             securedMessage = "An external service error occurred.";
         }
 
-
         String errorSummary = GITHUB_ERROR_SUMMARY;
 
-
         String requestPath = request.getRequestURI();
-
 
         APIErrorResponse errorResponse = new APIErrorResponse(
                 status,
@@ -136,10 +114,7 @@ public class UserGlobalExceptionHandler {
                 securedMessage,
                 requestPath
         );
-
-
         return new ResponseEntity<>(errorResponse, status);
     }
-
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/ExternalGithubServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/ExternalGithubServiceImpl.java
@@ -1,6 +1,7 @@
 package com.itachallenge.user.service;
 
 import com.itachallenge.githubcore.document.enums.GithubUserStatus;
+import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.githubcore.service.GithubApiService;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -17,6 +18,9 @@ public class ExternalGithubServiceImpl implements ExternalGithubService {
     @Override
     public Mono<Boolean> userExists(String username) {
         return githubApiService.userExists(username)
-                .map(status -> status != GithubUserStatus.NOT_FOUND);
+                .map(status -> status != GithubUserStatus.NOT_FOUND)
+                .onErrorMap(throwable ->
+                    new GithubUnavailableException("Error connecting to GitHub API.", throwable)
+                );
     }
 }

--- a/itachallenge-user/src/main/resources/application.yml
+++ b/itachallenge-user/src/main/resources/application.yml
@@ -28,7 +28,7 @@ springdoc:
     path: "/api-docs"
 
 server:
-  port: 8764
+  port: 8765
   tomcat:
     max-http-form-post-size: 2097152
 

--- a/itachallenge-user/src/main/resources/application.yml
+++ b/itachallenge-user/src/main/resources/application.yml
@@ -28,7 +28,7 @@ springdoc:
     path: "/api-docs"
 
 server:
-  port: 8765
+  port: 8764
   tomcat:
     max-http-form-post-size: 2097152
 

--- a/itachallenge-user/src/main/resources/message.properties
+++ b/itachallenge-user/src/main/resources/message.properties
@@ -1,0 +1,30 @@
+# ===============================
+# AdminCreateUserRequestDto Validation Messages
+# ===============================
+adminCreateUser.username.notBlank=The username must not be blank.
+adminCreateUser.username.invalidFormat=The username must follow GitHub username rules (only alphanumeric characters and hyphens, no consecutive hyphens, and cannot start or end with a hyphen).
+adminCreateUser.dto.invalid=The provided admin user data is invalid or incomplete.
+
+# ===============================
+# UserController Path Variables Validation Messages
+# ===============================
+user.githubUsername.invalid=The provided GitHub username is invalid. Please ensure it matches the GitHub username format.
+user.userId.invalid=The provided user ID must be a valid UUID.
+user.challengeId.invalid=The provided challenge ID must be a valid UUID.
+
+# ===============================
+# UserSolutionRequestDto Validation Messages
+# (if you later add validation to it)
+# ===============================
+user.solution.text.notEmpty=The solution text cannot be empty.
+user.solution.languageId.invalid=The language ID must be a valid UUID.
+user.solution.challengeId.invalid=The challenge ID must be a valid UUID.
+user.solution.dto.invalid=The provided user solution data is invalid or incomplete.
+
+# ===============================
+# Generic Validation and DTO Errors
+# ===============================
+validation.dto.invalid=The provided data is invalid or does not meet validation requirements.
+validation.field.required=This field is required.
+validation.uuid.invalid=The provided value must be a valid UUID.
+validation.githubUsername.invalid=The GitHub username provided is not valid.

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
@@ -19,8 +20,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.Set;
 import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 class UserControllerTest {
@@ -41,8 +40,10 @@ class UserControllerTest {
     @BeforeEach
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
+        MessageSource messageSource = mock(MessageSource.class);
+
         webTestClient = WebTestClient.bindToController(userController)
-                .controllerAdvice(new UserGlobalExceptionHandler())
+                .controllerAdvice(new UserGlobalExceptionHandler(messageSource))
                 .build();
     }
 
@@ -567,29 +568,29 @@ class UserControllerTest {
 
         verify(userService, times(1)).getUserBookmarks(userId.toString());
     }
-    
+
     @Test
     @DisplayName("GET /users/{userId}/solutions returns solutions")
     void getAllSolutions_returnsSolutions() {
         String userId = UUID.randomUUID().toString();
-        
+
         UserSolutionResponseDto sol1 = UserSolutionResponseDto.builder()
                 .userId(userId)
                 .challengeId("d43a1a4d-ee8f-432d-8f9c-68eda2547dae")
                 .languageId("409c9fe8-74de-4db3-81a1-a55280cf92ef")
                 .solutionText("This is the submitted solution")
                 .build();
-        
+
         UserSolutionResponseDto sol2 = UserSolutionResponseDto.builder()
                 .userId(userId)
                 .challengeId("b5c06903-f27b-4057-8220-ad9d957cdce4")
                 .languageId("09fabe32-7362-4bfb-ac05-b7bf854c6e0f")
                 .solutionText("This is the submitted solution")
                 .build();
-        
+
         when(userSolutionService.getAllSolutionsByUser(userId))
                 .thenReturn(Flux.just(sol1, sol2));
-        
+
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
                 .exchange()
@@ -597,73 +598,73 @@ class UserControllerTest {
                 .expectBodyList(UserSolutionResponseDto.class)
                 .hasSize(2)
                 .value(list -> {
-                    
+
                     Assertions.assertEquals(sol1.getUserId(), list.get(0).getUserId());
                     Assertions.assertEquals(sol1.getChallengeId(), list.get(0).getChallengeId());
                     Assertions.assertEquals(sol1.getLanguageId(), list.get(0).getLanguageId());
                     Assertions.assertEquals(sol1.getSolutionText(), list.get(0).getSolutionText());
-                    
+
                     Assertions.assertEquals(sol2.getUserId(), list.get(1).getUserId());
                     Assertions.assertEquals(sol2.getChallengeId(), list.get(1).getChallengeId());
                     Assertions.assertEquals(sol2.getLanguageId(), list.get(1).getLanguageId());
                     Assertions.assertEquals(sol2.getSolutionText(), list.get(1).getSolutionText());
                 });
-        
+
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
-    
+
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 404 if no solutions found")
     void getAllSolutions_returns404IfNotFound() {
         String userId = UUID.randomUUID().toString();
-        
+
         // Simulamos que el servicio lanza NotFoundException
         when(userSolutionService.getAllSolutionsByUser(userId))
                 .thenReturn(Flux.error(new NotFoundException("Solutions not found")));
-        
+
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
                 .exchange()
                 .expectStatus().isNotFound()
                 .expectBody(String.class)
                 .isEqualTo("Solutions not found");
-        
+
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
-    
+
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 400 if UUID is invalid")
     void getAllSolutions_returns400IfInvalidUUID() {
         String badUserId = "not-a-uuid";
-        
+
         when(userSolutionService.getAllSolutionsByUser(badUserId))
                 .thenReturn(Flux.error(new BadUUIDException("Bad UUID")));
-        
+
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", badUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody(String.class)
                 .isEqualTo("The provided IDs are not valid.");
-        
+
         verify(userSolutionService, times(1)).getAllSolutionsByUser(badUserId);
     }
-    
+
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 500 on unexpected error")
     void getAllSolutions_returns500IfUnexpectedError() {
         String userId = UUID.randomUUID().toString();
-        
+
         when(userSolutionService.getAllSolutionsByUser(userId))
                 .thenReturn(Flux.error(new RuntimeException("Boom")));
-        
+
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
                 .expectBody(String.class)
                 .isEqualTo("Unexpected error happened.");
-        
+
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -58,10 +58,11 @@ class APIErrorResponseTest {
                 .build();
 
         String json = objectMapper.writeValueAsString(response);
-        assertThat(json).contains("\"status\":404");
-        assertThat(json).contains("\"error\":\"Not Found\"");
-        assertThat(json).contains("\"path\":\"/api/v1/user\"");
-        assertThat(json).doesNotContain("errors");
+        assertThat(json)
+                .contains("\"status\":404")
+                .contains("\"error\":\"Not Found\"")
+                .contains("\"path\":\"/api/v1/user\"")
+                .doesNotContain("errors");
     }
 
     @Test
@@ -78,8 +79,9 @@ class APIErrorResponseTest {
                 .errors(List.of(fieldError))
                 .build();
         String json = objectMapper.writeValueAsString(response);
-        assertThat(json).contains("\"errors\"");
-        assertThat(json).contains("username");
-        assertThat(json).contains("not be empty");
+        assertThat(json)
+                .contains("\"errors\"")
+                .contains("username")
+                .contains("not be empty");
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -1,42 +1,85 @@
 package com.itachallenge.user.dto;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import java.time.Instant;
+import java.util.List;
 
-import org.springframework.http.HttpStatus;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class APIErrorResponseTest {
+    private ObjectMapper objectMapper;
 
-    @Test
-    void testConstructorAndGetters() {
-
-        APIErrorResponse errorResponse = new APIErrorResponse(HttpStatus.NOT_FOUND, "Some error", "Something went wrong", "http://localhost:8762/api/v1/user");
-
-        assertEquals("Some error", errorResponse.getError());
-        assertEquals("Something went wrong", errorResponse.getMessage());
-        assertNotNull(errorResponse.getTimestamp());
-        assertEquals(HttpStatus.NOT_FOUND.value(), errorResponse.getStatus());
-        assertEquals("http://localhost:8762/api/v1/user", errorResponse.getPath());
+    @BeforeEach
+    void setUp(){
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
     @Test
-    void testNoArgsConstructorAndSetters() {
+    void shouldBuildAPIErrorResponse(){
         Instant now = Instant.now();
-        APIErrorResponse errorResponse = new APIErrorResponse();
-        errorResponse.setError("Another error");
-        errorResponse.setMessage("Different message");
-        errorResponse.setTimestamp(now);
-        errorResponse.setStatus(404);
-        errorResponse.setPath("http://localhost:8762/api/v1/user");
+        FieldErrorDto fieldError = new FieldErrorDto("AdminCreateUserRequestDto","username", "must not be empty");
 
-        assertEquals("Another error", errorResponse.getError());
-        assertEquals("Different message", errorResponse.getMessage());
-        assertNotNull(errorResponse.getTimestamp());
-        assertEquals(404, errorResponse.getStatus());
-        assertEquals("http://localhost:8762/api/v1/user", errorResponse.getPath());
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(now)
+                .status(400)
+                .error("Bad Request")
+                .message("Validation failed")
+                .path("api/v1/user")
+                .errors(List.of(fieldError))
+                .build();
+
+        assertThat(response.getTimestamp()).isEqualTo(now);
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getError()).isEqualTo("Bad Request");
+        assertThat(response.getMessage()).isEqualTo("Validation failed");
+        assertThat(response.getPath()).isEqualTo("api/v1/user");
+        assertThat(response.getErrors()).containsExactly(fieldError);
+    }
+
+    @Test
+    void shouldSerializeToJsonWithoutEmptyFields() throws JsonProcessingException {
+        Instant now = Instant.parse("2025-10-15T10:00:00Z");
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(now)
+                .status(404)
+                .error("Not Found")
+                .message("User not found")
+                .path("/api/v1/user")
+                .build();
+
+        String json = objectMapper.writeValueAsString(response);
+        assertThat(json).contains("\"status\":404");
+        assertThat(json).contains("\"error\":\"Not Found\"");
+        assertThat(json).contains("\"path\":\"/api/v1/user\"");
+        assertThat(json).doesNotContain("errors");
+    }
+
+    @Test
+    void shouldIncludeErrorsWhenPresent() throws JsonProcessingException {
+        Instant now = Instant.parse("2025-10-15T10:00:00Z");
+        FieldErrorDto fieldError = new FieldErrorDto("AdminCreateUserRequestDto","username", "must not be empty");
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(now)
+                .status(400)
+                .error("Bad Request")
+                .message("Validation failed")
+                .path("/api/register")
+                .errors(List.of(fieldError))
+                .build();
+        String json = objectMapper.writeValueAsString(response);
+        assertThat(json).contains("\"errors\"");
+        assertThat(json).contains("username");
+        assertThat(json).contains("not be empty");
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -4,18 +4,23 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
+import org.springframework.http.HttpStatus;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class APIErrorResponseTest {
 
     @Test
     void testConstructorAndGetters() {
-        Instant now = Instant.now();
-        APIErrorResponse errorResponse = new APIErrorResponse("Some error", "Something went wrong", now);
+
+        APIErrorResponse errorResponse = new APIErrorResponse(HttpStatus.NOT_FOUND, "Some error", "Something went wrong", "http://localhost:8762/api/v1/user");
 
         assertEquals("Some error", errorResponse.getError());
         assertEquals("Something went wrong", errorResponse.getMessage());
-        assertEquals(now, errorResponse.getTimestamp());
+        assertNotNull(errorResponse.getTimestamp());
+        assertEquals(HttpStatus.NOT_FOUND.value(), errorResponse.getStatus());
+        assertEquals("http://localhost:8762/api/v1/user", errorResponse.getPath());
     }
 
     @Test
@@ -25,9 +30,13 @@ class APIErrorResponseTest {
         errorResponse.setError("Another error");
         errorResponse.setMessage("Different message");
         errorResponse.setTimestamp(now);
+        errorResponse.setStatus(404);
+        errorResponse.setPath("http://localhost:8762/api/v1/user");
 
         assertEquals("Another error", errorResponse.getError());
         assertEquals("Different message", errorResponse.getMessage());
-        assertEquals(now, errorResponse.getTimestamp());
+        assertNotNull(errorResponse.getTimestamp());
+        assertEquals(404, errorResponse.getStatus());
+        assertEquals("http://localhost:8762/api/v1/user", errorResponse.getPath());
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/FieldErrorDtoTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/FieldErrorDtoTest.java
@@ -1,0 +1,53 @@
+package com.itachallenge.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FieldErrorDtoTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+    }
+
+    @Test
+    @DisplayName("Serializes a fully populated FieldErrorDto correctly using builder")
+    void shouldSerializeFullyPopulatedDto() throws Exception {
+        FieldErrorDto dto = FieldErrorDto.builder()
+                .objectName("challengeDto")
+                .field("title")
+                .message("The title cannot be empty")
+                .build();
+
+        String json = objectMapper.writeValueAsString(dto);
+
+        assertThat(json).contains("\"objectName\":\"challengeDto\"")
+                .contains("\"field\":\"title\"")
+                .contains("\"message\":\"The title cannot be empty\"")
+                .startsWith("{").endsWith("}");
+    }
+
+    @Test
+    @DisplayName("Does not serialize null fields when using @JsonInclude.NON_EMPTY with builder")
+    void shouldOmitNullFieldsInJson() throws Exception {
+        FieldErrorDto dto = FieldErrorDto.builder()
+                .field("difficulty")
+                .build();  // objectName and message are null
+
+        String json = objectMapper.writeValueAsString(dto);
+
+        assertThat(json).contains("\"field\":\"difficulty\"")
+                .doesNotContain("objectName")
+                .doesNotContain("message");
+    }
+
+}

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -16,12 +16,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.web.server.ServerWebExchange;
-import java.util.List;
 import java.util.Objects;
 
 class UserGlobalExceptionHandlerTest {

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -100,7 +100,6 @@ class UserGlobalExceptionHandlerTest {
         assertEquals("Resource not found", response.getBody());
     }
 
-
     @Test
     void testHandleUnmodifiableSolutionException(){
         String message = "There's an existing solution with status 'ENDED'.";

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -1,46 +1,46 @@
 package com.itachallenge.user.exception;
 
-import static com.itachallenge.user.exception.UserGlobalExceptionHandler.GITHUB_ERROR_SUMMARY;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import jakarta.validation.ConstraintViolationException;
-import java.net.ConnectException;
-import java.net.SocketTimeoutException;
+import org.springframework.web.server.ServerWebExchange;
+import java.util.List;
 import java.util.Objects;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 class UserGlobalExceptionHandlerTest {
 
-    @InjectMocks
     private UserGlobalExceptionHandler exceptionHandler;
-
-    @Mock
-    private HttpServletRequest mockRequest;
+    private ServerWebExchange exchange;
+    private MockServerHttpRequest request;
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
-        exceptionHandler = new UserGlobalExceptionHandler();
+        MessageSource messageSource = mock(MessageSource.class);
+        exceptionHandler = new UserGlobalExceptionHandler(messageSource);
+
     }
 
     @Test
     void testHandleAny() {
         Exception exception = new Exception("Unexpected Error");
         ResponseEntity<String> response = exceptionHandler.handleAny(exception);
-
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertTrue(Objects.requireNonNull(response.getBody()).contains("Unexpected error happened."));
@@ -101,91 +101,148 @@ class UserGlobalExceptionHandlerTest {
     }
 
     @Test
-    void testHandleUnmodifiableSolutionException(){
-        String message = "There's an existing solution with status 'ENDED'.";
-        UnmodificableSolutionException exception = new UnmodificableSolutionException(message);
-        ResponseEntity<String> response = exceptionHandler.handleUnmodifiableSolutionException(exception);
+    void testHandleUnmodifiableSolutionException() {
+        UnmodificableSolutionException exception = new UnmodificableSolutionException("There's an existing solution with status 'ENDED'.");
+
+        request = MockServerHttpRequest.get("/test-path").build();
+        exchange = MockServerWebExchange.from(request);
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleUnmodifiableSolutionException(exception, exchange);
 
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
-        assertEquals(message, response.getBody());
+        assertEquals("There's an existing solution with status 'ENDED'.", response.getBody().getMessage());
+        assertEquals("There's an existing solution with status 'ENDED'.", response.getBody().getError());
+        assertEquals("/test-path", response.getBody().getPath());
+        assertNotNull(response.getBody().getTimestamp());
     }
+
 
     @Test
     void testHandleUsernameAlreadyExistsException() {
-        String username = "alfonso79";
-        UsernameAlreadyExistsException exception = new UsernameAlreadyExistsException(username);
-        ResponseEntity<String> response = exceptionHandler.handleUsernameAlreadyExistsException(exception);
+        UsernameAlreadyExistsException exception = new UsernameAlreadyExistsException("testuser");
+
+        request = MockServerHttpRequest.get("/test-path").build();
+        exchange = MockServerWebExchange.from(request);
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleUsernameAlreadyExistsException(exception, exchange);
+
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
-        assertEquals("The username 'alfonso79' is already registered.", response.getBody());
+        assertEquals("The username already exists", response.getBody().getMessage());
+        assertEquals("The username already exists", response.getBody().getError());
+        assertEquals("/test-path", response.getBody().getPath());
+        assertNotNull(response.getBody().getTimestamp());
     }
 
     @Test
+    void testHandleMethodArgumentNotValidException() {
+        BindingResult bindingResult = mock(BindingResult.class);
+        org.springframework.core.MethodParameter methodParameter = mock(org.springframework.core.MethodParameter.class);
+
+        java.lang.reflect.Method realMethod;
+        try {
+            realMethod = UserGlobalExceptionHandlerTest.class.getDeclaredMethod("testHandleMethodArgumentNotValidException");
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        when(methodParameter.getExecutable()).thenReturn(realMethod);
+        when(methodParameter.getParameterIndex()).thenReturn(0);
+
+        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(methodParameter, bindingResult);
+
+        request = MockServerHttpRequest.get("/test-path").build();
+        exchange = MockServerWebExchange.from(request);
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleMethodArgumentNotValidException(exception, exchange);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getBody().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST.getReasonPhrase(), response.getBody().getError());
+        assertEquals("/test-path", response.getBody().getPath());
+        assertNotNull(response.getBody().getTimestamp());
+        assertNotNull(response.getBody().getMessage());
+    }
+
+    @Test
+    void testHandleInternalServerErrorException() {
+        InternalServerErrorException exception = new InternalServerErrorException("Unexpected internal error");
+
+        request = MockServerHttpRequest.get("/test-path").build();
+        exchange = MockServerWebExchange.from(request);
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleInternalServerErrorException(exception, exchange);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getBody().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), response.getBody().getError());
+        assertEquals("Unexpected internal error", response.getBody().getMessage());
+        assertEquals("/test-path", response.getBody().getPath());
+        assertNotNull(response.getBody().getTimestamp());
+    }
+
+
+    @Test
     void handleGithubUnavailable_shouldReturn503() {
-        String expectedPath = "/api/v1/user/enroll";
-        Throwable connectCause = new ConnectException("Connection refused");
+        String expectedPath = "/itachallenge/api/v1/user/users/testbUser";
+        Throwable connectCause = new java.net.ConnectException("Connection refused");
         GithubUnavailableException ex = new GithubUnavailableException("Service error ocurred.", connectCause);
 
-        when(mockRequest.getRequestURI()).thenReturn(expectedPath);
+        request = MockServerHttpRequest.get(expectedPath).build();
+        exchange = MockServerWebExchange.from(request);
 
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, mockRequest);
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, exchange);
+
         APIErrorResponse responseBody = Objects.requireNonNull(response.getBody());
 
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode(),
-                "The handler must return HTTP 503 for a ConnectException cause.");
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), responseBody.getStatus(),
-                "DTO status field must match HTTP 503.");
-        assertEquals(GITHUB_ERROR_SUMMARY, responseBody.getError(),
-                "DTO error field must be the defined constant..");
-        assertEquals(expectedPath, responseBody.getPath(),
-                "DTO path field must match the request URI.");
-        assertTrue(responseBody.getMessage().contains("unavailable"),
-                "The secured message should indicate service unavailability.");
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), responseBody.getStatus()); // 503
+        assertEquals(UserGlobalExceptionHandler.GITHUB_ERROR_SUMMARY, responseBody.getError());
+        assertEquals("The external GitHub service is currently unavailable.", responseBody.getMessage());
+        assertEquals(expectedPath, responseBody.getPath());
+        assertNotNull(responseBody.getTimestamp());
     }
 
     @Test
     void handleGithubUnavailable_shouldReturn504() {
-        String expectedPath = "/api/v1/user/test-github";
-        Throwable timeoutCause = new SocketTimeoutException("Read timed out");
+        String expectedPath = "/itachallenge/api/v1/user/users/testUser";
+        Throwable timeoutCause = new java.net.SocketTimeoutException("Read timed out");
         GithubUnavailableException ex = new GithubUnavailableException("Service error ocurred.", timeoutCause);
 
-        when(mockRequest.getRequestURI()).thenReturn(expectedPath);
+        request = MockServerHttpRequest.get(expectedPath).build();
+        exchange = MockServerWebExchange.from(request);
 
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, mockRequest);
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, exchange);
+
         APIErrorResponse responseBody = Objects.requireNonNull(response.getBody());
 
-        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode(),
-                "The handler must return HTTP 504 for a SocketTimeoutException cause.");
-        assertEquals(HttpStatus.GATEWAY_TIMEOUT.value(), responseBody.getStatus(),
-                "DTO status field must match HTTP 504.");
-        assertEquals(GITHUB_ERROR_SUMMARY, responseBody.getError(),
-                "DTO error field must be the defined constant.");
-        assertEquals(expectedPath, responseBody.getPath(),
-                "DTO path field must match the request URI.");
-        assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("timed out"),
-                "The secured message should indicate a timeout.");
+        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode());
+        assertEquals(HttpStatus.GATEWAY_TIMEOUT.value(), responseBody.getStatus());
+        assertEquals(UserGlobalExceptionHandler.GITHUB_ERROR_SUMMARY, responseBody.getError());
+        assertEquals("The external GitHub service timed out.", responseBody.getMessage());
+        assertEquals(expectedPath, responseBody.getPath());
+        assertNotNull(responseBody.getTimestamp());
     }
 
     @Test
-    void handleGithubUnavailable_shouldReturn503ForOtherCauses() {
-        String expectedPath = "/api/v1/user/profile";
+    void handleGithubUnavailable_shouldReturn503_onOtherCauses() {
+        String expectedPath = "/itachallenge/api/v1/user/users/anyGithubUser";
         GithubUnavailableException ex = new GithubUnavailableException("Unknown error.");
 
-        when(mockRequest.getRequestURI()).thenReturn(expectedPath);
+        request = MockServerHttpRequest.get(expectedPath).build();
+        exchange = MockServerWebExchange.from(request);
 
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, mockRequest);
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, exchange);
+
         APIErrorResponse responseBody = Objects.requireNonNull(response.getBody());
 
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode(),
-                "The handler must return HTTP 503 for other types of causes (not recognized or null).");
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), responseBody.getStatus(),
-                "DTO status field must match HTTP 503.");
-        assertEquals(GITHUB_ERROR_SUMMARY, responseBody.getError(),
-                "DTO error field must be the defined constant.");
-        assertEquals(expectedPath, responseBody.getPath(),
-                "DTO path field must match the request URI.");
-        assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("external service error"),
-                "The secured message should indicate an external service error.");
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), responseBody.getStatus());
+        assertEquals(UserGlobalExceptionHandler.GITHUB_ERROR_SUMMARY, responseBody.getError());
+        assertEquals("An external service error occurred.", responseBody.getMessage());
+        assertEquals(expectedPath, responseBody.getPath());
+        assertNotNull(responseBody.getTimestamp());
     }
 
 }
-

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -1,13 +1,10 @@
 package com.itachallenge.user.exception;
 
-
 import static com.itachallenge.user.exception.UserGlobalExceptionHandler.GITHUB_ERROR_SUMMARY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,36 +15,26 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-
-
 import jakarta.validation.ConstraintViolationException;
-
-
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.util.Objects;
 
-
 import jakarta.servlet.http.HttpServletRequest;
 
-
 class UserGlobalExceptionHandlerTest {
-
 
     @InjectMocks
     private UserGlobalExceptionHandler exceptionHandler;
 
-
     @Mock
     private HttpServletRequest mockRequest;
-
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
         exceptionHandler = new UserGlobalExceptionHandler();
     }
-
 
     @Test
     void testHandleAny() {
@@ -59,67 +46,55 @@ class UserGlobalExceptionHandlerTest {
         assertTrue(Objects.requireNonNull(response.getBody()).contains("Unexpected error happened."));
     }
 
-
     @Test
     void testHandleIllegalArgument() {
         IllegalArgumentException exception = new IllegalArgumentException("Invalid argument");
         ResponseEntity<String> response = exceptionHandler.handleIllegalArgument(exception);
 
-
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertEquals("Invalid argument", response.getBody());
     }
-
 
     @Test
     void testHandleValidationExceptions() {
         ConstraintViolationException exception = new ConstraintViolationException("Validation failed", null);
         ResponseEntity<String> response = exceptionHandler.handleValidationExceptions(exception);
 
-
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals("Validation failed", response.getBody());
     }
-
 
     @Test
     void testHandleTypeMismatchException() {
         MethodArgumentTypeMismatchException exception = mock(MethodArgumentTypeMismatchException.class);
         ResponseEntity<String> response = exceptionHandler.handleTypeMismatchException(exception);
 
-
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals("Invalid parameter format.", response.getBody());
     }
-
 
     @Test
     void testHandleBadRequestException() {
         BadRequestException exception = new BadRequestException("Bad request error");
         ResponseEntity<String> response = exceptionHandler.handleBadRequestException(exception);
 
-
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals("Bad request error", response.getBody());
     }
-
 
     @Test
     void testHandleDatabaseException() {
         DatabaseException exception = new DatabaseException("Database connection failed");
         ResponseEntity<String> response = exceptionHandler.handleDatabaseException(exception);
 
-
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertEquals("Database error: Database connection failed", response.getBody());
     }
-
 
     @Test
     void testHandleNotFoundException() {
         NotFoundException exception = new NotFoundException("Resource not found");
         ResponseEntity<String> response = exceptionHandler.handleNotFoundException(exception);
-
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertEquals("Resource not found", response.getBody());
@@ -132,25 +107,18 @@ class UserGlobalExceptionHandlerTest {
         UnmodificableSolutionException exception = new UnmodificableSolutionException(message);
         ResponseEntity<String> response = exceptionHandler.handleUnmodifiableSolutionException(exception);
 
-
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
         assertEquals(message, response.getBody());
     }
-
 
     @Test
     void testHandleUsernameAlreadyExistsException() {
         String username = "alfonso79";
         UsernameAlreadyExistsException exception = new UsernameAlreadyExistsException(username);
         ResponseEntity<String> response = exceptionHandler.handleUsernameAlreadyExistsException(exception);
-
-
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
         assertEquals("The username 'alfonso79' is already registered.", response.getBody());
     }
-
-
-
 
     @Test
     void handleGithubUnavailable_shouldReturn503() {
@@ -158,13 +126,10 @@ class UserGlobalExceptionHandlerTest {
         Throwable connectCause = new ConnectException("Connection refused");
         GithubUnavailableException ex = new GithubUnavailableException("Service error ocurred.", connectCause);
 
-
         when(mockRequest.getRequestURI()).thenReturn(expectedPath);
-
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, mockRequest);
         APIErrorResponse responseBody = Objects.requireNonNull(response.getBody());
-
 
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode(),
                 "The handler must return HTTP 503 for a ConnectException cause.");
@@ -178,20 +143,16 @@ class UserGlobalExceptionHandlerTest {
                 "The secured message should indicate service unavailability.");
     }
 
-
     @Test
     void handleGithubUnavailable_shouldReturn504() {
         String expectedPath = "/api/v1/user/test-github";
         Throwable timeoutCause = new SocketTimeoutException("Read timed out");
         GithubUnavailableException ex = new GithubUnavailableException("Service error ocurred.", timeoutCause);
 
-
         when(mockRequest.getRequestURI()).thenReturn(expectedPath);
-
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, mockRequest);
         APIErrorResponse responseBody = Objects.requireNonNull(response.getBody());
-
 
         assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode(),
                 "The handler must return HTTP 504 for a SocketTimeoutException cause.");
@@ -205,19 +166,15 @@ class UserGlobalExceptionHandlerTest {
                 "The secured message should indicate a timeout.");
     }
 
-
     @Test
     void handleGithubUnavailable_shouldReturn503ForOtherCauses() {
         String expectedPath = "/api/v1/user/profile";
         GithubUnavailableException ex = new GithubUnavailableException("Unknown error.");
 
-
         when(mockRequest.getRequestURI()).thenReturn(expectedPath);
-
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, mockRequest);
         APIErrorResponse responseBody = Objects.requireNonNull(response.getBody());
-
 
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode(),
                 "The handler must return HTTP 503 for other types of causes (not recognized or null).");
@@ -230,7 +187,6 @@ class UserGlobalExceptionHandlerTest {
         assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("external service error"),
                 "The secured message should indicate an external service error.");
     }
-
 
 }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -1,94 +1,129 @@
 package com.itachallenge.user.exception;
 
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+
 import jakarta.validation.ConstraintViolationException;
+
 
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.util.Objects;
 
+
+import jakarta.servlet.http.HttpServletRequest;
+
+
 class UserGlobalExceptionHandlerTest {
 
+
+    @InjectMocks
     private UserGlobalExceptionHandler exceptionHandler;
+
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
 
     @BeforeEach
     void setUp() {
+        MockitoAnnotations.openMocks(this);
         exceptionHandler = new UserGlobalExceptionHandler();
     }
+
 
     @Test
     void testHandleAny() {
         Exception exception = new Exception("Unexpected Error");
         ResponseEntity<String> response = exceptionHandler.handleAny(exception);
 
+
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertTrue(Objects.requireNonNull(response.getBody()).contains("Unexpected error happened."));
     }
+
 
     @Test
     void testHandleIllegalArgument() {
         IllegalArgumentException exception = new IllegalArgumentException("Invalid argument");
         ResponseEntity<String> response = exceptionHandler.handleIllegalArgument(exception);
 
+
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertEquals("Invalid argument", response.getBody());
     }
+
 
     @Test
     void testHandleValidationExceptions() {
         ConstraintViolationException exception = new ConstraintViolationException("Validation failed", null);
         ResponseEntity<String> response = exceptionHandler.handleValidationExceptions(exception);
 
+
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals("Validation failed", response.getBody());
     }
+
 
     @Test
     void testHandleTypeMismatchException() {
         MethodArgumentTypeMismatchException exception = mock(MethodArgumentTypeMismatchException.class);
         ResponseEntity<String> response = exceptionHandler.handleTypeMismatchException(exception);
 
+
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals("Invalid parameter format.", response.getBody());
     }
+
 
     @Test
     void testHandleBadRequestException() {
         BadRequestException exception = new BadRequestException("Bad request error");
         ResponseEntity<String> response = exceptionHandler.handleBadRequestException(exception);
 
+
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals("Bad request error", response.getBody());
     }
+
 
     @Test
     void testHandleDatabaseException() {
         DatabaseException exception = new DatabaseException("Database connection failed");
         ResponseEntity<String> response = exceptionHandler.handleDatabaseException(exception);
 
+
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertEquals("Database error: Database connection failed", response.getBody());
     }
+
 
     @Test
     void testHandleNotFoundException() {
         NotFoundException exception = new NotFoundException("Resource not found");
         ResponseEntity<String> response = exceptionHandler.handleNotFoundException(exception);
 
+
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertEquals("Resource not found", response.getBody());
     }
+
 
     @Test
     void testHandleUnmodifiableSolutionException(){
@@ -96,9 +131,11 @@ class UserGlobalExceptionHandlerTest {
         UnmodificableSolutionException exception = new UnmodificableSolutionException(message);
         ResponseEntity<String> response = exceptionHandler.handleUnmodifiableSolutionException(exception);
 
+
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
         assertEquals(message, response.getBody());
     }
+
 
     @Test
     void testHandleUsernameAlreadyExistsException() {
@@ -106,48 +143,93 @@ class UserGlobalExceptionHandlerTest {
         UsernameAlreadyExistsException exception = new UsernameAlreadyExistsException(username);
         ResponseEntity<String> response = exceptionHandler.handleUsernameAlreadyExistsException(exception);
 
+
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
         assertEquals("The username 'alfonso79' is already registered.", response.getBody());
     }
 
 
+
+
     @Test
     void handleGithubUnavailable_shouldReturn503() {
+        String expectedPath = "/api/v1/user/enroll";
         Throwable connectCause = new ConnectException("Connection refused");
         GithubUnavailableException ex = new GithubUnavailableException("Service error ocurred.", connectCause);
 
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
+
+        when(mockRequest.getRequestURI()).thenReturn(expectedPath);
+
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, mockRequest);
+        APIErrorResponse responseBody = Objects.requireNonNull(response.getBody());
+
 
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode(),
                 "The handler must return HTTP 503 for a ConnectException cause.");
-        assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("unavailable"),
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), responseBody.getStatus(),
+                "DTO status field must match HTTP 503.");
+        assertEquals("GitHub API error", responseBody.getError(),
+                "DTO error field must be 'GitHub API error'.");
+        assertEquals(expectedPath, responseBody.getPath(),
+                "DTO path field must match the request URI.");
+        assertTrue(responseBody.getMessage().contains("unavailable"),
                 "The secured message should indicate service unavailability.");
     }
 
+
     @Test
     void handleGithubUnavailable_shouldReturn504() {
+        String expectedPath = "/api/v1/user/test-github";
         Throwable timeoutCause = new SocketTimeoutException("Read timed out");
         GithubUnavailableException ex = new GithubUnavailableException("Service error ocurred.", timeoutCause);
 
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
+
+        when(mockRequest.getRequestURI()).thenReturn(expectedPath);
+
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, mockRequest);
+        APIErrorResponse responseBody = Objects.requireNonNull(response.getBody());
+
 
         assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode(),
-        "The handler must return HTTP 504 for a SocketTimeoutException cause.");
+                "The handler must return HTTP 504 for a SocketTimeoutException cause.");
+        assertEquals(HttpStatus.GATEWAY_TIMEOUT.value(), responseBody.getStatus(),
+                "DTO status field must match HTTP 504.");
+        assertEquals("GitHub API error", responseBody.getError(),
+                "DTO error field must be 'GitHub API error'.");
+        assertEquals(expectedPath, responseBody.getPath(),
+                "DTO path field must match the request URI.");
         assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("timed out"),
                 "The secured message should indicate a timeout.");
     }
 
+
     @Test
     void handleGithubUnavailable_shouldReturn503ForOtherCauses() {
+        String expectedPath = "/api/v1/user/profile";
         GithubUnavailableException ex = new GithubUnavailableException("Unknown error.");
 
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
+
+        when(mockRequest.getRequestURI()).thenReturn(expectedPath);
+
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex, mockRequest);
+        APIErrorResponse responseBody = Objects.requireNonNull(response.getBody());
+
 
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode(),
                 "The handler must return HTTP 503 for other types of causes (not recognized or null).");
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), responseBody.getStatus(),
+                "DTO status field must match HTTP 503.");
+        assertEquals("GitHub API error", responseBody.getError(),
+                "DTO error field must be 'GitHub API error'.");
+        assertEquals(expectedPath, responseBody.getPath(),
+                "DTO path field must match the request URI.");
         assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("external service error"),
                 "The secured message should indicate an external service error.");
     }
+
 
 }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -1,6 +1,7 @@
 package com.itachallenge.user.exception;
 
 
+import static com.itachallenge.user.exception.UserGlobalExceptionHandler.GITHUB_ERROR_SUMMARY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -169,8 +170,8 @@ class UserGlobalExceptionHandlerTest {
                 "The handler must return HTTP 503 for a ConnectException cause.");
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), responseBody.getStatus(),
                 "DTO status field must match HTTP 503.");
-        assertEquals("GitHub API error", responseBody.getError(),
-                "DTO error field must be 'GitHub API error'.");
+        assertEquals(GITHUB_ERROR_SUMMARY, responseBody.getError(),
+                "DTO error field must be the defined constant..");
         assertEquals(expectedPath, responseBody.getPath(),
                 "DTO path field must match the request URI.");
         assertTrue(responseBody.getMessage().contains("unavailable"),
@@ -196,8 +197,8 @@ class UserGlobalExceptionHandlerTest {
                 "The handler must return HTTP 504 for a SocketTimeoutException cause.");
         assertEquals(HttpStatus.GATEWAY_TIMEOUT.value(), responseBody.getStatus(),
                 "DTO status field must match HTTP 504.");
-        assertEquals("GitHub API error", responseBody.getError(),
-                "DTO error field must be 'GitHub API error'.");
+        assertEquals(GITHUB_ERROR_SUMMARY, responseBody.getError(),
+                "DTO error field must be the defined constant.");
         assertEquals(expectedPath, responseBody.getPath(),
                 "DTO path field must match the request URI.");
         assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("timed out"),
@@ -222,8 +223,8 @@ class UserGlobalExceptionHandlerTest {
                 "The handler must return HTTP 503 for other types of causes (not recognized or null).");
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), responseBody.getStatus(),
                 "DTO status field must match HTTP 503.");
-        assertEquals("GitHub API error", responseBody.getError(),
-                "DTO error field must be 'GitHub API error'.");
+        assertEquals(GITHUB_ERROR_SUMMARY, responseBody.getError(),
+                "DTO error field must be the defined constant.");
         assertEquals(expectedPath, responseBody.getPath(),
                 "DTO path field must match the request URI.");
         assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("external service error"),

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -14,6 +14,8 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import jakarta.validation.ConstraintViolationException;
 
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.util.Objects;
 
 class UserGlobalExceptionHandlerTest {
@@ -111,22 +113,40 @@ class UserGlobalExceptionHandlerTest {
 
     @Test
     void handleGithubUnavailable_shouldReturn503() {
-        GithubUnavailableException ex = new GithubUnavailableException("Some 5xx error");
+        Throwable connectCause = new ConnectException("Connection refused");
+        GithubUnavailableException ex = new GithubUnavailableException("Service error ocurred.", connectCause);
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
 
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
-        assertEquals("GitHub API error", response.getBody().getError());
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode(),
+                "The handler must return HTTP 503 for a ConnectException cause.");
+        assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("unavailable"),
+                "The secured message should indicate service unavailability.");
     }
 
     @Test
     void handleGithubUnavailable_shouldReturn504() {
-        GithubUnavailableException ex = new GithubUnavailableException("timeout");
+        Throwable timeoutCause = new SocketTimeoutException("Read timed out");
+        GithubUnavailableException ex = new GithubUnavailableException("Service error ocurred.", timeoutCause);
 
         ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
 
-        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode());
-        assertEquals("GitHub API error", response.getBody().getError());
+        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode(),
+        "The handler must return HTTP 504 for a SocketTimeoutException cause.");
+        assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("timed out"),
+                "The secured message should indicate a timeout.");
+    }
+
+    @Test
+    void handleGithubUnavailable_shouldReturn503ForOtherCauses() {
+        GithubUnavailableException ex = new GithubUnavailableException("Unknown error.");
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode(),
+                "The handler must return HTTP 503 for other types of causes (not recognized or null).");
+        assertTrue(Objects.requireNonNull(response.getBody()).getMessage().contains("external service error"),
+                "The secured message should indicate an external service error.");
     }
 
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/ExternalGithubServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/ExternalGithubServiceImplTest.java
@@ -47,15 +47,18 @@ class ExternalGithubServiceImplTest {
     }
 
     @Test
-    @DisplayName("Should propagate error when GitHub API fails")
+    @DisplayName("Should wrap API errors in GithubUnavailableException, preserving the cause")
     void testUserExistsPropagatesError() {
+        RuntimeException originalLowLevelError = new RuntimeException("Original low-level API error.");
+
         when(githubApiService.userExists(anyString()))
-                .thenReturn(Mono.error(new GithubUnavailableException("GitHub API down")));
+                .thenReturn(Mono.error(originalLowLevelError));
 
         StepVerifier.create(externalGithubService.userExists("anyUser"))
                 .expectErrorMatches(throwable ->
                         throwable instanceof GithubUnavailableException &&
-                                throwable.getMessage().equals("GitHub API down"))
+                                throwable.getCause() == originalLowLevelError &&
+                                throwable.getMessage().equals("Error connecting to GitHub API."))
                 .verify();
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/ExternalGithubServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/ExternalGithubServiceImplTest.java
@@ -50,7 +50,6 @@ class ExternalGithubServiceImplTest {
     @DisplayName("Should wrap API errors in GithubUnavailableException, preserving the cause")
     void testUserExistsPropagatesError() {
         RuntimeException originalLowLevelError = new RuntimeException("Original low-level API error.");
-
         when(githubApiService.userExists(anyString()))
                 .thenReturn(Mono.error(originalLowLevelError));
 


### PR DESCRIPTION
**Summary**
This PR finalizes the implementation of the GithubUnavailableException handler, successfully integrating the existing robust 503/504 error logic ( task [#744](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/991)) with the new service-wide API error standardization (User Story [#786](https://tree.taiga.io/project/luisvi-ita-challenges/us/786)).
This ensures the error response is consistent across the service, secure, and utilizes the required reactive WebFlux architecture.

**Checklist Alignment**
This implementation completes the required handler update for the Github feature within the scope of the User Story [#786](https://tree.taiga.io/project/luisvi-ita-challenges/us/786) (Modify GlobalExceptionHandler to harmonize with Challenge APIErrorResponse). 

**Context & Changes**
This work combines existing robust error logic (from task [#744](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/991)) with the new service architecture (introduced in [#787](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1005), [#788](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1009), [#789](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1006) and [#790](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1007)):
- **Logic Preservation:** The resilient logic to determine between HTTP 503 (Service Unavailable) and HTTP 504 (Gateway Timeout) based on the internal exception cause is fully preserved and integrated.
- **Architecture Update:** The handleGithubUnavailable method signature is updated to the required reactive WebFlux style, utilizing ServerWebExchange.
- **DTO Compliance:** The response is correctly built using the new, standardized APIErrorResponse DTO builder, ensuring all required fields (status, path, error, message) are populated.

**Scope Clarification**
Reviewers should note that this implementation was achieved by merging the existing code from the obsoleted task [#766](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/992) with the new format established in User Story [#786](https://tree.taiga.io/project/luisvi-ita-challenges/us/786) ). The files modified by the author for this feature are limited to:
- UserGlobalExceptionHandler.java (handleGithubUnavailable (GithubUnavailableException ex) refactoring)
- UserGlobalExceptionHandlerTest.java (Tests update)
- UserControllerTest.java
- README.md
- CHANGELOG.md
- env.CI.dev

**CHANGELOG.md**
The CHANGELOG.md file has been updated with the following entry:
[Changed] Standardized Error Handler: The GithubUnavailableException handler is updated to use the final standardized APIErrorResponse DTO and the reactive WebFlux architecture. (Taiga [#791], PR [1008])

**SemVer**
The JSON response body structure for GitHub connection errors has changed to the new standardized format (APIErrorResponse). This is considered a Minor release (minor increment) due to the change in the public response body structure.

**How to Test**
Run Unit Tests: Execute the unit test suite for the user microservice, specifically verifying UserGlobalExceptionHandlerTest.java.
Confirm the test methods mock the ServerWebExchange.
Assert that the returned APIErrorResponse contains the correct status (503/504) and all five standardized fields.
Local Integration Test: Trigger an external GitHub connection error (simulating a timeout/service failure) and verify the JSON response body contains the new standardized format.

PR Author Self-check
✅ I tested my changes locally and verified they work as expected (All unit tests passed).
✅ The PR has a clear and focused purpose.
✅ Title, description, and changelog are filled in correctly, noting the Minor SemVer change.
✅ There are no leftover merge conflicts or unrelated changes.
✅ All automated checks (like SonarCloud) have passed.
      I responded to all previous review comments and only resolved those I truly addressed.
✅I ran SonarLint locally on the modified files and confirmed there are no warnings or errors.