### PR TITLE
PR1/2 - feature(user) - Foundation for action-based status handling (#887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Chore/Internal
+- Introduced `SolutionAction` enum (internal change)
+  - Values: SAVE, GIVE_UP, SUBMIT
+  - Prepared for action-based status handling (Taiga User Story [#871], PR [#1036])
+
 ### [itachallenge-user-3.0.5-RELEASE] - 2025-11-13
 
 ### Added

--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/ChallengeStatus.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/ChallengeStatus.java
@@ -27,5 +27,4 @@ public enum ChallengeStatus {
         return output;
     }
 
-
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/ChallengeStatus.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/ChallengeStatus.java
@@ -27,4 +27,5 @@ public enum ChallengeStatus {
         return output;
     }
 
+
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/SolutionAction.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/SolutionAction.java
@@ -12,6 +12,9 @@ public enum SolutionAction {
 
     @JsonCreator
     public static SolutionAction fromString(String action) {
+        if (action == null || action.isBlank()) {
+            throw new IllegalArgumentException("Action cannot be null");
+        }
         return Arrays.stream(SolutionAction.values())
                 .filter(e -> e.name().equalsIgnoreCase(action.trim()))
                 .findFirst()

--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/SolutionAction.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/SolutionAction.java
@@ -13,7 +13,7 @@ public enum SolutionAction {
     @JsonCreator
     public static SolutionAction fromString(String action) {
         if (action == null || action.isBlank()) {
-            throw new IllegalArgumentException("Action cannot be null");
+            throw new IllegalArgumentException("Action cannot be null or blank");
         }
         return Arrays.stream(SolutionAction.values())
                 .filter(e -> e.name().equalsIgnoreCase(action.trim()))

--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/SolutionAction.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/enums/SolutionAction.java
@@ -1,0 +1,24 @@
+package com.itachallenge.user.document.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public enum SolutionAction {
+    SAVE,
+    GIVE_UP,
+    SUBMIT;
+
+    @JsonCreator
+    public static SolutionAction fromString(String action) {
+        return Arrays.stream(SolutionAction.values())
+                .filter(e -> e.name().equalsIgnoreCase(action.trim()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Action must be one of: " + Arrays.stream(values())
+                                .map(Enum::name)
+                                .collect(Collectors.joining(", "))
+                ));
+    }
+}

--- a/itachallenge-user/src/test/java/com/itachallenge/user/document/enums/SolutionActionTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/document/enums/SolutionActionTest.java
@@ -1,0 +1,55 @@
+package com.itachallenge.user.document.enums;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SolutionActionTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void shouldDeserializeSaveIgnoringCase() throws Exception{
+        String json = "\"SaVe\"";
+        SolutionAction result = mapper.readValue(json, SolutionAction.class);
+
+        assertEquals(SolutionAction.SAVE, result);
+    }
+
+    @Test
+    void shouldDeserializeGiveUpIgnoringCase() throws Exception {
+        String json = "\"GivE_uP\"";
+        SolutionAction result = mapper.readValue(json, SolutionAction.class);
+
+        assertEquals(SolutionAction.GIVE_UP, result);
+    }
+
+    @Test
+    void shouldDeserializeSubmitWithSpaces() throws Exception {
+        String json = "\"   submit   \"";
+        SolutionAction result = mapper.readValue(json, SolutionAction.class);
+
+        assertEquals(SolutionAction.SUBMIT, result);
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidValue() {
+        String json = "\"INVALID_VALUE\"";
+
+        Exception ex = assertThrows(Exception.class, () ->
+                mapper.readValue(json, SolutionAction.class)
+        );
+
+        assertNotNull(ex.getCause());
+        assertTrue(ex.getCause().getMessage().contains("Action must be one of"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNull() throws Exception{
+        String json = "null";
+        SolutionAction result = mapper.readValue(json, SolutionAction.class);
+
+        assertNull(result);
+    }
+}

--- a/itachallenge-user/src/test/java/com/itachallenge/user/document/enums/SolutionActionTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/document/enums/SolutionActionTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.user.document.enums;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,11 +39,14 @@ class SolutionActionTest {
     void shouldThrowExceptionForInvalidValue() {
         String json = "\"INVALID_VALUE\"";
 
-        Exception ex = assertThrows(InvalidFormatException.class, () ->
-                mapper.readValue(json, SolutionAction.class)
+        ValueInstantiationException ex = assertThrows(
+                ValueInstantiationException.class,
+                () -> mapper.readValue(json, SolutionAction.class)
         );
 
+
         assertNotNull(ex.getCause());
+        assertInstanceOf(IllegalArgumentException.class, ex.getCause());
         assertTrue(ex.getCause().getMessage().contains("Action must be one of"));
     }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/document/enums/SolutionActionTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/document/enums/SolutionActionTest.java
@@ -1,6 +1,7 @@
 package com.itachallenge.user.document.enums;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +38,7 @@ class SolutionActionTest {
     void shouldThrowExceptionForInvalidValue() {
         String json = "\"INVALID_VALUE\"";
 
-        Exception ex = assertThrows(Exception.class, () ->
+        Exception ex = assertThrows(InvalidFormatException.class, () ->
                 mapper.readValue(json, SolutionAction.class)
         );
 
@@ -46,7 +47,7 @@ class SolutionActionTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenNull() throws Exception{
+    void shouldReturnNullWhenJsonNull() throws Exception{
         String json = "null";
         SolutionAction result = mapper.readValue(json, SolutionAction.class);
 


### PR DESCRIPTION
### 🔍 Summary

This PR establishes the foundation for action-based status determination. It introduces the SolutionAction enum, ActionValidator, and custom @ValidAction annotation to validate solution actions without modifying existing business logic.

Part of:  [Taiga UserStory #871](https://tree.taiga.io/project/luisvi-ita-challenges/us/871?milestone=490179) 
Followed by: PR2/2 - Implement action-handler to interpret actions and map to correct statuses

------------

### 🛠 Key Changes

Core Components Created

- [ ] SolutionAction enum - Defines valid actions: SAVE, GIVE_UP, SUBMIT



---------------------
### 📁 Modified Files
- changelog.md updated
- /user/dto/UserSolutionRequestDto.java : **PHANTOM CHANGE**


### 📄 Created Files
- /enums/SolutionAction.java

---------------------

### ✅ Outcomes
Validation Logic
- Correctly identifies valid actions (SAVE, GIVE_UP, SUBMIT)
- Case-insensitive validation (accepts any case variation)


-----------------
### Testing Coverage
- No need to test an enum

-----------------
### Component Quality
✅ All components in correct packages following project structure
✅ Code follows project conventions and formatting rules
✅ Ready for integration in PR2

--------------
### 📝 Notes
No breaking changes - Existing functionality unchanged
No database modifications - Pure validation layer
No API changes - Foundation for future enhancement
No business logic modifications - Isolated validation components

---------------------------
### 📋 Changelog updated
-------------
### ✅ PR Author Self-Check

- [x] All Acceptance Criteria met
- [x] Code compiles and tests pass locally and remotely
- [x] SonarQube/SonarCloud analysis passes with no new issues
- [x] Documentation updated (CHANGELOG)
- [x] Code follows project conventions and formatting rules
- [x] No modifications to existing DTOs, services, or controllers
- [x] No changes to database schema or documents
- [x] No integration with existing business logic
- [x] No API endpoint modifications
- [x] Ready for code review by 2 developers
- [x] Components ready for integration in PR2

