### PR TITLE
chore(contributors): add Diego Balaguer Gálvez to contributors.md (#855) 

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -109,4 +109,4 @@
 * Pablo Federico Gómez San Joaquín - https://github.com/Pablo2203
 * Eduardo Zavarce Forsythe - https://github.com/eduzavarce
 * Flavio Augusto D'Avirro - https://github.com/FlavioKde
-
+* Diego Balaguer Gálvez - https://github.com/DiegoBalaguer


### PR DESCRIPTION
Summary

Added myself, Diego Balaguer Gálvez, to the contributor’s list as part of the onboarding process.

Changes

Updated contributors.md file.