### PR TITLE
Refactor(favorite) - PR 3/3 - Move add favorite methods of UserController to FavoriteController (#935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [itachallenge-user-3.1.3-RELEASE] - 2025-12-12
+
+### Changed
+- [Changed] Refactored the logic for deleting favorites to integrate it into the FavoriteService structure (without controller) (Taiga [#918], PR [#1053])
+- [Changed] Refactored the logic for adding favorites to integrate it into the FavoriteService structure (with controller) (Taiga [#917], PR [#1052])
+- [Changed] Moved add favorite controller logic from UserController to FavoriteController (Taiga [#935], PR [#1058])
+
 ### [itachallenge-user-3.1.2-RELEASE] - 2025-12-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## [itachallenge-user-3.1.3-RELEASE] - 2025-12-12
+### [itachallenge-user-3.1.3-RELEASE] - 2025-12-12
 
 ### Changed
-- [Changed] Refactored the logic for deleting favorites to integrate it into the FavoriteService structure (without controller) (Taiga [#918], PR [#1053])
-- [Changed] Refactored the logic for adding favorites to integrate it into the FavoriteService structure (with controller) (Taiga [#917], PR [#1052])
-- [Changed] Moved add favorite controller logic from UserController to FavoriteController (Taiga [#935], PR [#1058])
+- Refactored the logic for adding favorites to integrate it into the FavoriteService structure (without controller) (Taiga US [#904], Taiga Task [#917], PR [#1052])
+- Refactored the logic for deleting favorites to integrate it into the FavoriteService structure (with controller) (Taiga US [#904], Taiga Task [#918], PR [#1053])
+- Moved add favorite controller logic from UserController to FavoriteController (Taiga US [#904], Taiga Task [#953], PR [#1058])
 
 ### [itachallenge-user-3.1.2-RELEASE] - 2025-12-04
 
@@ -49,9 +48,6 @@ Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 
 ## [Unreleased]
 
-### Changed
-- [Changed] Refactored the logic for adding favorites to integrate it into the FavoriteService structure (Taiga [#917], PR [#1052])
-- [Changed] Refactored the logic for adding favorites to integrate it into the FavoriteService structure (Taiga [#918], PR [#1053])
 
 ### Chore/Internal
 - Introduced `SolutionAction` enum (internal change)

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=3.1.2-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=3.1.3-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.2-RELEASE

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=3.1.1-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=3.1.2-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.0.2-RELEASE

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -7,7 +7,6 @@ import com.itachallenge.user.dto.UserSolutionRequestDto;
 import com.itachallenge.user.dto.UserSolutionResponseDto;
 import com.itachallenge.user.service.IUserSolutionService;
 import com.itachallenge.user.service.UserService;
-import com.itachallenge.userinteraction.service.favorite.FavoriteService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -35,12 +34,10 @@ public class UserController {
     public static final String X_GITHUB_USERNAME ="X-Github-Username";
 
     private final UserService userService;
-    private final FavoriteService favoriteService;
     private final IUserSolutionService userSolutionService;
 
-    public UserController(UserService userService, IUserSolutionService userSolutionService, FavoriteService favoriteService) {
+    public UserController(UserService userService, IUserSolutionService userSolutionService) {
         this.userService = userService;
-        this.favoriteService = favoriteService;
         this.userSolutionService = userSolutionService;
     }
 
@@ -93,66 +90,6 @@ public class UserController {
                             .header(X_VALIDATION_STATUS, "Success")
                             .header(X_GITHUB_USERNAME, githubUsername)
                             .body(user);
-                });
-    }
-
-    @Operation(
-            summary = "Add Challenge to User Favorite Challenges",
-            description = "Adds challenge to user favorites",
-            parameters = {
-                    @Parameter(
-                            name = "userId",
-                            description = "User ID",
-                            required = true,
-                            in = ParameterIn.PATH
-                    ),
-                    @Parameter(
-                            name = "challengeId",
-                            description = "Challenge ID",
-                            required = true,
-                            in = ParameterIn.PATH
-                    )
-            },
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "Challenge is already in favorites",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "201",
-                            description = "Challenge added to favorites",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "Bad Request. The provided IDs have a bad format",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "Not found. No user is found with the provided user id.",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "Internal server error. An unexpected error occurred.",
-                            content = @Content(mediaType = "application/json")
-                    )
-            }
-    )
-
-    @PostMapping("/users/{userId}/favorites/{challengeId}")
-    public Mono<ResponseEntity<Boolean>> addToFavorites(@PathVariable String userId, @PathVariable String challengeId) {
-        return favoriteService.addChallengeToFavorites(userId, challengeId)
-                .map(added -> {
-                    if (Boolean.TRUE.equals(added)) {
-                        log.info("Challenge '{}' added to user '{}' favorites", challengeId, userId);
-                        return ResponseEntity.status(HttpStatus.CREATED).body(true);
-                    } else {
-                        log.info("User's '{}' favorites already contain Challenge '{}'", userId, challengeId);
-                        return ResponseEntity.ok().body(false);
-                    }
                 });
     }
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteController.java
@@ -16,6 +16,10 @@ import reactor.core.publisher.Mono;
 import java.util.Set;
 import java.util.UUID;
 
+// TODO [TECH-DEBT][Taiga-#938]:
+// Refactor endpoint structure to treat favorites as a user subresource
+// and remove duplicated path segments. See Taiga task for details.
+
 @RestController
 @RequestMapping("/itachallenge/api/v1/userinteraction/favorites")
 public class FavoriteController {

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -25,6 +26,66 @@ public class FavoriteController {
 
     public FavoriteController(FavoriteService favoriteService) {
         this.favoriteService = favoriteService;
+    }
+
+    @Operation(
+            summary = "Add Challenge to User Favorite Challenges",
+            description = "Adds challenge to user favorites",
+            parameters = {
+                    @Parameter(
+                            name = "userId",
+                            description = "User ID",
+                            required = true,
+                            in = ParameterIn.PATH
+                    ),
+                    @Parameter(
+                            name = "challengeId",
+                            description = "Challenge ID",
+                            required = true,
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Challenge is already in favorites",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "Challenge added to favorites",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Bad Request. The provided IDs have a bad format",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Not found. No user is found with the provided user id.",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "Internal server error. An unexpected error occurred.",
+                            content = @Content(mediaType = "application/json")
+                    )
+            }
+    )
+
+    @PostMapping("/users/{userId}/favorites/{challengeId}")
+    public Mono<ResponseEntity<Boolean>> addToFavorites(@PathVariable String userId, @PathVariable String challengeId) {
+        return favoriteService.addChallengeToFavorites(userId, challengeId)
+                .map(added -> {
+                    if (Boolean.TRUE.equals(added)) {
+                        log.info("Challenge '{}' added to user '{}' favorites", challengeId, userId);
+                        return ResponseEntity.status(HttpStatus.CREATED).body(true);
+                    } else {
+                        log.info("User's '{}' favorites already contain Challenge '{}'", userId, challengeId);
+                        return ResponseEntity.ok().body(false);
+                    }
+                });
     }
 
     @Operation(

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -8,7 +8,6 @@ import com.itachallenge.user.exception.NotFoundException;
 import com.itachallenge.user.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.service.IUserSolutionService;
 import com.itachallenge.user.service.UserService;
-import com.itachallenge.userinteraction.service.favorite.FavoriteService;
 import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -26,9 +25,6 @@ class UserControllerTest {
 
     @Mock
     private UserService userService;
-
-    @Mock
-    private FavoriteService favoriteService;
 
     @Mock
     private IUserSolutionService userSolutionService;
@@ -111,22 +107,6 @@ class UserControllerTest {
     }
 
     @Test
-    void addToFavorites_WhenAdded_Returns201() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(favoriteService.addChallengeToFavorites(userId, challengeId))
-                .thenReturn(Mono.just(true));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.CREATED)
-                .expectBody(Boolean.class).isEqualTo(true);
-
-        verify(favoriteService, times(1)).addChallengeToFavorites(userId, challengeId);
-    }
-
-    @Test
     void addToBookmarks_WhenAdded_Returns201() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
@@ -140,22 +120,6 @@ class UserControllerTest {
                 .expectBody(Boolean.class).isEqualTo(true);
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void addToFavorites_WhenAlreadyInFavorites_Returns200() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(favoriteService.addChallengeToFavorites(userId, challengeId))
-                .thenReturn(Mono.just(false));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(Boolean.class).isEqualTo(false);
-
-        verify(favoriteService, times(1)).addChallengeToFavorites(userId, challengeId);
     }
 
     @Test
@@ -175,22 +139,6 @@ class UserControllerTest {
     }
 
     @Test
-    void addToFavorites_WhenUserNotExists_Returns404() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(favoriteService.addChallengeToFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new NotFoundException("User not found")));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
-                .exchange()
-                .expectStatus().isNotFound()
-                .expectBody(String.class).isEqualTo("User not found");
-
-        verify(favoriteService, times(1)).addChallengeToFavorites(userId, challengeId);
-    }
-
-    @Test
     void addToBookmarks_WhenUserNotExists_Returns404() {
         String userId = UUID.randomUUID().toString();
         String challengeId = UUID.randomUUID().toString();
@@ -207,22 +155,6 @@ class UserControllerTest {
     }
 
     @Test
-    void addToFavorites_WhenBadFormattedId_Returns400() {
-        String userId = "invalidUuid";
-        String challengeId = "invalidUUid";
-        when(favoriteService.addChallengeToFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
-                .exchange()
-                .expectStatus().isBadRequest()
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
-
-        verify(favoriteService, times(1)).addChallengeToFavorites(userId, challengeId);
-    }
-
-    @Test
     void addToBookmarks_WhenBadFormattedId_Returns400() {
         String userId = "invalidUuid";
         String challengeId = "invalidUUid";
@@ -236,22 +168,6 @@ class UserControllerTest {
                 .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
 
         verify(userService, times(1)).addChallengeToBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void addToFavorites_WhenUnexpectedError_Returns500() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(favoriteService.addChallengeToFavorites(userId, challengeId))
-                .thenReturn(Mono.error(new Exception()));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
-
-        verify(favoriteService, times(1)).addChallengeToFavorites(userId, challengeId);
     }
 
     @Test

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerIntegrationTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerIntegrationTest.java
@@ -197,7 +197,7 @@ class FavoriteControllerIntegrationTest {
 
     private void addFavorite(String userId, String challengeId){
         webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}", userId, challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/{userId}/favorites/{challengeId}", userId, challengeId)
                 .exchange()
                 .expectStatus().isCreated();
     }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
@@ -46,7 +46,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.just(true));
 
         webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.CREATED)
                 .expectBody(Boolean.class).isEqualTo(true);
@@ -62,7 +62,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.just(false));
 
         webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(Boolean.class).isEqualTo(false);
@@ -78,7 +78,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isNotFound()
                 .expectBody(String.class).isEqualTo("User not found");
@@ -94,7 +94,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.error(new BadUUIDException("Error message")));
 
         webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
@@ -110,7 +110,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.error(new Exception()));
 
         webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
                 .expectBody(String.class).isEqualTo("Unexpected error happened.");
@@ -180,7 +180,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.just(true));
 
         webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.OK)
                 .expectBody(Boolean.class).isEqualTo(true);
@@ -196,7 +196,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.just(false));
 
         webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(Boolean.class).isEqualTo(false);
@@ -212,7 +212,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.error(new NotFoundException("User not found")));
 
         webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
                 .expectBody(String.class).isEqualTo("User not found");
@@ -228,7 +228,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.error(new BadUUIDException("Error message")));
 
         webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
                 .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
@@ -244,7 +244,7 @@ class FavoriteControllerTest {
                 .thenReturn(Mono.error(new Exception()));
 
         webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .uri("/itachallenge/api/v1/userinteraction/favorites/users/" + userId + "/favorites/" + challengeId)
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
                 .expectBody(String.class).isEqualTo("Unexpected error happened.");

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
@@ -39,6 +39,86 @@ class FavoriteControllerTest {
     }
 
     @Test
+    void addToFavorites_WhenAdded_Returns201() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(favoriteService.addChallengeToFavorites(userId, challengeId))
+                .thenReturn(Mono.just(true));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.CREATED)
+                .expectBody(Boolean.class).isEqualTo(true);
+
+        verify(favoriteService, times(1)).addChallengeToFavorites(userId, challengeId);
+    }
+
+    @Test
+    void addToFavorites_WhenAlreadyInFavorites_Returns200() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(favoriteService.addChallengeToFavorites(userId, challengeId))
+                .thenReturn(Mono.just(false));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(Boolean.class).isEqualTo(false);
+
+        verify(favoriteService, times(1)).addChallengeToFavorites(userId, challengeId);
+    }
+
+    @Test
+    void addToFavorites_WhenUserNotExists_Returns404() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(favoriteService.addChallengeToFavorites(userId, challengeId))
+                .thenReturn(Mono.error(new NotFoundException("User not found")));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(String.class).isEqualTo("User not found");
+
+        verify(favoriteService, times(1)).addChallengeToFavorites(userId, challengeId);
+    }
+
+    @Test
+    void addToFavorites_WhenBadFormattedId_Returns400() {
+        String userId = "invalidUuid";
+        String challengeId = "invalidUUid";
+        when(favoriteService.addChallengeToFavorites(userId, challengeId))
+                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+
+        verify(favoriteService, times(1)).addChallengeToFavorites(userId, challengeId);
+    }
+
+    @Test
+    void addToFavorites_WhenUnexpectedError_Returns500() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(favoriteService.addChallengeToFavorites(userId, challengeId))
+                .thenReturn(Mono.error(new Exception()));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/favorites/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+
+        verify(favoriteService, times(1)).addChallengeToFavorites(userId, challengeId);
+    }
+
+    @Test
     @DisplayName("GET /userinteraction/favorites/{userId} returns favorite challenges")
     void getUserFavorites_returnsFavorites() {
         UUID userId = UUID.randomUUID();

--- a/postman/ITA-Challenges.postman_collection.json
+++ b/postman/ITA-Challenges.postman_collection.json
@@ -1285,12 +1285,12 @@
           "response": []
         },
         {
-          "name": "User/favorites [dev-only]",
+          "name": "Userinteraction/favorites",
           "request": {
-            "method": "POST",
+            "method": "GET",
             "header": [],
             "url": {
-              "raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/user/users/d0d6e141-24ac-42ed-8e74-ebb64a83899e/favorites/9ebfef53-9520-4f9f-abbb-d43353700865",
+              "raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/userinteraction/favorites/c85b9430-f5a8-48ea-a1b5-28e018c77d61",
               "protocol": "http",
               "host": [
                 "{{ip}}"
@@ -1300,9 +1300,35 @@
                 "itachallenge",
                 "api",
                 "v1",
-                "user",
+
+                "userinteraction",
+                "favorites",
+                "c85b9430-f5a8-48ea-a1b5-28e018c77d61"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Userinteraction/favorites [dev-only]",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/userinteraction/favorites/users/997a1dca-70f6-478a-b382-6e3173e34491/favorites/9ebfef53-9520-4f9f-abbb-d43353700865",
+              "protocol": "http",
+              "host": [
+                "{{ip}}"
+              ],
+              "port": "{{user_port}}",
+              "path": [
+                "itachallenge",
+                "api",
+                "v1",
+                "userinteraction",
+                "favorites",
                 "users",
-                "d0d6e141-24ac-42ed-8e74-ebb64a83899e",
+                "997a1dca-70f6-478a-b382-6e3173e34491",
                 "favorites",
                 "9ebfef53-9520-4f9f-abbb-d43353700865"
               ]
@@ -1311,12 +1337,12 @@
           "response": []
         },
         {
-          "name": "User/favorites [dev-only]",
+          "name": "Userinteraction/favorites [dev-only]",
           "request": {
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/user/users/d0d6e141-24ac-42ed-8e74-ebb64a83899e/favorites/9ebfef53-9520-4f9f-abbb-d43353700865",
+              "raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/userinteraction/favorites/users/997a1dca-70f6-478a-b382-6e3173e34491/favorites/9ebfef53-9520-4f9f-abbb-d43353700865",
               "protocol": "http",
               "host": [
                 "{{ip}}"
@@ -1326,9 +1352,10 @@
                 "itachallenge",
                 "api",
                 "v1",
-                "user",
+                "userinteraction",
+                "favorites",
                 "users",
-                "d0d6e141-24ac-42ed-8e74-ebb64a83899e",
+                "997a1dca-70f6-478a-b382-6e3173e34491",
                 "favorites",
                 "9ebfef53-9520-4f9f-abbb-d43353700865"
               ]


### PR DESCRIPTION
# 🎯 Summary

This PR corresponds to [Task 904](https://tree.taiga.io/project/luisvi-ita-challenges/task/904), where all the Favorites services are completely moved into a structure separated from User. 

Here, the ADD and DELETE services will be moved from their position within User to the new structure generated for Favorites. 

This PR specifically addresses the movement of the ADD Controller.

### 🔹 Key Changes: 

Since the entire persistence migration has already been carried out and Favorites is already separated into a new MongoDb Collection, which FavoriteRepository points to, the only remaining step is to physically change the methods' location to their final destination. 

- We will move the methods, both private and public, involved in the DELETE Favorites operation from UserService and UserServiceImpl to FavoriteService and FavoriteServiceImpl.
- For the tests, we will move the methods involved in the DELETE Favorites operation from UserServiceImplTest to FavoriteServiceImplTest.

🔹This task is the second of two into which the work has been divided: 

[#917](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/917)  [BE] Move Favorite logic for ADD to new location

[#918](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/918)  [BE] Move Favorite logic for DELETE to new location

[#935](https://github.com/IT-Academy-BCN/ita-challenges-backend/compare/refactor/project/luisvi-ita-challenges/t/935)  [BE] Move Favorite ADD Controller to FavoriteController: **_THIS PR_**


### 🔄 Created or Modified files

🔹Controllers:

- main/java/com/itachallenge/user/controller/UserController.java
- main/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteController.java

🔹Tests:

- test/java/com/itachallenge/user/controller/UserControllerTest.java

- test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java

🔹Postman:

- ita-challenges\ita-challenges-backend\postman\ITA-Challenges.postman_collection.json

### ✅PR Author Self-Check

- [x]  Modify UserController and FavoriteController.
- [x]  Modify tests.
- [x]  Code follows agreed-upon project conventions (naming, formatting, Sonar rules).
- [x]  All tests pass locally and in the development environment.
- [x]  SonarQube/SonarCloud analysis passes with no new issues or code smells.

### ⚠️ Technical Debt

This PR keeps the current FavoriteController endpoint structure, which
contains a known REST anti-pattern (duplicated path segments in mappings).

The refactor has been postponed to avoid a breaking change, as current
Frontend integrations consume the existing endpoints.

A technical debt task has been created to address this refactor in a
subsequent sprint, coordinating Backend and Frontend changes.

Taiga task: [Task 938](https://tree.taiga.io/project/luisvi-ita-challenges/issue/938)

