### PR TITLE
Refactor (FavoriteController)- New path to get favorites(#911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-3.1.2-RELEASE] - 2025-12-04
+### Changed
+- Created new path on FavoriteController to get favorites by user. (PR #1055) HU TAIGA #903
+- Implemented the new @RequestMapping("/itachallenge/api/v1/userinteraction/favorites/{userId}")
+- Updated the tests on FavoriteControllerTest and FavoriteControllerTestIntegration to include the new endpoint.
+### Added
+- Updated APISIX to include the new endpoint and future methods (add and delete))
+
 ### [itachallenge-user-3.1.1-RELEASE] - 2025-11-27
 ### Added
 - Foundation for managing user bookmarks in a dedicated collection. (PR #1040 #1042 #1046 and #1049)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,7 +331,6 @@ Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 
 ### [docker-compose-1.0] - 2023-11-30
 * First version
-### Refactored
-- Changued @RequestMapping("/itachallenge/api/v1/user") in FavoriteController to @RequestMapping("/itachallenge/api/v1/userinteraction/favorites/{userId}") PR #1054
-- New tests for FavoriteController in FavoriteControllerTest PR #1054
-- Changued APISIX routes to match new FavoriteController endpoints PR #1054
+
+### [itachallenge-user-1.0.0-RELEASE] - 2023-12-04
+* Refactored - TAIGA User Story #903 - Change FavoriteController path the migration of all favorites endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### [itachallenge-user-3.1.2-RELEASE] - 2025-12-04
+
 ### Changed
 - Created new path on FavoriteController to get favorites by user. (PR #1055) HU TAIGA #903
 - Implemented the new @RequestMapping("/itachallenge/api/v1/userinteraction/favorites/{userId}")
@@ -12,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated APISIX to include the new endpoint and future methods (add and delete)
 
 ### [itachallenge-user-3.1.1-RELEASE] - 2025-11-27
+
 ### Added
 - Foundation for managing user bookmarks in a dedicated collection. (PR #1040 #1042 #1046 and #1049)
   - Bookmarks domain & persistence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented the new @RequestMapping("/itachallenge/api/v1/userinteraction/favorites/{userId}")
 - Updated the tests on FavoriteControllerTest and FavoriteControllerTestIntegration to include the new endpoint.
 ### Added
-- Updated APISIX to include the new endpoint and future methods (add and delete))
+- Updated APISIX to include the new endpoint and future methods (add and delete)
 
 ### [itachallenge-user-3.1.1-RELEASE] - 2025-11-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+### [itachallenge-user-3.1.1-RELEASE] - 2023-12-04
+* Refactored - TAIGA User Story #903 - Change FavoriteController path to migration of all favorites endpoints
+
 ### [itachallenge-user-3.1.0-RELEASE] - 2025-11-25
 
 ### Breaking Change
@@ -331,6 +335,3 @@ Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 
 ### [docker-compose-1.0] - 2023-11-30
 * First version
-
-### [itachallenge-user-1.0.0-RELEASE] - 2023-12-04
-* Refactored - TAIGA User Story #903 - Change FavoriteController path the migration of all favorites endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,3 +331,7 @@ Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 
 ### [docker-compose-1.0] - 2023-11-30
 * First version
+### Refactored
+- Changued @RequestMapping("/itachallenge/api/v1/user") in FavoriteController to @RequestMapping("/itachallenge/api/v1/userinteraction/favorites/{userId}") PR #1054
+- New tests for FavoriteController in FavoriteControllerTest PR #1054
+- Changued APISIX routes to match new FavoriteController endpoints PR #1054

--- a/docker/apisix_conf/apisix_standalone_dev.yaml
+++ b/docker/apisix_conf/apisix_standalone_dev.yaml
@@ -39,7 +39,7 @@ routes:
   -
       uri: /itachallenge/api/v1/userinteraction/favorites/**
       methods:
-        - GET
+        - GET, POST, DELETE
       upstream_id: 6
 
 

--- a/docker/apisix_conf/apisix_standalone_dev.yaml
+++ b/docker/apisix_conf/apisix_standalone_dev.yaml
@@ -36,6 +36,11 @@ routes:
     methods:
       - GET
     upstream_id: 6
+  -
+      uri: /itachallenge/api/v1/userinteraction/favorites/**
+      methods:
+        - GET, POST, DELETE
+      upstream_id: 6
 
 
 upstreams:

--- a/docker/apisix_conf/apisix_standalone_dev.yaml
+++ b/docker/apisix_conf/apisix_standalone_dev.yaml
@@ -39,7 +39,7 @@ routes:
   -
       uri: /itachallenge/api/v1/userinteraction/favorites/**
       methods:
-        - GET, POST, DELETE
+        - GET
       upstream_id: 6
 
 

--- a/docker/apisix_conf/apisix_standalone_pro.yaml
+++ b/docker/apisix_conf/apisix_standalone_pro.yaml
@@ -30,7 +30,7 @@ routes:
   -
     uri: /itachallenge/api/v1/userinteraction/favorites/**
     methods:
-      - GET, POST, DELETE
+      - GET
     upstream_id: 2
 
 upstreams:

--- a/docker/apisix_conf/apisix_standalone_pro.yaml
+++ b/docker/apisix_conf/apisix_standalone_pro.yaml
@@ -30,7 +30,7 @@ routes:
   -
     uri: /itachallenge/api/v1/userinteraction/favorites/**
     methods:
-      - GET
+      - GET, POST, DELETE
     upstream_id: 2
 
 upstreams:

--- a/docker/apisix_conf/apisix_standalone_pro.yaml
+++ b/docker/apisix_conf/apisix_standalone_pro.yaml
@@ -27,6 +27,11 @@ routes:
       - GET
     upstream_id: 2
 
+  -
+    uri: /itachallenge/api/v1/userinteraction/favorites/**
+    methods:
+      - GET, POST, DELETE
+    upstream_id: 2
 
 upstreams:
   -

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteController.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/itachallenge/api/v1/user")
+@RequestMapping("/itachallenge/api/v1/userinteraction/favorites")
 public class FavoriteController {
 
     private static final Logger log = LoggerFactory.getLogger(FavoriteController.class);
@@ -44,7 +44,7 @@ public class FavoriteController {
                     @ApiResponse(responseCode = "500", description = "Unexpected error")
             }
     )
-    @GetMapping("/users/{userId}/favorites")
+    @GetMapping("/{userId}")
     public Mono<ResponseEntity<Set<UUID>>> getUserFavorites(@PathVariable String userId) {
         return favoriteService.getUserFavorites(userId)
                 .map(favorites -> {

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerIntegrationTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerIntegrationTest.java
@@ -70,7 +70,7 @@ class FavoriteControllerIntegrationTest {
         addFavorite(userId, challengeId3);
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/favorites", userId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/{userId}", userId)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk()
@@ -89,7 +89,7 @@ class FavoriteControllerIntegrationTest {
         String userId = createUser("user");
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/favorites", userId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/{userId}", userId)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk()
@@ -114,7 +114,7 @@ class FavoriteControllerIntegrationTest {
         addFavorite(user2, challengeId3);
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/favorites", user1)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/{userId}", user1)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk()
@@ -131,7 +131,7 @@ class FavoriteControllerIntegrationTest {
     @Test
     void getUserFavorites_WithInvalidUUID_Returns400(){
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/favorites", 321)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/{userId}", 321)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isBadRequest()
@@ -155,7 +155,7 @@ class FavoriteControllerIntegrationTest {
         String nonExistentUserId = UUID.randomUUID().toString();
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/favorites", nonExistentUserId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/{userId}", nonExistentUserId)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isNotFound()

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
@@ -38,7 +38,7 @@ class FavoriteControllerTest {
     }
 
     @Test
-    @DisplayName("GET /users/{userId}/favorites returns favorite challenges")
+    @DisplayName("GET /userinteraction/favorites/{userId} returns favorite challenges")
     void getUserFavorites_returnsFavorites() {
         UUID userId = UUID.randomUUID();
         Set<UUID> expectedFavorites = Set.of(UUID.randomUUID(), UUID.randomUUID());
@@ -47,7 +47,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.just(expectedFavorites));
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/favorites", userId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/{userId}", userId)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBodyList(UUID.class)
@@ -58,7 +58,7 @@ class FavoriteControllerTest {
     }
 
     @Test
-    @DisplayName("GET /users/{userId}/favorites returns 404 if user not found")
+    @DisplayName("GET /userinteraction/favorites/{userId} returns 404 if user not found")
     void getUserFavorites_returns404IfUserNotFound() {
         UUID userId = UUID.randomUUID();
 
@@ -66,7 +66,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/favorites", userId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/{userId}", userId)
                 .exchange()
                 .expectStatus().isNotFound()
                 .expectBody(String.class).isEqualTo("User not found");
@@ -75,7 +75,7 @@ class FavoriteControllerTest {
     }
 
     @Test
-    @DisplayName("GET /users/{userId}/favorites returns 400 if UUID is invalid")
+    @DisplayName("GET /userinteraction/favorites/{userId} returns 400 if UUID is invalid")
     void getUserFavorites_returns400IfInvalidUUID() {
         String invalidUserId = "invalid-uuid";
 
@@ -83,7 +83,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.error(new BadUUIDException("The provided IDs are not valid.")));
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/user/users/{userId}/favorites", invalidUserId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/{userId}", invalidUserId)
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody(String.class).isEqualTo("The provided IDs are not valid.");


### PR DESCRIPTION
PROFIT

The code will be more scalable and more efficient in intern logical program to difference favorites challenge of every user

💡 Context

⚠️ Currently, the FavoriteController maintains the same [@RequestMapping](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/profile/RequestMapping)("/itachallenge/api/v1/user") as the UserController, to avoid breaking the front end in this sprint.

However, this is not a best practice, as it mixes user and favorites resources under the same path.

🧩 Technical debt:         
Once the migration of all favorites endpoints is complete, we should update the base route to :         
"/itachallenge/api/v1/userinteraction/favorites/{userId}

This way, the module will be properly isolated and the resource will be semantically consistent with the REST API.

This task represents the first step in the 3-part modify path:

[#911](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/project/luisvi-ita-challenges/t/911)   Modify FavoriteController path on backend

[#912](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/project/luisvi-ita-challenges/t/912)   Change the acces path on Frontend

[#913](https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/project/luisvi-ita-challenges/t/913) Actualize Postman Collection and Wiki



🎯 Description

Change the mapping global/endpoint of Favorite controller in User microservice
Supervise the Service and Repository to: receive userId like parameter, verify restrictions and DTO
Actualize security, validations and OPENAPI if the code need
Change the unitary and integration tests with the new path.



✅ Acceptance Criteria

Endpoint returns the same HTTP 200 responses and structures (Set).
Proper logging kept.
No breaking changes in API behavior.



📜 Definition of Done

New ReuquestMapping on FavoriteController
New path on unitary test to: /userinteraction/favorites/{userId}
Modify apish_standalone_dev.yaml and apisix_standalone_pro.yaml to add new route than isn't coverage in prevouis route. 


TODO: Modify add favourites path when de add method ara implemented in favorite controller

<img width="1915" height="1080" alt="Captura de pantalla 2025-12-10 a las 11 45 13" src="https://github.com/user-attachments/assets/fcf7f108-b6da-4634-b5c0-8c9460d4c7cb" />

