### PR TITLE
PR1/5 - refactor(submission) move document and repository to new microservice (#882) (OLD)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/submission/document/SubmissionAttemptDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/submission/document/SubmissionAttemptDocument.java
@@ -1,0 +1,23 @@
+package com.itachallenge.submission.document;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class SubmissionAttemptDocument {
+
+    @Id
+    @Field(name="id_submission")
+    private UUID uuid;
+
+    @Field(name="submission_text")
+    private String submissionText;
+
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/submission/document/SubmissionDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/submission/document/SubmissionDocument.java
@@ -1,0 +1,37 @@
+package com.itachallenge.submission.document;
+
+import com.itachallenge.submission.enums.ChallengeStatus;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.util.UUID;
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@Document(collection="submissions")
+public class SubmissionDocument {
+
+    @Id
+    @Field("_id")
+    private UUID uuid;
+
+    @Field("user_id")
+    private UUID userId;
+
+    @Field("challenge_id")
+    private UUID challengeId;
+
+    @Field("language_id")
+    private UUID languageId;
+
+    @Field("status")
+    private ChallengeStatus status;
+
+    @Field("submission")
+    private SubmissionAttemptDocument submissionAttemptDocument;
+
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/submission/document/UserSubmissionDocument.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/submission/document/UserSubmissionDocument.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @Document(collection="submissions")
-public class SubmissionDocument {
+public class UserSubmissionDocument {
 
     @Id
     @Field("_id")

--- a/itachallenge-challenge/src/main/java/com/itachallenge/submission/enums/ChallengeStatus.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/submission/enums/ChallengeStatus.java
@@ -1,0 +1,30 @@
+package com.itachallenge.submission.enums;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum ChallengeStatus {
+    SUBMITTED_COMPLETE("SUBMITTED_COMPLETE"),
+    IN_PROGRESS("IN_PROGRESS"),
+    SUBMITTED_INCOMPLETE("SUBMITTED_INCOMPLETE");
+
+    private final String value;
+
+    ChallengeStatus(String value) {
+        this.value = value;
+    }
+
+    public static ChallengeStatus challengeStatusFromString(String status) {
+        ChallengeStatus output = null;
+        if (status != null) {
+            output = Arrays.stream(ChallengeStatus.values())
+                    .filter(s -> status.equalsIgnoreCase(s.getValue()))
+                    .findFirst()
+                    .orElse(null);
+        }
+        return output;
+    }
+
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/submission/repository/ISubmissionRepository.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/submission/repository/ISubmissionRepository.java
@@ -1,6 +1,6 @@
 package com.itachallenge.submission.repository;
 
-import com.itachallenge.submission.document.SubmissionDocument;
+import com.itachallenge.submission.document.UserSubmissionDocument;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
@@ -9,8 +9,8 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 @Repository
-public interface ISubmissionRepository extends ReactiveMongoRepository<SubmissionDocument, UUID> {
+public interface ISubmissionRepository extends ReactiveMongoRepository<UserSubmissionDocument, UUID> {
 
-    Mono<SubmissionDocument> findByUserIdAndChallengeIdAndLanguageId(UUID userId, UUID challengeId, UUID languageId);
-    Flux<SubmissionDocument> findAllByUserId(UUID userId);
+    Mono<UserSubmissionDocument> findByUserIdAndChallengeIdAndLanguageId(UUID userId, UUID challengeId, UUID languageId);
+    Flux<UserSubmissionDocument> findAllByUserId(UUID userId);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/submission/repository/ISubmissionRepository.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/submission/repository/ISubmissionRepository.java
@@ -1,0 +1,16 @@
+package com.itachallenge.submission.repository;
+
+import com.itachallenge.submission.document.SubmissionDocument;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Repository
+public interface ISubmissionRepository extends ReactiveMongoRepository<SubmissionDocument, UUID> {
+
+    Mono<SubmissionDocument> findByUserIdAndChallengeIdAndLanguageId(UUID userId, UUID challengeId, UUID languageId);
+    Flux<SubmissionDocument> findAllByUserId(UUID userId);
+}


### PR DESCRIPTION
🎯 Summary

This PR corresponds to **[[Task 872](https://tree.taiga.io/project/luisvi-ita-challenges/task/872)]** 

🛑 Problem

The **User microservice** has attached functionalities that, after a detailed study, have been found not to be correctly defined, such as **User Solutions**.

🧠 Solution

The Task is a first step of a broader refactor aimed at decoupling **Solutions** logic from the User microservice and move to **Challenge microservice**. The goal of this step is to establish the domain, persistence layer, and base structure for the future **Solutions** service in **Challenge microservice**.

In the past, official and user solutions were often given the same name. Therefore, we're taking advantage of this location change to also make a name change. From now on, official solutions will be called Solutions, and user solutions will be renamed Submission.

🔹This task is the first of a serie of 5:

[#882](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/882) [BE] PR 1/5 - Create"Submissions" documents and repositories : preparation phase : THIS PR

[#883](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/883) [BE] PR 2/5 - Implement "SubmissionService"

[#884](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/884) [BE] PR 3/5 - Implement "SubmissionController"

[#885](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/885) [BE] PR4/5 - Delete field Solutions from the UserDocument

[#886](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/886) [BE] PR 5/5 - Integration tests + Documentation update

🔄 Changelog:

- Added the UserSubmission domain and persistence layer.
- Created UserSubmissionDocument under com.itachallenge.submission.document
- Implemented SubmissionRepository using ReactiveMongoRepository.

For now, the GET endpoint continues to rely on the user Solutions field within UserDocument.

🔄 Created or Modified files

🔹Documents:

com.itachallenge.submission.document.SubmissionAttemptDocument
com.itachallenge.submission.document.UserSubmissionDocument


🔹Repository:

com.itachallenge.submission.repository.ISubmissionRepository

✅PR Author Self-Check

 New UserSubmissionDocument entity created under the challenge.submission collection.
 SubmissionRepository created.
 Code follows agreed-upon project conventions (naming, formatting, Sonar rules).
 All tests pass locally and in the development environment.
 SonarQube/SonarCloud analysis passes with no new issues or code smells.