### PR TITLE
Refactor(favorite): PR 2/3 - Move logic for DELETE to new Favorite structure (#918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 
 ### Changed
 - [Changed] Refactored the logic for adding favorites to integrate it into the FavoriteService structure (Taiga [#917], PR [#1052])
+- [Changed] Refactored the logic for adding favorites to integrate it into the FavoriteService structure (Taiga [#918], PR [#1053])
 
 ### Chore/Internal
 - Introduced `SolutionAction` enum (internal change)

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -243,60 +243,6 @@ public class UserController {
     }
 
     @Operation(
-            summary = "Delete Challenge from User Favorite Challenges",
-            description = "Deletes challenge from user favorites",
-            parameters = {
-                    @Parameter(
-                            name = "userId",
-                            description = "User ID",
-                            required = true,
-                            in = ParameterIn.PATH
-                    ),
-                    @Parameter(
-                            name = "challengeId",
-                            description = "Challenge ID",
-                            required = true,
-                            in = ParameterIn.PATH
-                    )
-            },
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "Challenge deleted from favorites or was not in favorites",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "Bad Request. The provided IDs have a bad format",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "Not found. No user is found with the provided user id.",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "Internal server error. An unexpected error occurred.",
-                            content = @Content(mediaType = "application/json")
-                    )
-            }
-    )
-    @DeleteMapping("/users/{userId}/favorites/{challengeId}")
-    public Mono<ResponseEntity<Boolean>> deleteFromFavorites(@PathVariable String userId, @PathVariable String challengeId) {
-        return userService.deleteChallengeFromFavorites(userId, challengeId)
-                .map(deleted -> {
-                    if (Boolean.TRUE.equals(deleted)) {
-                        log.info("Challenge '{}' deleted from user '{}' favorites", challengeId, userId);
-                        return ResponseEntity.ok().body(true);
-                    } else {
-                        log.info("No change, User's '{}' favorites doesn't contain Challenge '{}'", userId, challengeId);
-                        return ResponseEntity.ok().body(false);
-                    }
-                });
-    }
-
-    @Operation(
             summary = "Delete Challenge from User Bookmark Challenges",
             description = "Deletes challenge from user bookmarks",
             parameters = {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteController.java
@@ -4,6 +4,7 @@ import com.itachallenge.userinteraction.service.favorite.FavoriteService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +51,60 @@ public class FavoriteController {
                 .map(favorites -> {
                     log.info("Retrieved {} favorite challenges for user {}", favorites.size(), userId);
                     return ResponseEntity.ok(favorites);
+                });
+    }
+
+    @Operation(
+            summary = "Delete Challenge from User Favorite Challenges",
+            description = "Deletes challenge from user favorites",
+            parameters = {
+                    @Parameter(
+                            name = "userId",
+                            description = "User ID",
+                            required = true,
+                            in = ParameterIn.PATH
+                    ),
+                    @Parameter(
+                            name = "challengeId",
+                            description = "Challenge ID",
+                            required = true,
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Challenge deleted from favorites or was not in favorites",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Bad Request. The provided IDs have a bad format",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Not found. No user is found with the provided user id.",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "Internal server error. An unexpected error occurred.",
+                            content = @Content(mediaType = "application/json")
+                    )
+            }
+    )
+    @DeleteMapping("/users/{userId}/favorites/{challengeId}")
+    public Mono<ResponseEntity<Boolean>> deleteFromFavorites(@PathVariable String userId, @PathVariable String challengeId) {
+        return favoriteService.deleteChallengeFromFavorites(userId, challengeId)
+                .map(deleted -> {
+                    if (Boolean.TRUE.equals(deleted)) {
+                        log.info("Challenge '{}' deleted from user '{}' favorites", challengeId, userId);
+                        return ResponseEntity.ok().body(true);
+                    } else {
+                        log.info("No change, User's '{}' favorites doesn't contain Challenge '{}'", userId, challengeId);
+                        return ResponseEntity.ok().body(false);
+                    }
                 });
     }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserService.java
@@ -8,8 +8,6 @@ public interface UserService {
 
     Mono<Boolean> addChallengeToBookmarks(String userId, String challengeId);
 
-    Mono<Boolean> deleteChallengeFromFavorites(String userId, String challengeId);
-
     Mono<Boolean> deleteChallengeFromBookmarks(String userId, String challengeId);
 
     Mono<UserDocument> getUserById(String userId);

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -7,7 +7,6 @@ import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;
 import org.springframework.stereotype.Service;
 
-import com.itachallenge.userinteraction.repository.favorite.FavoriteRepository;
 import com.itachallenge.userinteraction.repository.bookmark.BookmarkRepository;
 import reactor.core.publisher.Mono;
 
@@ -17,12 +16,10 @@ import java.util.UUID;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
-    private final FavoriteRepository favoriteRepository;
     private final BookmarkRepository bookmarkRepository;
 
-    public UserServiceImpl(UserRepository userRepository, FavoriteRepository favoriteRepository, BookmarkRepository bookmarkRepository) {
+    public UserServiceImpl(UserRepository userRepository, BookmarkRepository bookmarkRepository) {
         this.userRepository = userRepository;
-        this.favoriteRepository = favoriteRepository;
         this.bookmarkRepository = bookmarkRepository;
     }
 
@@ -43,20 +40,6 @@ public class UserServiceImpl implements UserService {
                     return userRepository.findById(userUuid)
                             .switchIfEmpty(Mono.error(new NotFoundException("User not found")))
                             .flatMap(user -> addToBookmarks(userUuid, challengeUuid));
-                });
-    }
-
-    //TODO : TO IMPLEMENT IN FAVORITE SERVICE IMPL
-    @Override
-    public Mono<Boolean> deleteChallengeFromFavorites(String userId, String challengeId) {
-        return Mono.zip(parseAndValidateUUID(userId), parseAndValidateUUID(challengeId))
-                .flatMap(uuidTuple -> {
-                    UUID userUuid = uuidTuple.getT1();
-                    UUID challengeUuid = uuidTuple.getT2();
-
-                    return userRepository.findById(userUuid)
-                            .switchIfEmpty(Mono.error(new NotFoundException("User not found")))
-                            .flatMap(user -> deleteFromFavorites(userUuid, challengeUuid));
                 });
     }
 
@@ -89,16 +72,6 @@ public class UserServiceImpl implements UserService {
                     return bookmarkRepository.save(bookmark)
                             .thenReturn(true);
                 });
-    }
-
-    //TODO : TO IMPLEMENT IN FAVORITE SERVICE IMPL
-    private Mono<Boolean> deleteFromFavorites(UUID userId, UUID challengeUuid) {
-        return favoriteRepository.findByUserIdAndChallengeId(userId, challengeUuid)
-                .flatMap(favorite ->
-                        favoriteRepository.delete(favorite)
-                                .then(Mono.just(true))
-                )
-                .switchIfEmpty(Mono.just(false));
     }
 
     //TODO : TO IMPLEMENT TO BOOKMARK SERVICE IMPL

--- a/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/favorite/FavoriteService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/favorite/FavoriteService.java
@@ -9,4 +9,6 @@ public interface FavoriteService {
     Mono<Boolean> addChallengeToFavorites(String userId, String challengeId);
 
     Mono<Set<UUID>> getUserFavorites(String userId);
+
+    Mono<Boolean> deleteChallengeFromFavorites(String userId, String challengeId);
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImpl.java
@@ -81,4 +81,26 @@ public class FavoriteServiceImpl implements FavoriteService {
                                 })
                 );
     }
+
+    @Override
+    public Mono<Boolean> deleteChallengeFromFavorites(String userId, String challengeId) {
+        return Mono.zip(parseAndValidateUUID(userId), parseAndValidateUUID(challengeId))
+                .flatMap(uuidTuple -> {
+                    UUID userUuid = uuidTuple.getT1();
+                    UUID challengeUuid = uuidTuple.getT2();
+
+                    return userRepository.findById(userUuid)
+                            .switchIfEmpty(Mono.error(new NotFoundException("User not found")))
+                            .flatMap(user -> deleteFromFavorites(userUuid, challengeUuid));
+                });
+    }
+
+    private Mono<Boolean> deleteFromFavorites(UUID userId, UUID challengeUuid) {
+        return favoriteRepository.findByUserIdAndChallengeId(userId, challengeUuid)
+                .flatMap(favorite ->
+                        favoriteRepository.delete(favorite)
+                                .then(Mono.just(true))
+                )
+                .switchIfEmpty(Mono.just(false));
+    }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -271,22 +271,6 @@ class UserControllerTest {
     }
 
     @Test
-    void deleteFromFavorites_WhenDeleted_Returns200() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(userService.deleteChallengeFromFavorites(userId, challengeId))
-                .thenReturn(Mono.just(true));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.OK)
-                .expectBody(Boolean.class).isEqualTo(true);
-
-        verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
-    }
-
-    @Test
     void deleteFromBookmarks_WhenDeleted_Returns200() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
