### PR TITLE
PR 5/5 - refactor(user): Quitting favorites from UserDocument and all related files (clean) (#856)

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/document/UserDocument.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/document/UserDocument.java
@@ -28,9 +28,6 @@ public class UserDocument {
     @Field("role")
     private Role role;
 
-    @Field("favorite_challenges")
-    private Set<UUID> favoriteChallenges;
-
     @Field("bookmark_challenges")
     private Set<UUID> bookmarkChallenges;
 
@@ -50,12 +47,6 @@ public class UserDocument {
         }
         if (role != null) {
             joiner.add("role='" + role + "'");
-        }
-        if (favoriteChallenges != null && !favoriteChallenges.isEmpty()) {
-            joiner.add("favoriteChallenges='");
-            joiner.add(favoriteChallenges.stream()
-                    .map(String::valueOf)
-                    .collect(Collectors.joining(", ")));
         }
         if (bookmarkChallenges != null && !bookmarkChallenges.isEmpty()) {
             joiner.add("bookmarkChallenges='");

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -64,7 +64,7 @@ class UserControllerTest {
     @Test
     void getUser_WhenUserExists_Returns200() {
         String githubUsername = "existingUser";
-        UserDocument expectedUser = new UserDocument(UUID.randomUUID(), githubUsername, Role.ADMIN, null, null, 0);
+        UserDocument expectedUser = new UserDocument(UUID.randomUUID(), githubUsername, Role.ADMIN, null, 0);
         when(userService.getUser(githubUsername)).thenReturn(Mono.just(expectedUser));
 
         webTestClient.get()

--- a/itachallenge-user/src/test/java/com/itachallenge/user/document/UserDocumentTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/document/UserDocumentTest.java
@@ -14,9 +14,7 @@ class UserDocumentTest {
     private String username;
     private Role role;
     private UserDocument userDocument;
-    private Set<UUID> favoriteChallenges;
     private Set<UUID> bookmarkChallenges;
-    private UUID favoriteChallenge;
     private UUID bookmarkChallenge;
     private Integer points;
 
@@ -25,9 +23,6 @@ class UserDocumentTest {
         uuid = UUID.randomUUID();
         username = "testUser";
         role = Role.ADMIN;
-        favoriteChallenges = new HashSet<>();
-        favoriteChallenge = UUID.randomUUID();
-        favoriteChallenges.add(favoriteChallenge);
         bookmarkChallenges = new HashSet<>();
         bookmarkChallenge = UUID.randomUUID();
         bookmarkChallenges.add(bookmarkChallenge);
@@ -36,7 +31,6 @@ class UserDocumentTest {
                 .uuid(uuid)
                 .username(username)
                 .role(role)
-                .favoriteChallenges(favoriteChallenges)
                 .bookmarkChallenges(bookmarkChallenges)
                 .points(0)
                 .build();
@@ -48,7 +42,6 @@ class UserDocumentTest {
         assertEquals(uuid, userDocument.getUuid());
         assertEquals(username, userDocument.getUsername());
         assertEquals(role, userDocument.getRole());
-        assertEquals(favoriteChallenges, userDocument.getFavoriteChallenges());
         assertEquals(bookmarkChallenges, userDocument.getBookmarkChallenges());
         assertEquals(points, userDocument.getPoints());
     }
@@ -58,21 +51,18 @@ class UserDocumentTest {
         UUID newUuid = UUID.randomUUID();
         String newUsername = "newUser";
         Role newRole = Role.USER;
-        Set<UUID> newFavoriteChallenges = Set.of(UUID.randomUUID());
         Set<UUID> newBookmarkChallenges = Set.of(UUID.randomUUID());
         Integer newPoints = 0;
 
         userDocument.setUuid(newUuid);
         userDocument.setUsername(newUsername);
         userDocument.setRole(newRole);
-        userDocument.setFavoriteChallenges(newFavoriteChallenges);
         userDocument.setBookmarkChallenges(newBookmarkChallenges);
         userDocument.setPoints(newPoints);
 
         assertEquals(newUuid, userDocument.getUuid());
         assertEquals(newUsername, userDocument.getUsername());
         assertEquals(newRole, userDocument.getRole());
-        assertEquals(newFavoriteChallenges, userDocument.getFavoriteChallenges());
         assertEquals(newBookmarkChallenges, userDocument.getBookmarkChallenges());
         assertEquals(newPoints, userDocument.getPoints());
     }
@@ -83,7 +73,6 @@ class UserDocumentTest {
                 .uuid(uuid)
                 .username(username)
                 .role(role)
-                .favoriteChallenges(favoriteChallenges)
                 .bookmarkChallenges(bookmarkChallenges)
                 .points(points)
                 .build();
@@ -92,7 +81,6 @@ class UserDocumentTest {
         assertEquals(uuid, user.getUuid());
         assertEquals(username, user.getUsername());
         assertEquals(role, user.getRole());
-        assertEquals(favoriteChallenges, user.getFavoriteChallenges());
         assertEquals(bookmarkChallenges, user.getBookmarkChallenges());
         assertEquals(points, user.getPoints());
     }
@@ -104,27 +92,25 @@ class UserDocumentTest {
         assertNull(emptyUser.getUuid());
         assertNull(emptyUser.getUsername());
         assertNull(emptyUser.getRole());
-        assertNull(emptyUser.getFavoriteChallenges());
         assertNull(emptyUser.getBookmarkChallenges());
         assertEquals(0, emptyUser.getPoints());
     }
 
     @Test
     void allArgsConstructor() {
-        UserDocument user = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user = new UserDocument(uuid, username, role, bookmarkChallenges, points);
         assertNotNull(user);
         assertEquals(uuid, user.getUuid());
         assertEquals(username, user.getUsername());
         assertEquals(role, user.getRole());
-        assertEquals(favoriteChallenges, user.getFavoriteChallenges());
         assertEquals(bookmarkChallenges, user.getBookmarkChallenges());
         assertEquals(points, user.getPoints());
     }
 
     @Test
     void equalsAndHashCode() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user1 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
 
         assertEquals(user1, user2);
         assertEquals(user1.hashCode(), user2.hashCode());
@@ -140,7 +126,6 @@ class UserDocumentTest {
         assertTrue(toString.contains(uuid.toString()), "ToString should contain UUID");
         assertTrue(toString.contains(username), "ToString should contain username");
         assertTrue(toString.contains(role.toString()), "ToString should contain role");
-        assertTrue(toString.contains(favoriteChallenge.toString()), "ToString should contain favorite challenge");
         assertTrue(toString.contains(bookmarkChallenge.toString()), "ToString should contain bookmark challenge");
         assertTrue(toString.contains(points.toString()), "ToString should contain points");
     }
@@ -157,7 +142,7 @@ class UserDocumentTest {
 
     @Test
     void equalsAndHashCodeWithDifferentUUIDs() {
-        UserDocument differentUser = new UserDocument(UUID.randomUUID(), username, role, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument differentUser = new UserDocument(UUID.randomUUID(), username, role, bookmarkChallenges, points);
 
         assertNotEquals(userDocument, differentUser);
         assertNotEquals(userDocument.hashCode(), differentUser.hashCode());
@@ -165,7 +150,7 @@ class UserDocumentTest {
 
     @Test
     void equalsAndHashCodeWithDifferentUsernames() {
-        UserDocument sameUuidDifferentUsername = new UserDocument(uuid, "differentUser", Role.USER, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument sameUuidDifferentUsername = new UserDocument(uuid, "differentUser", Role.USER, bookmarkChallenges, points);
 
         assertNotEquals(userDocument, sameUuidDifferentUsername);
         assertNotEquals(userDocument.hashCode(), sameUuidDifferentUsername.hashCode());
@@ -173,18 +158,16 @@ class UserDocumentTest {
 
     @Test
     void equalsAndHashCodeWithNullFields() {
-        UserDocument userWithNullUuid = new UserDocument(null, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument userWithNullUsername = new UserDocument(uuid, null, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument userWithNullRole = new UserDocument(uuid, username, null, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument userWithNullFavoriteChallenges = new UserDocument(uuid, username, role, null, bookmarkChallenges, points);
-        UserDocument userWithNullBookmarkChallenges = new UserDocument(uuid, username, role, favoriteChallenges, null, points);
-        UserDocument userWithNullPoints = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, 0);
-        UserDocument completelyNullUser = new UserDocument(null, null, null, null, null, 0);
+        UserDocument userWithNullUuid = new UserDocument(null, username, role, bookmarkChallenges, points);
+        UserDocument userWithNullUsername = new UserDocument(uuid, null, role, bookmarkChallenges, points);
+        UserDocument userWithNullRole = new UserDocument(uuid, username, null, bookmarkChallenges, points);
+        UserDocument userWithNullBookmarkChallenges = new UserDocument(uuid, username, role, null, points);
+        UserDocument userWithNullPoints = new UserDocument(uuid, username, role, bookmarkChallenges, 0);
+        UserDocument completelyNullUser = new UserDocument(null, null, null,  null, 0);
 
         assertNotEquals(userDocument, userWithNullUuid);
         assertNotEquals(userDocument, userWithNullUsername);
         assertNotEquals(userDocument, userWithNullRole);
-        assertNotEquals(userDocument, userWithNullFavoriteChallenges);
         assertNotEquals(userDocument, userWithNullBookmarkChallenges);
         assertEquals(userDocument, userWithNullPoints);
         assertNotEquals(userDocument, completelyNullUser);
@@ -192,7 +175,6 @@ class UserDocumentTest {
         assertNotEquals(userDocument.hashCode(), userWithNullUuid.hashCode());
         assertNotEquals(userDocument.hashCode(), userWithNullUsername.hashCode());
         assertNotEquals(userDocument.hashCode(), userWithNullRole.hashCode());
-        assertNotEquals(userDocument.hashCode(), userWithNullFavoriteChallenges.hashCode());
         assertNotEquals(userDocument.hashCode(), userWithNullBookmarkChallenges.hashCode());
         assertEquals(userDocument.hashCode(), userWithNullPoints.hashCode());
         assertNotEquals(userDocument.hashCode(), completelyNullUser.hashCode());
@@ -211,8 +193,8 @@ class UserDocumentTest {
 
     @Test
     void equalsConsistencyTest() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user1 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
 
         assertEquals(user1, user2);
         assertEquals(user1, user2); // Repeated check for consistency
@@ -226,9 +208,9 @@ class UserDocumentTest {
 
     @Test
     void equalsTransitivityTest() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user3 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user1 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
+        UserDocument user3 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
 
         assertEquals(user1, user2);
         assertEquals(user2, user3);
@@ -237,8 +219,8 @@ class UserDocumentTest {
 
     @Test
     void equalsSymmetryTest() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user1 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
 
         assertEquals(user1, user2);
         assertEquals(user2, user1);
@@ -246,24 +228,24 @@ class UserDocumentTest {
 
     @Test
     void hashCodeEqualityForEqualObjects() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user1 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
 
         assertEquals(user1.hashCode(), user2.hashCode());
     }
 
     @Test
     void hashCodeDifferenceForNonEqualObjects() {
-        UserDocument user1 = new UserDocument(UUID.randomUUID(), "user1", Role.ADMIN, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(UUID.randomUUID(), "user2", Role.ADMIN, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user1 = new UserDocument(UUID.randomUUID(), "user1", Role.ADMIN, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(UUID.randomUUID(), "user2", Role.ADMIN, bookmarkChallenges, points);
 
         assertNotEquals(user1.hashCode(), user2.hashCode());
     }
 
     @Test
     void equalsWithNullAttributes() {
-        UserDocument user1 = new UserDocument(null, null, null, null, null, 0);
-        UserDocument user2 = new UserDocument(null, null, null, null, null, 0);
+        UserDocument user1 = new UserDocument(null, null, null, null, 0);
+        UserDocument user2 = new UserDocument(null, null, null, null, 0);
 
         assertEquals(user1, user2);
         assertEquals(user1.hashCode(), user2.hashCode());
@@ -271,8 +253,8 @@ class UserDocumentTest {
 
     @Test
     void equalsWithOneNullUuid() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(null, username, role, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user1 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(null, username, role, bookmarkChallenges, points);
 
         assertNotEquals(user1, user2);
         assertNotEquals(user1.hashCode(), user2.hashCode());
@@ -280,8 +262,8 @@ class UserDocumentTest {
 
     @Test
     void equalsWithOneNullUsername() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(uuid, null, role, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user1 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(uuid, null, role, bookmarkChallenges, points);
 
         assertNotEquals(user1, user2);
         assertNotEquals(user1.hashCode(), user2.hashCode());
@@ -289,26 +271,18 @@ class UserDocumentTest {
 
     @Test
     void equalsWithOneNullRole() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(uuid, username, null, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user1 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(uuid, username, null, bookmarkChallenges, points);
 
         assertNotEquals(user1, user2);
         assertNotEquals(user1.hashCode(), user2.hashCode());
     }
 
-    @Test
-    void equalsWithOneNullFavoriteChallenges() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(uuid, username, role, null, bookmarkChallenges, points);
-
-        assertNotEquals(user1, user2);
-        assertNotEquals(user1.hashCode(), user2.hashCode());
-    }
 
     @Test
     void equalsWithOneNullBookmarkChallenges() {
-        UserDocument user1 = new UserDocument(uuid, username, role, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(uuid, username, role, favoriteChallenges, null, points);
+        UserDocument user1 = new UserDocument(uuid, username, role, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(uuid, username, role, null, points);
 
         assertNotEquals(user1, user2);
         assertNotEquals(user1.hashCode(), user2.hashCode());
@@ -316,14 +290,13 @@ class UserDocumentTest {
 
     @Test
     void toStringHandlesNullValues() {
-        UserDocument user = new UserDocument(null, null, null, null, null, 0);
+        UserDocument user = new UserDocument(null, null, null, null, 0);
         String toString = user.toString();
 
         assertTrue(toString.contains("UserDocument"), "ToString should contain class name");
         assertFalse(toString.contains("uuid="), "ToString should not contain 'uuid=' when null");
         assertFalse(toString.contains("username="), "ToString should not contain 'username=' when null");
         assertFalse(toString.contains("role="), "ToString should not contain 'role=' when null");
-        assertFalse(toString.contains("favoriteChallenges="), "ToString should not contain 'favoriteChallenges=' when null");
         assertFalse(toString.contains("bookmarkChallenges="), "ToString should not contain 'bookmarkChallenges=' when null");
         assertFalse(toString.contains("points="), "ToString should not contain 'points=' when null");
         assertEquals("UserDocument{}", toString, "ToString should return an empty object representation");
@@ -336,7 +309,6 @@ class UserDocumentTest {
                 .uuid(null)
                 .username(null)
                 .role(null)
-                .favoriteChallenges(null)
                 .bookmarkChallenges(null)
                 .points(0)
                 .build();
@@ -345,7 +317,6 @@ class UserDocumentTest {
         assertNull(user.getUuid());
         assertNull(user.getUsername());
         assertNull(user.getRole());
-        assertNull(user.getFavoriteChallenges());
         assertNull(user.getBookmarkChallenges());
         assertEquals(0, user.getPoints());
     }
@@ -355,22 +326,20 @@ class UserDocumentTest {
         userDocument.setUuid(null);
         userDocument.setUsername(null);
         userDocument.setRole(null);
-        userDocument.setFavoriteChallenges(null);
         userDocument.setBookmarkChallenges(null);
         userDocument.setPoints(null);
 
         assertNull(userDocument.getUuid());
         assertNull(userDocument.getUsername());
         assertNull(userDocument.getRole());
-        assertNull(userDocument.getFavoriteChallenges());
         assertNull(userDocument.getBookmarkChallenges());
         assertNull(userDocument.getPoints());
     }
 
     @Test
     void hashCodeDifferentForDifferentObjects() {
-        UserDocument user1 = new UserDocument(UUID.randomUUID(), "UserA", Role.ADMIN, favoriteChallenges, bookmarkChallenges, points);
-        UserDocument user2 = new UserDocument(UUID.randomUUID(), "UserB", Role.ADMIN, favoriteChallenges, bookmarkChallenges, points);
+        UserDocument user1 = new UserDocument(UUID.randomUUID(), "UserA", Role.ADMIN, bookmarkChallenges, points);
+        UserDocument user2 = new UserDocument(UUID.randomUUID(), "UserB", Role.ADMIN, bookmarkChallenges, points);
 
         assertNotEquals(user1.hashCode(), user2.hashCode());
     }
@@ -412,19 +381,6 @@ class UserDocumentTest {
     }
 
     @Test
-    void builderHandlesOnlyFavoriteChallenges() {
-        UserDocument user = UserDocument.builder()
-                .favoriteChallenges(favoriteChallenges)
-                .build();
-
-        assertNotNull(user);
-        assertNull(user.getUuid());
-        assertNull(user.getUsername());
-        assertNull(user.getRole());
-        assertEquals(favoriteChallenges, user.getFavoriteChallenges());
-    }
-
-    @Test
     void builderHandlesOnlyBookmarkChallenges() {
         UserDocument user = UserDocument.builder()
                 .bookmarkChallenges(bookmarkChallenges)
@@ -453,12 +409,10 @@ class UserDocumentTest {
     @Test
     void builderCreatesNewInstances() {
         UserDocument user1 = UserDocument.builder().uuid(uuid).username(username).role(role)
-                .favoriteChallenges(favoriteChallenges)
                 .bookmarkChallenges(bookmarkChallenges)
                 .build();
 
         UserDocument user2 = UserDocument.builder().uuid(uuid).username(username).role(role)
-                .favoriteChallenges(favoriteChallenges)
                 .bookmarkChallenges(bookmarkChallenges)
                 .build();
 
@@ -474,19 +428,16 @@ class UserDocumentTest {
         assertNull(user.getUuid());
         assertNull(user.getUsername());
         assertNull(user.getRole());
-        assertNull(user.getFavoriteChallenges());
         assertNull(user.getBookmarkChallenges());
     }
 
     @Test
     void modifyingBuiltObjectDoesNotAffectOriginalBuilder() {
         UserDocument.UserDocumentBuilder builder = UserDocument.builder().uuid(uuid).username(username).role(role)
-                .favoriteChallenges(favoriteChallenges)
                 .bookmarkChallenges(bookmarkChallenges);
 
         UserDocument user1 = builder.build();
         UserDocument user2 = builder.uuid(UUID.randomUUID()).username("newUser").role(Role.USER)
-                .favoriteChallenges(new HashSet<>())
                 .bookmarkChallenges(new HashSet<>())
                 .build();
 
@@ -494,7 +445,6 @@ class UserDocumentTest {
         assertNotEquals(user1.getUuid(), user2.getUuid());
         assertNotEquals(user1.getUsername(), user2.getUsername());
         assertNotEquals(user1.getRole(), user2.getRole());
-        assertNotEquals(user1.getFavoriteChallenges(), user2.getFavoriteChallenges());
         assertNotEquals(user1.getBookmarkChallenges(), user2.getBookmarkChallenges());
     }
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -16,7 +16,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -33,10 +32,8 @@ class UserServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
-
     @Mock
     private FavoriteRepository favoriteRepository;
-
 
     @InjectMocks
     private UserServiceImpl userService;
@@ -58,7 +55,7 @@ class UserServiceImplTest {
     @Test
     void getUser_ShouldReturnUser_WhenUserExists() {
         String username = "existingUser";
-        UserDocument existingUser = new UserDocument(UUID.randomUUID(), username, Role.ADMIN, null, null, 0);
+        UserDocument existingUser = new UserDocument(UUID.randomUUID(), username, Role.ADMIN, null, 0);
         when(userRepository.findByUsername(username)).thenReturn(Mono.just(existingUser));
 
         StepVerifier.create(userService.getUser(username))
@@ -87,7 +84,7 @@ class UserServiceImplTest {
     void addChallengeToFavorites_ShouldReturnTrue_WhenFavoriteDoesNotExist() {
         UUID userId = UUID.randomUUID();
         UUID challengeId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, new HashSet<>(), null, 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, null, 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(favoriteRepository.existsByUserIdAndChallengeId(userId, challengeId))
@@ -109,7 +106,7 @@ class UserServiceImplTest {
     void addChallengeToBookmarks_ShouldReturnTrue_WhenBookmarksIsNull() {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, null, null, 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, null, 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(userRepository.save(user)).thenReturn(Mono.just(user));
@@ -129,7 +126,7 @@ class UserServiceImplTest {
     void addChallengeToBookmarks_ShouldReturnTrue_WhenBookmarksIsEmpty() {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, null, new HashSet<>(), 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, new HashSet<>(), 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(userRepository.save(user)).thenReturn(Mono.just(user));
@@ -150,7 +147,7 @@ class UserServiceImplTest {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Set<UUID> bookmarks = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID()));
-        UserDocument user = new UserDocument(userId, "testUser", null, null, bookmarks, 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, bookmarks, 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(userRepository.save(user)).thenReturn(Mono.just(user));
@@ -170,8 +167,7 @@ class UserServiceImplTest {
     void addChallengeToFavorites_ShouldReturnFalse_WhenFavoriteAlreadyExists() {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        Set<UUID> favorites = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID(), challengeId));
-        UserDocument user = new UserDocument(userId, "testUser", null, favorites, null, 0);
+        UserDocument user = new UserDocument(userId, "testUser", null,null, 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(favoriteRepository.existsByUserIdAndChallengeId(userId, challengeId))
@@ -180,9 +176,6 @@ class UserServiceImplTest {
         StepVerifier.create(userService.addChallengeToFavorites(userId.toString(), challengeId.toString()))
                 .expectNext(false)
                 .verifyComplete();
-
-        assertNotNull(user.getFavoriteChallenges());
-        assertTrue(user.getFavoriteChallenges().contains(challengeId));
 
         verify(userRepository, times(1)).findById(userId);
         verify(favoriteRepository, times(1)).existsByUserIdAndChallengeId(userId, challengeId);
@@ -194,7 +187,7 @@ class UserServiceImplTest {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Set<UUID> bookmarks = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID(), challengeId));
-        UserDocument user = new UserDocument(userId, "testUser", null, null, bookmarks, 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, bookmarks, 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
 
@@ -373,7 +366,7 @@ class UserServiceImplTest {
     void deleteChallengeFromFavorites_ShouldReturnFalse_WhenFavoriteDoesNotExist() {
         UUID userId = UUID.randomUUID();
         UUID challengeId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, null, null, 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, null, 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(favoriteRepository.findByUserIdAndChallengeId(any(UUID.class), any(UUID.class)))
@@ -392,7 +385,7 @@ class UserServiceImplTest {
     void deleteChallengeFromBookmarks_ShouldReturnFalse_WhenBookmarksIsNull() {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, null, null, 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, null, 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
 
@@ -410,7 +403,7 @@ class UserServiceImplTest {
     void deleteChallengeFromBookmarks_ShouldReturnFalse_WhenBookmarksIsEmpty() {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, null, new HashSet<>(), 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, new HashSet<>(), 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
 
@@ -430,7 +423,7 @@ class UserServiceImplTest {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Set<UUID> bookmarks = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID()));
-        UserDocument user = new UserDocument(userId, "testUser", null, null, bookmarks, 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, bookmarks, 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
 
@@ -450,7 +443,7 @@ class UserServiceImplTest {
         // Arrange
         UUID userId = UUID.randomUUID();
         UUID challengeId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, null, null, 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, null, 0);
         FavoriteDocument favorite = new FavoriteDocument(UUID.randomUUID(), userId, challengeId, LocalDateTime.now());
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
@@ -474,7 +467,7 @@ class UserServiceImplTest {
         UUID challengeId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         Set<UUID> bookmarks = new HashSet<>(Set.of(UUID.randomUUID(), UUID.randomUUID(), challengeId));
-        UserDocument user = new UserDocument(userId, "testUser", null, null, bookmarks, 0);
+        UserDocument user = new UserDocument(userId, "testUser", null, bookmarks, 0);
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
         when(userRepository.save(user)).thenReturn(Mono.just(user));
@@ -653,7 +646,6 @@ class UserServiceImplTest {
 
         UserDocument user = new UserDocument();
         user.setUuid(userId);
-        user.setFavoriteChallenges(null); // explícitely null
 
         when(userRepository.findById(userId)).thenReturn(Mono.just(user));
 
@@ -696,7 +688,7 @@ class UserServiceImplTest {
     void getUserById_ShouldReturnUser_WhenUserExists() {
         String username = "existingUser";
         UUID userId=UUID.randomUUID();
-        UserDocument existingUser = new UserDocument(userId, username, Role.ADMIN, null, null, 0);
+        UserDocument existingUser = new UserDocument(userId, username, Role.ADMIN, null, 0);
         when(userRepository.findById(userId)).thenReturn(Mono.just(existingUser));
         
         StepVerifier.create(userService.getUserById(userId.toString()))


### PR DESCRIPTION
### 🧩 Summary 

Task [856:](https://tree.taiga.io/project/luisvi-ita-challenges/task/856) Delete favorites field from UserDocument

This PR corresponds to Task [856:](https://tree.taiga.io/project/luisvi-ita-challenges/task/856)  and represents the final cleanup step in the Favorites refactoring initiative.
It removes all legacy favorites references from the UserDocument and related files, ensuring that favorites data is now fully managed by the new user-interactions module.

It follows the work completed in:
Task 840 – Create Favorite documents and repositories [PR1/5](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1018)
Task 841 – Implement Favorite services [PR2/5](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1021)
Task 842 – Implement Favorite controller (GET endpoint) [PR3/5](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1019)
Task 843 – Integration tests and documentation updates [PR4/5](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1020)

 With this change, the user microservice is now cleanly decoupled from the favorites domain.

------------
### 🔑 Key Changes
1. UserDocument Cleanup
- Removed the legacy favorites field from UserDocument.java
- Deleted all related annotations and persistence mappings (@Field("favorites"), lists, or embedded documents)
- Updated constructors, equals/hashCode, and toString methods accordingly

2. Codebase Adjustments

Removed all references to favorites from:
- UserService 
- Ensured all GetFavorites logic now lives exclusively in the user-interactions module

3. Testing & Validation
- Updated and validated unit + integration tests
- Confirmed successful application startup and service behavior
- Verified that GET /users/{userId}/favorites endpoint continues to function correctly through the new FavoriteController
- SonarQube/SonarCloud validation passed with no new issues or code smells

As seen in the screenshot below, besides the UserDocument and the UserDocumentTest, 3 other test classes had to be modified. In these classes, in order to simulate a user, UserDocument has to been instanciated and therefore were using the favorite field in the constructor. This has to be removed. 

example in [UserControllerTest.java]

<img width="911" height="177" alt="image" src="https://github.com/user-attachments/assets/0335c7fe-c70d-4074-94c9-57b6d3135337" />


------

### 🗂️ Modified Files

- UserDocument
- UserDocumentTest
- UserServiceImplTest
- UserControllerTest

-------- 

### ✅ Outcomes

- favorites field fully removed from User domain
- GetFavorites logic fully delegated to FavoriteService and the new favorites collection (POST AND DELETE still in userService even if they are already calling favoriteService)
- No functional or API contract changes for the frontend

---------------
### 💡 Notes

This PR completes the Favorites decoupling initiative started in user story #795.
All references to favorites are now centralized under user-interactions, paving the way for the upcoming itachallenge-interactions microservice.

No data migration or transformation is included here — this was handled in Task 848.

------

### 🧾 Changelog

Updated Changelog

-----

### ✅ PR Author Self-Check

- [x]  favorites field removed from UserDocument
- [x] Codebase references cleaned up
- [x] Application compiles and tests pass locally and remotely
- [x] SonarQube/SonarCloud analysis passes with no new issues
- [x] API behavior unchanged
- [x] Documentation updated
- [x] Code follows project conventions and formatting rules