### PR TITLE
PR 2.2/2 - refactor(user) - 4 user exception handlers (#788)

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -3,6 +3,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 import java.util.List;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/APIErrorResponse.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @AllArgsConstructor
+@NoArgsConstructor(force = true)
 @Getter
 @Builder
 public class APIErrorResponse {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/AdminCreateUserRequestDto.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/AdminCreateUserRequestDto.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Setter
 public class AdminCreateUserRequestDto {
 
-    @NotBlank(message = "Username must not be blank")
+    @NotBlank(message = "{adminCreateUser.username.notBlank}")
     private String username;
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/FieldErrorDto.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/FieldErrorDto.java
@@ -1,21 +1,16 @@
 package com.itachallenge.user.dto;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.Instant;
-import java.util.List;
-
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+@Builder
 @AllArgsConstructor
 @Getter
-@Builder
-public class APIErrorResponse {
-    private final Instant timestamp;
-    private final int status;
-    private final String error;
+public class FieldErrorDto {
+    private final String objectName;
+    private final String field;
     private final String message;
-    private final String path;
-    private final List<FieldErrorDto> errors;
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/UserSolutionRequestDto.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/UserSolutionRequestDto.java
@@ -15,22 +15,22 @@ import org.springframework.stereotype.Component;
 public class UserSolutionRequestDto {
 
     @JsonProperty(value ="uuid_user")
-    @GenericUUIDValid(message = "Invalid UUID")
+    @GenericUUIDValid(message = "{validation.uuid.invalid}")
     private String userId;
 
     @JsonProperty(value ="uuid_challenge")
-    @GenericUUIDValid(message = "Invalid UUID")
+    @GenericUUIDValid(message = "{user.solution.challengeId.invalid}")
     private String challengeId;
 
     @JsonProperty(value ="uuid_language")
-    @GenericUUIDValid(message = "Invalid UUID")
+    @GenericUUIDValid(message = "{user.solution.languageId.invalid}")
     private String languageId;
 
     @JsonProperty(value ="status")
     private String status;
 
     @JsonProperty(value ="solution_text")
-    @NotBlank(message = "Solution text is required")
+    @NotBlank(message = "{user.solution.text.notEmpty}")
     private String solutionText;
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -66,9 +66,20 @@ public class UserGlobalExceptionHandler {
 
 
     @ExceptionHandler(BadUUIDException.class)
-    public ResponseEntity<String> handleBadUUIDException(BadUUIDException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("The provided IDs are not valid.");
+    public ResponseEntity<APIErrorResponse> handleBadUUIDException(BadUUIDException e, ServerWebExchange exchange) {
+        log.error("Bad UUID: {}", e.getMessage(), e);
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(Instant.now())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .error("Bad Request")
+                .message("The provided IDs are not valid.")
+                .path(exchange.getRequest().getPath().value())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
+
 
     @ExceptionHandler(DatabaseException.class)
     public ResponseEntity<APIErrorResponse> handleDatabaseException(DatabaseException e, ServerWebExchange exchange) {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -99,7 +99,6 @@ public class UserGlobalExceptionHandler {
                 .message(e.getMessage())
                 .path(exchange.getRequest().getPath().value())
                 .build();
-
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -63,6 +63,8 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
+
+
     @ExceptionHandler(BadUUIDException.class)
     public ResponseEntity<String> handleBadUUIDException(BadUUIDException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("The provided IDs are not valid.");
@@ -97,6 +99,7 @@ public class UserGlobalExceptionHandler {
                 .message(e.getMessage())
                 .path(exchange.getRequest().getPath().value())
                 .build();
+
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -48,9 +48,19 @@ public class UserGlobalExceptionHandler {
     }
 
     @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<String> handleBadRequestException(BadRequestException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    public ResponseEntity<APIErrorResponse> handleBadRequestException(BadRequestException e) {
+        log.error("Bad Request: {}", e.getMessage(), e);
+
+        APIErrorResponse errorResponse = APIErrorResponse.builder()
+                .timestamp(Instant.now())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .error("Bad Request")
+                .message(e.getMessage())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
+
 
     @ExceptionHandler(BadUUIDException.class)
     public ResponseEntity<String> handleBadUUIDException(BadUUIDException e) {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -70,9 +70,20 @@ public class UserGlobalExceptionHandler {
     }
 
     @ExceptionHandler(DatabaseException.class)
-    public ResponseEntity<String> handleDatabaseException(DatabaseException e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Database error: " + e.getMessage());
+    public ResponseEntity<APIErrorResponse> handleDatabaseException(DatabaseException e, ServerWebExchange exchange) {
+        log.error("Database error: {}", e.getMessage(), e);
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(Instant.now())
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .error("Database Error")
+                .message(e.getMessage())
+                .path(exchange.getRequest().getPath().value())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }
+
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<String> handleNotFoundException(NotFoundException e) {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import jakarta.validation.ConstraintViolationException;
+import org.springframework.web.server.ServerWebExchange;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -48,18 +49,20 @@ public class UserGlobalExceptionHandler {
     }
 
     @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<APIErrorResponse> handleBadRequestException(BadRequestException e) {
+    public ResponseEntity<APIErrorResponse> handleBadRequestException(BadRequestException e, ServerWebExchange exchange) {
         log.error("Bad Request: {}", e.getMessage(), e);
 
-        APIErrorResponse errorResponse = APIErrorResponse.builder()
+        APIErrorResponse response = APIErrorResponse.builder()
                 .timestamp(Instant.now())
                 .status(HttpStatus.BAD_REQUEST.value())
                 .error("Bad Request")
                 .message(e.getMessage())
+                .path(exchange.getRequest().getPath().value())
                 .build();
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
+
 
 
     @ExceptionHandler(BadUUIDException.class)

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -64,7 +64,6 @@ public class UserGlobalExceptionHandler {
     }
 
 
-
     @ExceptionHandler(BadUUIDException.class)
     public ResponseEntity<APIErrorResponse> handleBadUUIDException(BadUUIDException e, ServerWebExchange exchange) {
         log.error("Bad UUID: {}", e.getMessage(), e);

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -95,6 +95,7 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }
 
+
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<APIErrorResponse> handleNotFoundException(
             NotFoundException e,

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -64,7 +64,6 @@ public class UserGlobalExceptionHandler {
     }
 
 
-
     @ExceptionHandler(BadUUIDException.class)
     public ResponseEntity<String> handleBadUUIDException(BadUUIDException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("The provided IDs are not valid.");

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -63,7 +63,6 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
-
     @ExceptionHandler(BadUUIDException.class)
     public ResponseEntity<String> handleBadUUIDException(BadUUIDException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("The provided IDs are not valid.");
@@ -84,10 +83,21 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }
 
-
     @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<String> handleNotFoundException(NotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    public ResponseEntity<APIErrorResponse> handleNotFoundException(
+            NotFoundException e,
+            ServerWebExchange exchange) {
+
+        log.error("Not Found: {}", e.getMessage(), e);
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(Instant.now())
+                .status(HttpStatus.NOT_FOUND.value())
+                .error("Not Found")
+                .message(e.getMessage())
+                .path(exchange.getRequest().getPath().value())
+                .build();
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.itachallenge.user.exception;
 
-import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -136,20 +135,4 @@ public class UserGlobalExceptionHandler {
     public ResponseEntity<String> handleUsernameAlreadyExistsException(UsernameAlreadyExistsException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
-
-//    @ExceptionHandler(GithubUnavailableException.class)
-//    public ResponseEntity<APIErrorResponse> handleGithubUnavailable(GithubUnavailableException ex) {
-//        HttpStatus status;
-//
-//        if ("timeout".equalsIgnoreCase(ex.getMessage())) {
-//            status = HttpStatus.GATEWAY_TIMEOUT; // 504
-//        } else {
-//            status = HttpStatus.SERVICE_UNAVAILABLE; // 503
-//        }
-//
-//        return ResponseEntity.status(status).body(
-//                new APIErrorResponse("GitHub API error", ex.getMessage(), Instant.now())
-//        );
-//    }
-
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -2,7 +2,10 @@ package com.itachallenge.user.exception;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,8 +20,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class UserGlobalExceptionHandler {
+
+    private final MessageSource messageSource;
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleAny(Exception e) {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/exception/UserGlobalExceptionHandler.java
@@ -91,19 +91,19 @@ public class UserGlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
 
-    @ExceptionHandler(GithubUnavailableException.class)
-    public ResponseEntity<APIErrorResponse> handleGithubUnavailable(GithubUnavailableException ex) {
-        HttpStatus status;
-
-        if ("timeout".equalsIgnoreCase(ex.getMessage())) {
-            status = HttpStatus.GATEWAY_TIMEOUT; // 504
-        } else {
-            status = HttpStatus.SERVICE_UNAVAILABLE; // 503
-        }
-
-        return ResponseEntity.status(status).body(
-                new APIErrorResponse("GitHub API error", ex.getMessage(), Instant.now())
-        );
-    }
+//    @ExceptionHandler(GithubUnavailableException.class)
+//    public ResponseEntity<APIErrorResponse> handleGithubUnavailable(GithubUnavailableException ex) {
+//        HttpStatus status;
+//
+//        if ("timeout".equalsIgnoreCase(ex.getMessage())) {
+//            status = HttpStatus.GATEWAY_TIMEOUT; // 504
+//        } else {
+//            status = HttpStatus.SERVICE_UNAVAILABLE; // 503
+//        }
+//
+//        return ResponseEntity.status(status).body(
+//                new APIErrorResponse("GitHub API error", ex.getMessage(), Instant.now())
+//        );
+//    }
 
 }

--- a/itachallenge-user/src/main/resources/messages.properties
+++ b/itachallenge-user/src/main/resources/messages.properties
@@ -29,12 +29,3 @@ validation.field.required=This field is required.
 validation.uuid.invalid=The provided value must be a valid UUID.
 validation.githubUsername.invalid=The GitHub username provided is not valid.
 
-# ===============================
-#DE MOMENTO SOLO USAMOS :
-# adminCreateUser.username.notBlank=The username must not be blank.
-# user.solution.text.notEmpty=The solution text cannot be empty.
-#user.solution.languageId.invalid=The language ID must be a valid UUID.
-#user.solution.challengeId.invalid=The challenge ID must be a valid UUID.
-# validation.uuid.invalid=The provided value must be a valid UUID.
-#
-# ===============================

--- a/itachallenge-user/src/main/resources/messages.properties
+++ b/itachallenge-user/src/main/resources/messages.properties
@@ -28,3 +28,13 @@ validation.dto.invalid=The provided data is invalid or does not meet validation 
 validation.field.required=This field is required.
 validation.uuid.invalid=The provided value must be a valid UUID.
 validation.githubUsername.invalid=The GitHub username provided is not valid.
+
+# ===============================
+#DE MOMENTO SOLO USAMOS :
+# adminCreateUser.username.notBlank=The username must not be blank.
+# user.solution.text.notEmpty=The solution text cannot be empty.
+#user.solution.languageId.invalid=The language ID must be a valid UUID.
+#user.solution.challengeId.invalid=The challenge ID must be a valid UUID.
+# validation.uuid.invalid=The provided value must be a valid UUID.
+#
+# ===============================

--- a/itachallenge-user/src/main/resources/messages.properties
+++ b/itachallenge-user/src/main/resources/messages.properties
@@ -1,0 +1,30 @@
+# ===============================
+# AdminCreateUserRequestDto Validation Messages
+# ===============================
+adminCreateUser.username.notBlank=The username must not be blank.
+adminCreateUser.username.invalidFormat=The username must follow GitHub username rules (only alphanumeric characters and hyphens, no consecutive hyphens, and cannot start or end with a hyphen).
+adminCreateUser.dto.invalid=The provided admin user data is invalid or incomplete.
+
+# ===============================
+# UserController Path Variables Validation Messages
+# ===============================
+user.githubUsername.invalid=The provided GitHub username is invalid. Please ensure it matches the GitHub username format.
+user.userId.invalid=The provided user ID must be a valid UUID.
+user.challengeId.invalid=The provided challenge ID must be a valid UUID.
+
+# ===============================
+# UserSolutionRequestDto Validation Messages
+# (if you later add validation to it)
+# ===============================
+user.solution.text.notEmpty=The solution text cannot be empty.
+user.solution.languageId.invalid=The language ID must be a valid UUID.
+user.solution.challengeId.invalid=The challenge ID must be a valid UUID.
+user.solution.dto.invalid=The provided user solution data is invalid or incomplete.
+
+# ===============================
+# Generic Validation and DTO Errors
+# ===============================
+validation.dto.invalid=The provided data is invalid or does not meet validation requirements.
+validation.field.required=This field is required.
+validation.uuid.invalid=The provided value must be a valid UUID.
+validation.githubUsername.invalid=The GitHub username provided is not valid.

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -43,8 +43,9 @@ class UserControllerTest {
     @BeforeEach
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
+        MessageSource messageSource = mock(MessageSource.class);
         webTestClient = WebTestClient.bindToController(userController)
-                .controllerAdvice(new UserGlobalExceptionHandler())
+                .controllerAdvice(new UserGlobalExceptionHandler(messageSource))
                 .build();
     }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -85,18 +85,29 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("GET /users/{githubUsername} returns 404 when user not found")
     void getUser_WhenUserNotExists_Returns404() {
         String githubUsername = "nonExistentUser";
-        when(userService.getUser(githubUsername)).thenReturn(Mono.error(new NotFoundException("User not found")));
+
+        when(userService.getUser(githubUsername))
+                .thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/" + githubUsername)
+                .uri("/itachallenge/api/v1/user/users/{githubUsername}", githubUsername)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + githubUsername, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).getUser(githubUsername);
     }
+
 
     @Test
     void getUser_WhenServiceReturnsError_Returns500() {
@@ -187,7 +198,14 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).addChallengeToFavorites(userId, challengeId);
     }
@@ -202,8 +220,15 @@ class UserControllerTest {
         webTestClient.post()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectStatus().isNotFound()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }
@@ -213,13 +238,20 @@ class UserControllerTest {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.addChallengeToFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).addChallengeToFavorites(userId, challengeId);
     }
@@ -229,13 +261,20 @@ class UserControllerTest {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.addChallengeToBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectStatus().isBadRequest()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }
@@ -346,8 +385,15 @@ class UserControllerTest {
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectStatus().isNotFound()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
@@ -362,8 +408,15 @@ class UserControllerTest {
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectStatus().isNotFound()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
     }
@@ -373,13 +426,20 @@ class UserControllerTest {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.deleteChallengeFromFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
 
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectStatus().isBadRequest()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
@@ -389,13 +449,20 @@ class UserControllerTest {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.deleteChallengeFromBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
 
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectStatus().isBadRequest()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
     }
@@ -475,7 +542,6 @@ class UserControllerTest {
         verify(userService, times(1)).getUserFavorites(userId.toString());
     }
 
-
     @Test
     @DisplayName("GET /users/{userId}/favorites returns 400 if UUID is invalid")
     void getUserFavorites_returns400IfInvalidUUID() {
@@ -488,7 +554,14 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/favorites", invalidUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + invalidUserId + "/favorites", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).getUserFavorites(invalidUserId);
     }
@@ -541,7 +614,14 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).getUserBookmarks(userId.toString());
     }
@@ -558,7 +638,14 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", invalidUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + invalidUserId + "/bookmarks", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).getUserBookmarks(invalidUserId);
     }
@@ -623,41 +710,52 @@ class UserControllerTest {
         
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
-    
+
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 404 if no solutions found")
     void getAllSolutions_returns404IfNotFound() {
         String userId = UUID.randomUUID().toString();
-        
-        // Simulamos que el servicio lanza NotFoundException
+
         when(userSolutionService.getAllSolutionsByUser(userId))
                 .thenReturn(Flux.error(new NotFoundException("Solutions not found")));
-        
+
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class)
-                .isEqualTo("Solutions not found");
-        
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("Solutions not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/solutions", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
+
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
-    
+
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 400 if UUID is invalid")
     void getAllSolutions_returns400IfInvalidUUID() {
         String badUserId = "not-a-uuid";
-        
+
         when(userSolutionService.getAllSolutionsByUser(badUserId))
-                .thenReturn(Flux.error(new BadUUIDException("Bad UUID")));
-        
+                .thenReturn(Flux.error(new BadUUIDException("The provided IDs are not valid.")));
+
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", badUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(String.class)
-                .isEqualTo("The provided IDs are not valid.");
-        
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + badUserId + "/solutions", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
+
         verify(userSolutionService, times(1)).getAllSolutionsByUser(badUserId);
     }
     

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -20,8 +20,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.Set;
 import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 class UserControllerTest {

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.user.controller;
 
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
+import com.itachallenge.user.dto.APIErrorResponse;
 import com.itachallenge.user.dto.UserSolutionResponseDto;
 import com.itachallenge.user.exception.BadUUIDException;
 import com.itachallenge.user.exception.NotFoundException;
@@ -20,6 +21,8 @@ import reactor.core.publisher.Mono;
 
 import java.util.Set;
 import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 class UserControllerTest {
@@ -40,10 +43,8 @@ class UserControllerTest {
     @BeforeEach
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
-        MessageSource messageSource = mock(MessageSource.class);
-
         webTestClient = WebTestClient.bindToController(userController)
-                .controllerAdvice(new UserGlobalExceptionHandler(messageSource))
+                .controllerAdvice(new UserGlobalExceptionHandler())
                 .build();
     }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -87,16 +87,25 @@ class UserControllerTest {
     @Test
     void getUser_WhenUserNotExists_Returns404() {
         String githubUsername = "nonExistentUser";
-        when(userService.getUser(githubUsername)).thenReturn(Mono.error(new NotFoundException("User not found")));
+        when(userService.getUser(githubUsername))
+                .thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/" + githubUsername)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + githubUsername, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).getUser(githubUsername);
     }
+
 
     @Test
     void getUser_WhenServiceReturnsError_Returns500() {
@@ -180,6 +189,7 @@ class UserControllerTest {
     void addToFavorites_WhenUserNotExists_Returns404() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
+
         when(userService.addChallengeToFavorites(userId, challengeId))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
@@ -187,26 +197,43 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).addChallengeToFavorites(userId, challengeId);
     }
+
 
     @Test
     void addToBookmarks_WhenUserNotExists_Returns404() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
+
         when(userService.addChallengeToBookmarks(userId, challengeId))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectStatus().isNotFound()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }
+
 
     @Test
     void addToFavorites_WhenBadFormattedId_Returns400() {
@@ -340,33 +367,51 @@ class UserControllerTest {
     void deleteFromFavorites_WhenUserNotExists_Returns404() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
+
         when(userService.deleteChallengeFromFavorites(userId, challengeId))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectStatus().isNotFound()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
+
 
     @Test
     void deleteFromBookmarks_WhenUserNotExists_Returns404() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
+
         when(userService.deleteChallengeFromBookmarks(userId, challengeId))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectStatus().isNotFound()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
     }
+
 
     @Test
     void deleteFromFavorites_WhenBadFormattedId_Returns404() {
@@ -541,10 +586,18 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).getUserBookmarks(userId.toString());
     }
+
 
     @Test
     @DisplayName("GET /users/{userId}/bookmarks returns 400 if UUID is invalid")
@@ -623,25 +676,31 @@ class UserControllerTest {
         
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
-    
+
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 404 if no solutions found")
     void getAllSolutions_returns404IfNotFound() {
         String userId = UUID.randomUUID().toString();
-        
-        // Simulamos que el servicio lanza NotFoundException
+
         when(userSolutionService.getAllSolutionsByUser(userId))
                 .thenReturn(Flux.error(new NotFoundException("Solutions not found")));
-        
+
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class)
-                .isEqualTo("Solutions not found");
-        
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("Solutions not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/solutions", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
+
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
+
     
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 400 if UUID is invalid")

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
@@ -41,8 +42,10 @@ class UserControllerTest {
     @BeforeEach
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
+        MessageSource messageSource = mock(MessageSource.class);
+
         webTestClient = WebTestClient.bindToController(userController)
-                .controllerAdvice(new UserGlobalExceptionHandler())
+                .controllerAdvice(new UserGlobalExceptionHandler(messageSource))
                 .build();
     }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 class UserControllerTest {
@@ -462,10 +463,18 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/favorites", userId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
+                    assertEquals("Not Found", response.getError());
+                    assertEquals("User not found", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).getUserFavorites(userId.toString());
     }
+
 
     @Test
     @DisplayName("GET /users/{userId}/favorites returns 400 if UUID is invalid")

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 class UserControllerTest {
@@ -44,9 +43,8 @@ class UserControllerTest {
     @BeforeEach
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
-        MessageSource messageSource = mock(MessageSource.class);
         webTestClient = WebTestClient.bindToController(userController)
-                .controllerAdvice(new UserGlobalExceptionHandler(messageSource))
+                .controllerAdvice(new UserGlobalExceptionHandler())
                 .build();
     }
 
@@ -85,23 +83,15 @@ class UserControllerTest {
     }
 
     @Test
-    void getUser_WhenUserNotExists_Returns404_JSON() {
+    void getUser_WhenUserNotExists_Returns404() {
         String githubUsername = "nonExistentUser";
-        when(userService.getUser(githubUsername))
-                .thenReturn(Mono.error(new NotFoundException("User not found")));
+        when(userService.getUser(githubUsername)).thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/" + githubUsername)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
-                    assertEquals("Not Found", response.getError());
-                    assertEquals("User not found", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + githubUsername, response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectBody(String.class).isEqualTo("User not found");
 
         verify(userService, times(1)).getUser(githubUsername);
     }
@@ -185,7 +175,7 @@ class UserControllerTest {
     }
 
     @Test
-    void addToFavorites_WhenUserNotExists_Returns404_JSON() {
+    void addToFavorites_WhenUserNotExists_Returns404() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
         when(userService.addChallengeToFavorites(userId, challengeId))
@@ -195,21 +185,13 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
-                    assertEquals("Not Found", response.getError());
-                    assertEquals("User not found", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectBody(String.class).isEqualTo("User not found");
 
         verify(userService, times(1)).addChallengeToFavorites(userId, challengeId);
     }
 
-
     @Test
-    void addToBookmarks_WhenUserNotExists_Returns404_JSON() {
+    void addToBookmarks_WhenUserNotExists_Returns404() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
         when(userService.addChallengeToBookmarks(userId, challengeId))
@@ -218,67 +200,43 @@ class UserControllerTest {
         webTestClient.post()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isNotFound()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
-                    assertEquals("Not Found", response.getError());
-                    assertEquals("User not found", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
+                .expectBody(String.class).isEqualTo("User not found");
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }
-
 
     @Test
     void addToFavorites_WhenBadFormattedId_Returns400() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.addChallengeToFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
+                .thenReturn(Mono.error(new BadUUIDException("Error message")));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
-                    assertEquals("Bad Request", response.getError());
-                    assertEquals("The provided IDs are not valid.", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
 
         verify(userService, times(1)).addChallengeToFavorites(userId, challengeId);
     }
 
-
     @Test
-    void addToBookmarks_WhenBadFormattedId_Returns400_JSON() {
+    void addToBookmarks_WhenBadFormattedId_Returns400() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.addChallengeToBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
+                .thenReturn(Mono.error(new BadUUIDException("Error message")));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isBadRequest()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
-                    assertEquals("Bad Request", response.getError());
-                    assertEquals("The provided IDs are not valid.", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }
-
 
     @Test
     void addToFavorites_WhenUnexpectedError_Returns500() {
@@ -377,7 +335,7 @@ class UserControllerTest {
     }
 
     @Test
-    void deleteFromFavorites_WhenUserNotExists_Returns404_JSON() {
+    void deleteFromFavorites_WhenUserNotExists_Returns404() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
         when(userService.deleteChallengeFromFavorites(userId, challengeId))
@@ -386,21 +344,14 @@ class UserControllerTest {
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
-                .expectStatus().isNotFound()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
-                    assertEquals("Not Found", response.getError());
-                    assertEquals("User not found", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
+                .expectBody(String.class).isEqualTo("User not found");
 
         verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
 
     @Test
-    void deleteFromBookmarks_WhenUserNotExists_Returns404_JSON() {
+    void deleteFromBookmarks_WhenUserNotExists_Returns404() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
         when(userService.deleteChallengeFromBookmarks(userId, challengeId))
@@ -409,61 +360,40 @@ class UserControllerTest {
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isNotFound()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
-                    assertEquals("Not Found", response.getError());
-                    assertEquals("User not found", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
+                .expectBody(String.class).isEqualTo("User not found");
 
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
     }
 
     @Test
-    void deleteFromFavorites_WhenBadFormattedId_Returns400_JSON() {
+    void deleteFromFavorites_WhenBadFormattedId_Returns404() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.deleteChallengeFromFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
+                .thenReturn(Mono.error(new BadUUIDException("Error message")));
 
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
-                .expectStatus().isBadRequest()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
-                    assertEquals("Bad Request", response.getError());
-                    assertEquals("The provided IDs are not valid.", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
 
         verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
 
     @Test
-    void deleteFromBookmarks_WhenBadFormattedId_Returns400_JSON() {
+    void deleteFromBookmarks_WhenBadFormattedId_Returns404() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.deleteChallengeFromBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
+                .thenReturn(Mono.error(new BadUUIDException("Error message")));
 
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isBadRequest()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
-                    assertEquals("Bad Request", response.getError());
-                    assertEquals("The provided IDs are not valid.", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
 
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
     }
@@ -520,29 +450,21 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("GET /users/{userId}/bookmarks returns 404 if user not found")
-    void getUserBookmarks_returns404IfUserNotFound_JSON() {
+    @DisplayName("GET /users/{userId}/favorites returns 404 if user not found")
+    void getUserFavorites_returns404IfUserNotFound() {
         UUID userId = UUID.randomUUID();
 
-        when(userService.getUserBookmarks(userId.toString()))
+        when(userService.getUserFavorites(userId.toString()))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
+                .uri("/itachallenge/api/v1/user/users/{userId}/favorites", userId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
-                    assertEquals("Not Found", response.getError());
-                    assertEquals("User not found", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks", response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectBody(String.class).isEqualTo("User not found");
 
-        verify(userService, times(1)).getUserBookmarks(userId.toString());
+        verify(userService, times(1)).getUserFavorites(userId.toString());
     }
-
 
     @Test
     @DisplayName("GET /users/{userId}/favorites returns 400 if UUID is invalid")
@@ -556,18 +478,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/favorites", invalidUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
-                    assertEquals("Bad Request", response.getError());
-                    assertEquals("The provided IDs are not valid.", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + invalidUserId + "/favorites", response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
 
         verify(userService, times(1)).getUserFavorites(invalidUserId);
     }
-
 
     @Test
     @DisplayName("GET /users/{userId}/favorites returns 500 if there is an internal error")
@@ -606,6 +520,23 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("GET /users/{userId}/bookmarks returns 404 if user not found")
+    void getUserBookmarks_returns404IfUserNotFound() {
+        UUID userId = UUID.randomUUID();
+
+        when(userService.getUserBookmarks(userId.toString()))
+                .thenReturn(Mono.error(new NotFoundException("User not found")));
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(String.class).isEqualTo("User not found");
+
+        verify(userService, times(1)).getUserBookmarks(userId.toString());
+    }
+
+    @Test
     @DisplayName("GET /users/{userId}/bookmarks returns 400 if UUID is invalid")
     void getUserBookmarks_returns400IfInvalidUUID() {
         String invalidUserId = "invalid-uuid";
@@ -617,18 +548,10 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", invalidUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
-                    assertEquals("Bad Request", response.getError());
-                    assertEquals("The provided IDs are not valid.", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + invalidUserId + "/bookmarks", response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
 
         verify(userService, times(1)).getUserBookmarks(invalidUserId);
     }
-
 
     @Test
     @DisplayName("GET /users/{userId}/bookmarks returns 500 if there is an internal error")
@@ -690,52 +613,41 @@ class UserControllerTest {
         
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
-
+    
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 404 if no solutions found")
-    void getAllSolutions_returns404IfNotFound_JSON() {
+    void getAllSolutions_returns404IfNotFound() {
         String userId = UUID.randomUUID().toString();
-
+        
+        // Simulamos que el servicio lanza NotFoundException
         when(userSolutionService.getAllSolutionsByUser(userId))
                 .thenReturn(Flux.error(new NotFoundException("Solutions not found")));
-
+        
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", userId)
                 .exchange()
                 .expectStatus().isNotFound()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
-                    assertEquals("Not Found", response.getError());
-                    assertEquals("Solutions not found", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/solutions", response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
-
+                .expectBody(String.class)
+                .isEqualTo("Solutions not found");
+        
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
-
+    
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 400 if UUID is invalid")
-    void getAllSolutions_returns400IfInvalidUUID_JSON() {
+    void getAllSolutions_returns400IfInvalidUUID() {
         String badUserId = "not-a-uuid";
-
+        
         when(userSolutionService.getAllSolutionsByUser(badUserId))
-                .thenReturn(Flux.error(new BadUUIDException("The provided IDs are not valid.")));
-
+                .thenReturn(Flux.error(new BadUUIDException("Bad UUID")));
+        
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", badUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
-                    assertEquals("Bad Request", response.getError());
-                    assertEquals("The provided IDs are not valid.", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + badUserId + "/solutions", response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
-
+                .expectBody(String.class)
+                .isEqualTo("The provided IDs are not valid.");
+        
         verify(userSolutionService, times(1)).getAllSolutionsByUser(badUserId);
     }
     

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -85,7 +85,7 @@ class UserControllerTest {
     }
 
     @Test
-    void getUser_WhenUserNotExists_Returns404() {
+    void getUser_WhenUserNotExists_Returns404_JSON() {
         String githubUsername = "nonExistentUser";
         when(userService.getUser(githubUsername))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
@@ -105,7 +105,6 @@ class UserControllerTest {
 
         verify(userService, times(1)).getUser(githubUsername);
     }
-
 
     @Test
     void getUser_WhenServiceReturnsError_Returns500() {
@@ -186,10 +185,9 @@ class UserControllerTest {
     }
 
     @Test
-    void addToFavorites_WhenUserNotExists_Returns404() {
+    void addToFavorites_WhenUserNotExists_Returns404_JSON() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
-
         when(userService.addChallengeToFavorites(userId, challengeId))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
@@ -211,10 +209,9 @@ class UserControllerTest {
 
 
     @Test
-    void addToBookmarks_WhenUserNotExists_Returns404() {
+    void addToBookmarks_WhenUserNotExists_Returns404_JSON() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
-
         when(userService.addChallengeToBookmarks(userId, challengeId))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
@@ -240,32 +237,48 @@ class UserControllerTest {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.addChallengeToFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).addChallengeToFavorites(userId, challengeId);
     }
 
+
     @Test
-    void addToBookmarks_WhenBadFormattedId_Returns400() {
+    void addToBookmarks_WhenBadFormattedId_Returns400_JSON() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.addChallengeToBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectStatus().isBadRequest()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
     }
+
 
     @Test
     void addToFavorites_WhenUnexpectedError_Returns500() {
@@ -364,10 +377,9 @@ class UserControllerTest {
     }
 
     @Test
-    void deleteFromFavorites_WhenUserNotExists_Returns404() {
+    void deleteFromFavorites_WhenUserNotExists_Returns404_JSON() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
-
         when(userService.deleteChallengeFromFavorites(userId, challengeId))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
@@ -387,12 +399,10 @@ class UserControllerTest {
         verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
 
-
     @Test
-    void deleteFromBookmarks_WhenUserNotExists_Returns404() {
+    void deleteFromBookmarks_WhenUserNotExists_Returns404_JSON() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
-
         when(userService.deleteChallengeFromBookmarks(userId, challengeId))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
@@ -412,35 +422,48 @@ class UserControllerTest {
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
     }
 
-
     @Test
-    void deleteFromFavorites_WhenBadFormattedId_Returns404() {
+    void deleteFromFavorites_WhenBadFormattedId_Returns400_JSON() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.deleteChallengeFromFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
 
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectStatus().isBadRequest()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
 
     @Test
-    void deleteFromBookmarks_WhenBadFormattedId_Returns404() {
+    void deleteFromBookmarks_WhenBadFormattedId_Returns400_JSON() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
         when(userService.deleteChallengeFromBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+                .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
 
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
                 .exchange()
-                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectStatus().isBadRequest()
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId, response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
     }
@@ -497,15 +520,15 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("GET /users/{userId}/favorites returns 404 if user not found")
-    void getUserFavorites_returns404IfUserNotFound() {
+    @DisplayName("GET /users/{userId}/bookmarks returns 404 if user not found")
+    void getUserBookmarks_returns404IfUserNotFound_JSON() {
         UUID userId = UUID.randomUUID();
 
-        when(userService.getUserFavorites(userId.toString()))
+        when(userService.getUserBookmarks(userId.toString()))
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/favorites", userId)
+                .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
                 .exchange()
                 .expectStatus().isNotFound()
                 .expectBody(APIErrorResponse.class)
@@ -513,11 +536,11 @@ class UserControllerTest {
                     assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
                     assertEquals("Not Found", response.getError());
                     assertEquals("User not found", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/favorites", response.getPath());
+                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks", response.getPath());
                     assertNotNull(response.getTimestamp());
                 });
 
-        verify(userService, times(1)).getUserFavorites(userId.toString());
+        verify(userService, times(1)).getUserBookmarks(userId.toString());
     }
 
 
@@ -533,10 +556,18 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/favorites", invalidUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + invalidUserId + "/favorites", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).getUserFavorites(invalidUserId);
     }
+
 
     @Test
     @DisplayName("GET /users/{userId}/favorites returns 500 if there is an internal error")
@@ -575,31 +606,6 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("GET /users/{userId}/bookmarks returns 404 if user not found")
-    void getUserBookmarks_returns404IfUserNotFound() {
-        UUID userId = UUID.randomUUID();
-
-        when(userService.getUserBookmarks(userId.toString()))
-                .thenReturn(Mono.error(new NotFoundException("User not found")));
-
-        webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
-                .exchange()
-                .expectStatus().isNotFound()
-                .expectBody(APIErrorResponse.class)
-                .value(response -> {
-                    assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
-                    assertEquals("Not Found", response.getError());
-                    assertEquals("User not found", response.getMessage());
-                    assertEquals("/itachallenge/api/v1/user/users/" + userId + "/bookmarks", response.getPath());
-                    assertNotNull(response.getTimestamp());
-                });
-
-        verify(userService, times(1)).getUserBookmarks(userId.toString());
-    }
-
-
-    @Test
     @DisplayName("GET /users/{userId}/bookmarks returns 400 if UUID is invalid")
     void getUserBookmarks_returns400IfInvalidUUID() {
         String invalidUserId = "invalid-uuid";
@@ -611,10 +617,18 @@ class UserControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", invalidUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + invalidUserId + "/bookmarks", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
 
         verify(userService, times(1)).getUserBookmarks(invalidUserId);
     }
+
 
     @Test
     @DisplayName("GET /users/{userId}/bookmarks returns 500 if there is an internal error")
@@ -679,7 +693,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 404 if no solutions found")
-    void getAllSolutions_returns404IfNotFound() {
+    void getAllSolutions_returns404IfNotFound_JSON() {
         String userId = UUID.randomUUID().toString();
 
         when(userSolutionService.getAllSolutionsByUser(userId))
@@ -701,22 +715,27 @@ class UserControllerTest {
         verify(userSolutionService, times(1)).getAllSolutionsByUser(userId);
     }
 
-    
     @Test
     @DisplayName("GET /users/{userId}/solutions returns 400 if UUID is invalid")
-    void getAllSolutions_returns400IfInvalidUUID() {
+    void getAllSolutions_returns400IfInvalidUUID_JSON() {
         String badUserId = "not-a-uuid";
-        
+
         when(userSolutionService.getAllSolutionsByUser(badUserId))
-                .thenReturn(Flux.error(new BadUUIDException("Bad UUID")));
-        
+                .thenReturn(Flux.error(new BadUUIDException("The provided IDs are not valid.")));
+
         webTestClient.get()
                 .uri("/itachallenge/api/v1/user/users/{userId}/solutions", badUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
-                .expectBody(String.class)
-                .isEqualTo("The provided IDs are not valid.");
-        
+                .expectBody(APIErrorResponse.class)
+                .value(response -> {
+                    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+                    assertEquals("Bad Request", response.getError());
+                    assertEquals("The provided IDs are not valid.", response.getMessage());
+                    assertEquals("/itachallenge/api/v1/user/users/" + badUserId + "/solutions", response.getPath());
+                    assertNotNull(response.getTimestamp());
+                });
+
         verify(userSolutionService, times(1)).getAllSolutionsByUser(badUserId);
     }
     

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -1,33 +1,58 @@
 package com.itachallenge.user.dto;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class APIErrorResponseTest {
+    private ObjectMapper objectMapper;
 
-    @Test
-    void testConstructorAndGetters() {
-        Instant now = Instant.now();
-        APIErrorResponse errorResponse = new APIErrorResponse("Some error", "Something went wrong", now);
-
-        assertEquals("Some error", errorResponse.getError());
-        assertEquals("Something went wrong", errorResponse.getMessage());
-        assertEquals(now, errorResponse.getTimestamp());
+    @BeforeEach
+    void setUp(){
+        objectMapper = new ObjectMapper();
     }
 
     @Test
-    void testNoArgsConstructorAndSetters() {
+    void shouldBuildAPIErrorResponse(){
         Instant now = Instant.now();
-        APIErrorResponse errorResponse = new APIErrorResponse();
-        errorResponse.setError("Another error");
-        errorResponse.setMessage("Different message");
-        errorResponse.setTimestamp(now);
+        FieldErrorDto fieldError = new FieldErrorDto("AdminCreateUserRequestDto","username", "must not be empty");
 
-        assertEquals("Another error", errorResponse.getError());
-        assertEquals("Different message", errorResponse.getMessage());
-        assertEquals(now, errorResponse.getTimestamp());
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(now)
+                .status(400)
+                .error("Bad Request")
+                .message("Validation failed")
+                .path("api/v1/user")
+                .errors(List.of(fieldError))
+                .build();
+
+        assertThat(response.getTimestamp()).isEqualTo(now);
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getError()).isEqualTo("Bad Request");
+        assertThat(response.getMessage()).isEqualTo("Validation failed");
+        assertThat(response.getPath()).isEqualTo("api/v1/user");
+        assertThat(response.getErrors()).containsExactly(fieldError);
     }
+
 }
+
+//    @Test
+//    void testNoArgsConstructorAndSetters() {
+//        Instant now = Instant.now();
+//        APIErrorResponse errorResponse = new APIErrorResponse();
+//        errorResponse.setError("Another error");
+//        errorResponse.setMessage("Different message");
+//        errorResponse.setTimestamp(now);
+//
+//        assertEquals("Another error", errorResponse.getError());
+//        assertEquals("Different message", errorResponse.getMessage());
+//        assertEquals(now, errorResponse.getTimestamp());
+//    }
+

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/APIErrorResponseTest.java
@@ -1,15 +1,17 @@
 package com.itachallenge.user.dto;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class APIErrorResponseTest {
     private ObjectMapper objectMapper;
@@ -17,6 +19,8 @@ class APIErrorResponseTest {
     @BeforeEach
     void setUp(){
         objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
     @Test
@@ -41,18 +45,50 @@ class APIErrorResponseTest {
         assertThat(response.getErrors()).containsExactly(fieldError);
     }
 
+    @Test
+    void shouldSerializeToJsonWithoutEmptyFields() throws JsonProcessingException {
+        Instant now = Instant.parse("2025-10-15T10:00:00Z");
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(now)
+                .status(404)
+                .error("Not Found")
+                .message("User not found")
+                .path("/api/v1/user")
+                .build();
+
+
+        String json = objectMapper.writeValueAsString(response);
+        assertThat(json).contains("\"status\":404");
+        assertThat(json).contains("\"error\":\"Not Found\"");
+        assertThat(json).contains("\"path\":\"/api/v1/user\"");
+        assertThat(json).doesNotContain("errors");
+    }
+
+    @Test
+    void shouldIncludeErrorsWhenPresent() throws JsonProcessingException {
+        Instant now = Instant.parse("2025-10-15T10:00:00Z");
+        FieldErrorDto fieldError = new FieldErrorDto("AdminCreateUserRequestDto","username", "must not be empty");
+
+        APIErrorResponse response = APIErrorResponse.builder()
+                .timestamp(now)
+                .status(400)
+                .error("Bad Request")
+                .message("Validation failed")
+                .path("/api/register")
+                .errors(List.of(fieldError))
+                .build();
+        String json = objectMapper.writeValueAsString(response);
+        assertThat(json).contains("\"errors\"");
+        assertThat(json).contains("username");
+        assertThat(json).contains("not be empty");
+    }
+
+
+
 }
 
-//    @Test
-//    void testNoArgsConstructorAndSetters() {
-//        Instant now = Instant.now();
-//        APIErrorResponse errorResponse = new APIErrorResponse();
-//        errorResponse.setError("Another error");
-//        errorResponse.setMessage("Different message");
-//        errorResponse.setTimestamp(now);
-//
-//        assertEquals("Another error", errorResponse.getError());
-//        assertEquals("Different message", errorResponse.getMessage());
-//        assertEquals(now, errorResponse.getTimestamp());
-//    }
+
+
+
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/AdminCreateUserRequestDtoTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/AdminCreateUserRequestDtoTest.java
@@ -4,10 +4,16 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+
+import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
+import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.Set;
+
+import org.springframework.context.MessageSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -15,11 +21,18 @@ class AdminCreateUserRequestDtoTest {
 
     private static Validator validator;
 
+
     @BeforeAll
-    static void setUpValidator() {
-        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
-            validator = factory.getValidator();
-        }
+    static void setupValidator() {
+        ValidatorFactory factory = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(
+                        new ResourceBundleMessageInterpolator(
+                                new PlatformResourceBundleLocator("messages")
+                        )
+                )
+                .buildValidatorFactory();
+        validator = factory.getValidator();
     }
 
     @Test
@@ -30,6 +43,6 @@ class AdminCreateUserRequestDtoTest {
         Set<ConstraintViolation<AdminCreateUserRequestDto>> violations = validator.validate(request);
 
         assertEquals(1, violations.size());
-        assertEquals("Username must not be blank", violations.iterator().next().getMessage());
+        assertEquals("The username must not be blank.", violations.iterator().next().getMessage());
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/dto/FieldErrorDtoTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/dto/FieldErrorDtoTest.java
@@ -1,0 +1,53 @@
+package com.itachallenge.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FieldErrorDtoTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+    }
+
+    @Test
+    @DisplayName("Serializes a fully populated FieldErrorDto correctly using builder")
+    void shouldSerializeFullyPopulatedDto() throws Exception {
+        FieldErrorDto dto = FieldErrorDto.builder()
+                .objectName("challengeDto")
+                .field("title")
+                .message("The title cannot be empty")
+                .build();
+
+        String json = objectMapper.writeValueAsString(dto);
+
+        assertThat(json).contains("\"objectName\":\"challengeDto\"")
+                .contains("\"field\":\"title\"")
+                .contains("\"message\":\"The title cannot be empty\"")
+                .startsWith("{").endsWith("}");
+    }
+
+    @Test
+    @DisplayName("Does not serialize null fields when using @JsonInclude.NON_EMPTY with builder")
+    void shouldOmitNullFieldsInJson() throws Exception {
+        FieldErrorDto dto = FieldErrorDto.builder()
+                .field("difficulty")
+                .build();  // objectName and message are null
+
+        String json = objectMapper.writeValueAsString(dto);
+
+        assertThat(json).contains("\"field\":\"difficulty\"")
+                .doesNotContain("objectName")
+                .doesNotContain("message");
+    }
+
+}

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,6 +86,26 @@ class UserGlobalExceptionHandlerTest {
         assertNotNull(response.getBody().getTimestamp());
     }
 
+    @Test
+    void testHandleBadUUIDException() {
+        BadUUIDException exception = new BadUUIDException("Invalid UUID format");
+
+        request = mock(MockServerHttpRequest.class);
+        exchange = mock(MockServerWebExchange.class);
+        when(exchange.getRequest()).thenReturn(request);
+        when(request.getPath()).thenReturn(RequestPath.parse("/test/uuid", ""));
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleBadUUIDException(exception, exchange);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        APIErrorResponse body = response.getBody();
+        assertNotNull(body);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), body.getStatus());
+        assertEquals("Bad Request", body.getError());
+        assertEquals("The provided IDs are not valid.", body.getMessage());
+        assertEquals("/test/uuid", body.getPath());
+        assertNotNull(body.getTimestamp());
+    }
 
     @Test
     void testHandleDatabaseException() {
@@ -152,27 +171,5 @@ class UserGlobalExceptionHandlerTest {
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
         assertEquals("The username 'alfonso79' is already registered.", response.getBody());
     }
-
-
-//    @Test
-//    void handleGithubUnavailable_shouldReturn503() {
-//        GithubUnavailableException ex = new GithubUnavailableException("Some 5xx error");
-//
-//        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
-//
-//        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
-//        assertEquals("GitHub API error", response.getBody().getError());
-//    }
-//
-//    @Test
-//    void handleGithubUnavailable_shouldReturn504() {
-//        GithubUnavailableException ex = new GithubUnavailableException("timeout");
-//
-//        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
-//
-//        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode());
-//        assertEquals("GitHub API error", response.getBody().getError());
-//    }
-
 }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -87,6 +87,24 @@ class UserGlobalExceptionHandlerTest {
         assertNotNull(response.getBody().getTimestamp());
     }
 
+    @Test
+    void testHandleBadUUIDException() {
+        BadUUIDException exception = new BadUUIDException("Invalid UUID");
+
+        request = MockServerHttpRequest.get("/test/bad-uuid").build();
+        exchange = MockServerWebExchange.from(request);
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleBadUUIDException(exception, exchange);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        APIErrorResponse body = response.getBody();
+        assertNotNull(body);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), body.getStatus());
+        assertEquals("Bad Request", body.getError());
+        assertEquals("The provided IDs are not valid.", body.getMessage());
+        assertEquals("/test/bad-uuid", body.getPath());
+        assertNotNull(body.getTimestamp());
+    }
 
     @Test
     void testHandleDatabaseException() {

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -93,7 +93,7 @@ class UserGlobalExceptionHandlerTest {
         DatabaseException exception = new DatabaseException("Database connection failed");
 
         request = mock(MockServerHttpRequest.class);
-        exchange = mock(ServerWebExchange.class);
+        exchange = mock(MockServerWebExchange.class);
         when(exchange.getRequest()).thenReturn(request);
         when(request.getPath()).thenReturn(RequestPath.parse("/test/database", ""));
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.server.RequestPath;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -87,69 +86,24 @@ class UserGlobalExceptionHandlerTest {
         assertNotNull(response.getBody().getTimestamp());
     }
 
-    @Test
-    void testHandleBadUUIDException() {
-        BadUUIDException exception = new BadUUIDException("Invalid UUID");
-
-        request = MockServerHttpRequest.get("/test/bad-uuid").build();
-        exchange = MockServerWebExchange.from(request);
-
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleBadUUIDException(exception, exchange);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        APIErrorResponse body = response.getBody();
-        assertNotNull(body);
-        assertEquals(HttpStatus.BAD_REQUEST.value(), body.getStatus());
-        assertEquals("Bad Request", body.getError());
-        assertEquals("The provided IDs are not valid.", body.getMessage());
-        assertEquals("/test/bad-uuid", body.getPath());
-        assertNotNull(body.getTimestamp());
-    }
 
     @Test
     void testHandleDatabaseException() {
         DatabaseException exception = new DatabaseException("Database connection failed");
-
-        request = mock(MockServerHttpRequest.class);
-        exchange = mock(MockServerWebExchange.class);
-        when(exchange.getRequest()).thenReturn(request);
-        when(request.getPath()).thenReturn(RequestPath.parse("/test/database", ""));
-
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleDatabaseException(exception, exchange);
+        ResponseEntity<String> response = exceptionHandler.handleDatabaseException(exception);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        APIErrorResponse body = response.getBody();
-        assertNotNull(body);
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), body.getStatus());
-        assertEquals("Database Error", body.getError());
-        assertEquals("Database connection failed", body.getMessage());
-        assertEquals("/test/database", body.getPath());
-        assertNotNull(body.getTimestamp());
+        assertEquals("Database error: Database connection failed", response.getBody());
     }
-
-
 
     @Test
     void testHandleNotFoundException() {
         NotFoundException exception = new NotFoundException("Resource not found");
-
-        exchange = mock(MockServerWebExchange.class);
-        request = mock(MockServerHttpRequest.class);
-        when(exchange.getRequest()).thenReturn(request);
-        when(request.getPath()).thenReturn(RequestPath.parse("/test/resource", ""));
-
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleNotFoundException(exception, exchange);
+        ResponseEntity<String> response = exceptionHandler.handleNotFoundException(exception);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        APIErrorResponse body = response.getBody();
-        assertNotNull(body);
-        assertEquals(HttpStatus.NOT_FOUND.value(), body.getStatus());
-        assertEquals("Not Found", body.getError());
-        assertEquals("Resource not found", body.getMessage());
-        assertEquals("/test/resource", body.getPath());
-        assertNotNull(body.getTimestamp());
+        assertEquals("Resource not found", response.getBody());
     }
-
 
     @Test
     void testHandleUnmodifiableSolutionException(){

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.RequestPath;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -90,11 +91,25 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleDatabaseException() {
         DatabaseException exception = new DatabaseException("Database connection failed");
-        ResponseEntity<String> response = exceptionHandler.handleDatabaseException(exception);
+
+        request = mock(MockServerHttpRequest.class);
+        exchange = mock(ServerWebExchange.class);
+        when(exchange.getRequest()).thenReturn(request);
+        when(request.getPath()).thenReturn(RequestPath.parse("/test/database", ""));
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleDatabaseException(exception, exchange);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        assertEquals("Database error: Database connection failed", response.getBody());
+        APIErrorResponse body = response.getBody();
+        assertNotNull(body);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), body.getStatus());
+        assertEquals("Database Error", body.getError());
+        assertEquals("Database connection failed", body.getMessage());
+        assertEquals("/test/database", body.getPath());
+        assertNotNull(body.getTimestamp());
     }
+
+
 
     @Test
     void testHandleNotFoundException() {

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -114,11 +114,24 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleNotFoundException() {
         NotFoundException exception = new NotFoundException("Resource not found");
-        ResponseEntity<String> response = exceptionHandler.handleNotFoundException(exception);
+
+        exchange = mock(MockServerWebExchange.class);
+        request = mock(MockServerHttpRequest.class);
+        when(exchange.getRequest()).thenReturn(request);
+        when(request.getPath()).thenReturn(RequestPath.parse("/test/resource", ""));
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleNotFoundException(exception, exchange);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertEquals("Resource not found", response.getBody());
+        APIErrorResponse body = response.getBody();
+        assertNotNull(body);
+        assertEquals(HttpStatus.NOT_FOUND.value(), body.getStatus());
+        assertEquals("Not Found", body.getError());
+        assertEquals("Resource not found", body.getMessage());
+        assertEquals("/test/resource", body.getPath());
+        assertNotNull(body.getTimestamp());
     }
+
 
     @Test
     void testHandleUnmodifiableSolutionException(){

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -8,6 +8,7 @@ import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -22,7 +23,8 @@ class UserGlobalExceptionHandlerTest {
 
     @BeforeEach
     void setUp() {
-        exceptionHandler = new UserGlobalExceptionHandler();
+        MessageSource messageSource = mock(MessageSource.class);
+        exceptionHandler = new UserGlobalExceptionHandler(messageSource);
     }
 
     @Test
@@ -109,25 +111,25 @@ class UserGlobalExceptionHandlerTest {
     }
 
 
-    @Test
-    void handleGithubUnavailable_shouldReturn503() {
-        GithubUnavailableException ex = new GithubUnavailableException("Some 5xx error");
-
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
-
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
-        assertEquals("GitHub API error", response.getBody().getError());
-    }
-
-    @Test
-    void handleGithubUnavailable_shouldReturn504() {
-        GithubUnavailableException ex = new GithubUnavailableException("timeout");
-
-        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
-
-        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode());
-        assertEquals("GitHub API error", response.getBody().getError());
-    }
+//    @Test
+//    void handleGithubUnavailable_shouldReturn503() {
+//        GithubUnavailableException ex = new GithubUnavailableException("Some 5xx error");
+//
+//        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
+//
+//        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+//        assertEquals("GitHub API error", response.getBody().getError());
+//    }
+//
+//    @Test
+//    void handleGithubUnavailable_shouldReturn504() {
+//        GithubUnavailableException ex = new GithubUnavailableException("timeout");
+//
+//        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleGithubUnavailable(ex);
+//
+//        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode());
+//        assertEquals("GitHub API error", response.getBody().getError());
+//    }
 
 }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -1,8 +1,10 @@
 package com.itachallenge.user.exception;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
@@ -11,15 +13,20 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import jakarta.validation.ConstraintViolationException;
+import org.springframework.web.server.ServerWebExchange;
 
 import java.util.Objects;
 
 class UserGlobalExceptionHandlerTest {
 
     private UserGlobalExceptionHandler exceptionHandler;
+    private ServerWebExchange exchange;
+    private MockServerHttpRequest request;
 
     @BeforeEach
     void setUp() {
@@ -66,11 +73,19 @@ class UserGlobalExceptionHandlerTest {
     @Test
     void testHandleBadRequestException() {
         BadRequestException exception = new BadRequestException("Bad request error");
-        ResponseEntity<String> response = exceptionHandler.handleBadRequestException(exception);
+
+        request = MockServerHttpRequest.get("/test-path").build();
+        exchange = MockServerWebExchange.from(request);
+
+        ResponseEntity<APIErrorResponse> response = exceptionHandler.handleBadRequestException(exception, exchange);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("Bad request error", response.getBody());
+        assertEquals("Bad request error", response.getBody().getMessage());
+        assertEquals("Bad Request", response.getBody().getError());
+        assertEquals("/test-path", response.getBody().getPath());
+        assertNotNull(response.getBody().getTimestamp());
     }
+
 
     @Test
     void testHandleDatabaseException() {


### PR DESCRIPTION
**SUMMARY**
Refactorize core exception handlers to return standardized ApiErrorResponseDto (#1005 )

**MODIFIED FILES**
- UserGlobalExceptionHandler : refactored 4 handlers
- UserGlobalExceptionHandlerTest : refactored tests for the 4 handlers

**DETAILS**
This PR continues the work on standardizing error responses across the Challenge microservice. Building on #996, we now refactor the following handlers to produce structured, consistent error responses:

- [x] handleBadRequestException(BadRequestException e)
- [x] handleBadUUIDException(BadUUIDException e)
- [x] handleDatabaseException(DatabaseException e)
- [x] handleNotFoundException(NotFoundException e)

Each handler now returns an ApiErrorResponseDto that includes:
- Timestamp – when the error occurred
- HTTP Status – corresponding to the exception type 
- Message – human-friendly description 
- Field-level errors – via FieldErrorDto, if applicable

This ensures all validation and exception errors are clear, consistent, and user-friendly, while technical details are safely logged rather than exposed.

**OUT OF SCOPE**
Handlers refactored in [Taiga #789](https://tree.taiga.io/project/luisvi-ita-challenges/task/789) and [Taiga #790](https://tree.taiga.io/project/luisvi-ita-challenges/t/790)

**IMPACT**
API error responses are now standardized across the microservice
Existing unit tests updated and verified green
Messages are more user-friendly and secure (exception details are logged, not returned)

**DEFINITION OF DONE**

- [x] 4 handlers refactored to return ApiErrorResponseDto
- [x] Unit tests updated and passing



**Author Self-check**

- [x]  I tested my changes locally and verified they work as expected
- [x]  The PR has a clear and focused purpose (single feature/fix/refactor)
- [x]  Title, description, and changelog are correctly filled
- [x]  All automated checks (SonarCloud, CI) pass
- [x] I responded to all previous review comments
- [x] No unrelated commits or merge leftovers remain