@@ -300,22 +284,6 @@ class UserControllerTest {
                 .expectBody(Boolean.class).isEqualTo(true);
 
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void deleteFromFavorites_WhenNotInFavorites_Returns200() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(userService.deleteChallengeFromFavorites(userId, challengeId))
-                .thenReturn(Mono.just(false));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(Boolean.class).isEqualTo(false);
-
-        verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
 
     @Test
@@ -335,22 +303,6 @@ class UserControllerTest {
     }
 
     @Test
-    void deleteFromFavorites_WhenUserNotExists_Returns404() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(userService.deleteChallengeFromFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new NotFoundException("User not found")));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
-
-        verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
-    }
-
-    @Test
     void deleteFromBookmarks_WhenUserNotExists_Returns404() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
@@ -367,22 +319,6 @@ class UserControllerTest {
     }
 
     @Test
-    void deleteFromFavorites_WhenBadFormattedId_Returns404() {
-        String userId = "invalidUuid";
-        String challengeId = "invalidUUid";
-        when(userService.deleteChallengeFromFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
-
-        verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
-    }
-
-    @Test
     void deleteFromBookmarks_WhenBadFormattedId_Returns404() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
@@ -396,22 +332,6 @@ class UserControllerTest {
                 .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
 
         verify(userService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void deleteFromFavorites_WhenUnexpectedError_Returns500() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(userService.deleteChallengeFromFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new Exception()));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
-
-        verify(userService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -89,5 +90,85 @@ class FavoriteControllerTest {
                 .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
 
         verify(favoriteService, times(1)).getUserFavorites(invalidUserId);
+    }
+
+    @Test
+    void deleteFromFavorites_WhenDeleted_Returns200() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(favoriteService.deleteChallengeFromFavorites(userId, challengeId))
+                .thenReturn(Mono.just(true));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.OK)
+                .expectBody(Boolean.class).isEqualTo(true);
+
+        verify(favoriteService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
+    }
+
+    @Test
+    void deleteFromFavorites_WhenNotInFavorites_Returns200() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(favoriteService.deleteChallengeFromFavorites(userId, challengeId))
+                .thenReturn(Mono.just(false));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(Boolean.class).isEqualTo(false);
+
+        verify(favoriteService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
+    }
+
+    @Test
+    void deleteFromFavorites_WhenUserNotExists_Returns404() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(favoriteService.deleteChallengeFromFavorites(userId, challengeId))
+                .thenReturn(Mono.error(new NotFoundException("User not found")));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
+                .expectBody(String.class).isEqualTo("User not found");
+
+        verify(favoriteService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
+    }
+
+    @Test
+    void deleteFromFavorites_WhenBadFormattedId_Returns404() {
+        String userId = "invalidUuid";
+        String challengeId = "invalidUUid";
+        when(favoriteService.deleteChallengeFromFavorites(userId, challengeId))
+                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+
+        verify(favoriteService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
+    }
+
+    @Test
+    void deleteFromFavorites_WhenUnexpectedError_Returns500() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(favoriteService.deleteChallengeFromFavorites(userId, challengeId))
+                .thenReturn(Mono.error(new Exception()));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+
+        verify(favoriteService, times(1)).deleteChallengeFromFavorites(userId, challengeId);
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -6,9 +6,7 @@ import com.itachallenge.user.exception.BadUUIDException;
 import com.itachallenge.user.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;
-import com.itachallenge.userinteraction.document.favorite.FavoriteDocument;
 import com.itachallenge.userinteraction.repository.bookmark.BookmarkRepository;
-import com.itachallenge.userinteraction.repository.favorite.FavoriteRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,9 +29,6 @@ class UserServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
-
-    @Mock
-    private FavoriteRepository favoriteRepository;
 
     @Mock
     private BookmarkRepository bookmarkRepository;
@@ -289,22 +284,6 @@ class UserServiceImplTest {
     }
 
     @Test
-    void deleteChallengeFromFavorites_ShouldThrowNotFoundException_WhenUserNotFound() {
-
-        when(userRepository.findById(any(UUID.class))).thenReturn(Mono.empty());
-
-        StepVerifier.create(userService.deleteChallengeFromFavorites(UUID.randomUUID().toString(), UUID.randomUUID().toString()))
-                .expectErrorSatisfies(throwable -> {
-                    assertInstanceOf(NotFoundException.class, throwable);
-                    assertEquals("User not found", throwable.getMessage());
-                })
-                .verify();
-
-        verify(userRepository, times(1)).findById(any(UUID.class));
-        verify(userRepository, times(0)).save(any());
-    }
-
-    @Test
     void deleteChallengeFromBookmarks_ShouldThrowNotFoundException_WhenUserNotFound() {
 
         when(userRepository.findById(any(UUID.class))).thenReturn(Mono.empty());
@@ -321,34 +300,8 @@ class UserServiceImplTest {
     }
 
     @Test
-    void deleteChallengeFromFavorites_ShouldThrowBadRequestException_WhenUserUuidIsNull() {
-        StepVerifier.create(userService.deleteChallengeFromFavorites(null, UUID.randomUUID().toString()))
-                .expectErrorSatisfies(throwable -> {
-                    assertInstanceOf(BadUUIDException.class, throwable);
-                    assertEquals("Invalid ID format", throwable.getMessage());
-                })
-                .verify();
-
-        verify(userRepository, times(0)).findById(any(UUID.class));
-        verify(userRepository, times(0)).save(any());
-    }
-
-    @Test
     void deleteChallengeFromBookmarks_ShouldThrowBadRequestException_WhenUserUuidIsNull() {
         StepVerifier.create(userService.deleteChallengeFromBookmarks(null, UUID.randomUUID().toString()))
-                .expectErrorSatisfies(throwable -> {
-                    assertInstanceOf(BadUUIDException.class, throwable);
-                    assertEquals("Invalid ID format", throwable.getMessage());
-                })
-                .verify();
-
-        verify(userRepository, times(0)).findById(any(UUID.class));
-        verify(userRepository, times(0)).save(any());
-    }
-
-    @Test
-    void deleteChallengeFromFavorites_ShouldThrowBadRequestException_WhenChallengeUuidIsNull() {
-        StepVerifier.create(userService.deleteChallengeFromFavorites(UUID.randomUUID().toString(), null))
                 .expectErrorSatisfies(throwable -> {
                     assertInstanceOf(BadUUIDException.class, throwable);
                     assertEquals("Invalid ID format", throwable.getMessage());
@@ -373,34 +326,8 @@ class UserServiceImplTest {
     }
 
     @Test
-    void deleteChallengeFromFavorites_ShouldThrowBadRequestException_WhenUserUuidIsNotValid() {
-        StepVerifier.create(userService.deleteChallengeFromFavorites("invalidUuid", UUID.randomUUID().toString()))
-                .expectErrorSatisfies(throwable -> {
-                    assertInstanceOf(BadUUIDException.class, throwable);
-                    assertEquals("Invalid ID format", throwable.getMessage());
-                })
-                .verify();
-
-        verify(userRepository, times(0)).findById(any(UUID.class));
-        verify(userRepository, times(0)).save(any());
-    }
-
-    @Test
     void deleteChallengeFromBookmarks_ShouldThrowBadRequestException_WhenUserUuidIsNotValid() {
         StepVerifier.create(userService.deleteChallengeFromBookmarks("invalidUuid", UUID.randomUUID().toString()))
-                .expectErrorSatisfies(throwable -> {
-                    assertInstanceOf(BadUUIDException.class, throwable);
-                    assertEquals("Invalid ID format", throwable.getMessage());
-                })
-                .verify();
-
-        verify(userRepository, times(0)).findById(any(UUID.class));
-        verify(userRepository, times(0)).save(any());
-    }
-
-    @Test
-    void deleteChallengeFromFavorites_ShouldThrowBadRequestException_WhenChallengeUuidIsNotValid() {
-        StepVerifier.create(userService.deleteChallengeFromFavorites(UUID.randomUUID().toString(), "invalidUuid"))
                 .expectErrorSatisfies(throwable -> {
                     assertInstanceOf(BadUUIDException.class, throwable);
                     assertEquals("Invalid ID format", throwable.getMessage());
@@ -452,52 +379,5 @@ class UserServiceImplTest {
                 })
                 .verify();
         verify(userRepository, times(1)).findById(userId);
-    }
-
-    @Test
-    void deleteChallengeFromFavorites_ShouldReturnFalse_WhenFavoriteDoesNotExist() {
-        UUID userId = UUID.randomUUID();
-        UUID challengeId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, 0);
-
-        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
-        when(favoriteRepository.findByUserIdAndChallengeId(any(UUID.class), any(UUID.class)))
-                .thenReturn(Mono.empty());
-
-        StepVerifier.create(userService.deleteChallengeFromFavorites(userId.toString(), challengeId.toString()))
-                .expectNext(false)
-                .verifyComplete();
-
-        verify(userRepository).findById(userId);
-        verify(favoriteRepository).findByUserIdAndChallengeId(any(UUID.class), any(UUID.class));
-        verify(favoriteRepository, never()).delete(any());
-    }
-
-    @Test
-    void deleteChallengeFromFavorites_ShouldReturnTrue_WhenFavoriteAlreadyExists() {
-        // Arrange
-        UUID userId = UUID.randomUUID();
-        UUID challengeId = UUID.randomUUID();
-        UserDocument user = new UserDocument(userId, "testUser", null, 0);
-        FavoriteDocument favorite = FavoriteDocument.builder()
-                .uuid(UUID.randomUUID())
-                .userId(userId)
-                .challengeId(challengeId)
-                .build();
-
-        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
-        when(favoriteRepository.findByUserIdAndChallengeId(userId, challengeId))
-                .thenReturn(Mono.just(favorite));
-        when(favoriteRepository.delete(any(FavoriteDocument.class))).thenReturn(Mono.empty());
-
-        // Act & Assert
-        StepVerifier.create(userService.deleteChallengeFromFavorites(userId.toString(), challengeId.toString()))
-                .expectNext(true)
-                .verifyComplete();
-
-        // Verify
-        verify(userRepository).findById(userId);
-        verify(favoriteRepository).findByUserIdAndChallengeId(userId, challengeId);
-        verify(favoriteRepository).delete(favorite);
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImplTest.java
@@ -278,4 +278,119 @@ class FavoriteServiceImplTest {
         verify(userRepository, times(1)).existsById(userId);
         verify(favoriteRepository, times(1)).findByUserId(userId);
     }
+
+    @Test
+    void deleteChallengeFromFavorites_ShouldThrowNotFoundException_WhenUserNotFound() {
+
+        when(userRepository.findById(any(UUID.class))).thenReturn(Mono.empty());
+
+        StepVerifier.create(favoriteService.deleteChallengeFromFavorites(UUID.randomUUID().toString(), UUID.randomUUID().toString()))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(NotFoundException.class, throwable);
+                    assertEquals("User not found", throwable.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(1)).findById(any(UUID.class));
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    void deleteChallengeFromFavorites_ShouldThrowBadRequestException_WhenUserUuidIsNull() {
+        StepVerifier.create(favoriteService.deleteChallengeFromFavorites(null, UUID.randomUUID().toString()))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadUUIDException.class, throwable);
+                    assertEquals("Invalid ID format", throwable.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(0)).findById(any(UUID.class));
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    void deleteChallengeFromFavorites_ShouldThrowBadRequestException_WhenChallengeUuidIsNull() {
+        StepVerifier.create(favoriteService.deleteChallengeFromFavorites(UUID.randomUUID().toString(), null))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadUUIDException.class, throwable);
+                    assertEquals("Invalid ID format", throwable.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(0)).findById(any(UUID.class));
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    void deleteChallengeFromFavorites_ShouldThrowBadRequestException_WhenUserUuidIsNotValid() {
+        StepVerifier.create(favoriteService.deleteChallengeFromFavorites("invalidUuid", UUID.randomUUID().toString()))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadUUIDException.class, throwable);
+                    assertEquals("Invalid ID format", throwable.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(0)).findById(any(UUID.class));
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    void deleteChallengeFromFavorites_ShouldThrowBadRequestException_WhenChallengeUuidIsNotValid() {
+        StepVerifier.create(favoriteService.deleteChallengeFromFavorites(UUID.randomUUID().toString(), "invalidUuid"))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(BadUUIDException.class, throwable);
+                    assertEquals("Invalid ID format", throwable.getMessage());
+                })
+                .verify();
+
+        verify(userRepository, times(0)).findById(any(UUID.class));
+        verify(userRepository, times(0)).save(any());
+    }
+
+    @Test
+    void deleteChallengeFromFavorites_ShouldReturnFalse_WhenFavoriteDoesNotExist() {
+        UUID userId = UUID.randomUUID();
+        UUID challengeId = UUID.randomUUID();
+        UserDocument user = new UserDocument(userId, "testUser", null, 0);
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(favoriteRepository.findByUserIdAndChallengeId(any(UUID.class), any(UUID.class)))
+                .thenReturn(Mono.empty());
+
+        StepVerifier.create(favoriteService.deleteChallengeFromFavorites(userId.toString(), challengeId.toString()))
+                .expectNext(false)
+                .verifyComplete();
+
+        verify(userRepository).findById(userId);
+        verify(favoriteRepository).findByUserIdAndChallengeId(any(UUID.class), any(UUID.class));
+        verify(favoriteRepository, never()).delete(any());
+    }
+
+    @Test
+    void deleteChallengeFromFavorites_ShouldReturnTrue_WhenFavoriteAlreadyExists() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        UUID challengeId = UUID.randomUUID();
+        UserDocument user = new UserDocument(userId, "testUser", null, 0);
+        FavoriteDocument favorite = FavoriteDocument.builder()
+                .uuid(UUID.randomUUID())
+                .userId(userId)
+                .challengeId(challengeId)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Mono.just(user));
+        when(favoriteRepository.findByUserIdAndChallengeId(userId, challengeId))
+                .thenReturn(Mono.just(favorite));
+        when(favoriteRepository.delete(any(FavoriteDocument.class))).thenReturn(Mono.empty());
+
+        // Act & Assert
+        StepVerifier.create(favoriteService.deleteChallengeFromFavorites(userId.toString(), challengeId.toString()))
+                .expectNext(true)
+                .verifyComplete();
+
+        // Verify
+        verify(userRepository).findById(userId);
+        verify(favoriteRepository).findByUserIdAndChallengeId(userId, challengeId);
+        verify(favoriteRepository).delete(favorite);
+    }
 }


### PR DESCRIPTION
# 🎯 Summary

This PR corresponds to [Task 904](https://tree.taiga.io/project/luisvi-ita-challenges/task/904), where all the Favorites services are completely moved into a structure separated from User. 

Here, the ADD and DELETE services will be moved from their position within User to the new structure generated for Favorites. 

This PR specifically addresses the movement of the DELETE services. 

### 🔹 Key Changes: 

Since the entire persistence migration has already been carried out and Favorites is already separated into a new MongoDb Collection, which FavoriteRepository points to, the only remaining step is to physically change the methods' location to their final destination. 

- We will move the methods, both private and public, involved in the DELETE Favorites operation from UserService and UserServiceImpl to FavoriteService and FavoriteServiceImpl.
- For the tests, we will move the methods involved in the DELETE Favorites operation from UserServiceImplTest to FavoriteServiceImplTest.

🔹This task is the second of two into which the work has been divided: 

[#917](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/917)  [BE] Move Favorite logic for ADD to new location

[#918](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/918)  [BE] Move Favorite logic for DELETE to new location: **_THIS PR_**

[#935](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/935)  [BE] Move Favorite ADD Controller to FavoriteController


### 🔄 Created or Modified files

🔹Controllers:

- main/java/com/itachallenge/user/controller/UserController.java
- main/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteController.java

🔹Services:

- main/java/com/itachallenge/user/service/UserService.java
- main/java/com/itachallenge/user/service/UserServiceImpl.java

- main/java/com/itachallenge/user/userinteraction/service/favorite/FavoriteService.java
- main/java/com/itachallenge/user/userinteraction/service/favorite/FavoriteServiceImpl.java

🔹Tests:

- test/java/com/itachallenge/user/controller/UserControllerTest.java

- test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java

- test/java/com/itachallenge/user/service/UserServiceImplTest.java

- test/java/com/itachallenge/user/userinteraction/service/favorite/FavoriteServiceImplTest.java

### ✅PR Author Self-Check

- [x]  Modify UserController and FavoriteController.
- [x]  Modify UserService and UserServiceImpl.
- [x]  Modify FavoriteService and FavoriteServiceImpl.
- [x]  Modify tests.
- [x]  Code follows agreed-upon project conventions (naming, formatting, Sonar rules).
- [x]  All tests pass locally and in the development environment.
- [x]  SonarQube/SonarCloud analysis passes with no new issues or code smells.
