### PR TITLE
docs (postman): add  Get favorites on Postman collection #913

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/App.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/App.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Import;
 @EnableDiscoveryClient
 @OpenAPIDefinition(info = @Info(title = "Ita Backend User", version = "1.0", description = "Description"))
 public class App {
+    
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);
     }

--- a/itachallenge-user/src/main/java/com/itachallenge/App.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/App.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.Import;
 @OpenAPIDefinition(info = @Info(title = "Ita Backend User", version = "1.0", description = "Description"))
 public class App {
 
+    
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);
     }

--- a/itachallenge-user/src/main/java/com/itachallenge/App.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/App.java
@@ -13,7 +13,6 @@ import org.springframework.context.annotation.Import;
 @EnableDiscoveryClient
 @OpenAPIDefinition(info = @Info(title = "Ita Backend User", version = "1.0", description = "Description"))
 public class App {
-
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);
     }

--- a/itachallenge-user/src/main/java/com/itachallenge/App.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/App.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Import;
 @EnableDiscoveryClient
 @OpenAPIDefinition(info = @Info(title = "Ita Backend User", version = "1.0", description = "Description"))
 public class App {
-    
+
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);
     }

--- a/itachallenge-user/src/main/java/com/itachallenge/App.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/App.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Import;
 @EnableDiscoveryClient
 @OpenAPIDefinition(info = @Info(title = "Ita Backend User", version = "1.0", description = "Description"))
 public class App {
+
     
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);

--- a/itachallenge-user/src/main/java/com/itachallenge/App.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/App.java
@@ -13,7 +13,6 @@ import org.springframework.context.annotation.Import;
 @EnableDiscoveryClient
 @OpenAPIDefinition(info = @Info(title = "Ita Backend User", version = "1.0", description = "Description"))
 public class App {
-
     
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);

--- a/postman/ITA-Challenges.postman_collection.json
+++ b/postman/ITA-Challenges.postman_collection.json
@@ -1335,6 +1335,30 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "User/favorites [dev-only]",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://{{ip}}:{{user_port}}/itachallenge/api/v1/userinteraction/favorites/d0d6e141-24ac-42ed-8e74-ebb64a83899e",
+              "protocol": "http",
+              "host": [
+                "{{ip}}"
+              ],
+              "port": "{{user_port}}",
+              "path": [
+                "itachallenge",
+                "api",
+                "v1",
+                "userinteraction",
+                "favorites",
+                "d0d6e141-24ac-42ed-8e74-ebb64a83899e"
+              ]
+            }
+          },
+          "response": []
         }
       ]
     },


### PR DESCRIPTION
💡 Context

⚠️ Currently, the FavoriteController maintains the same [@RequestMapping](https://tree.taiga.io/project/luisvi-ita-challenges/task/undefined)("/itachallenge/api/v1/user") as the UserController, to avoid breaking the front end in this sprint.

However, this is not a best practice, as it mixes user and favorites resources under the same path.

🧩 Technical debt:    
Once the migration of all favorites endpoints is complete, we should update the base route to :    
"/itachallenge/api/v1/userinteraction/favorites/{userId}

This way, the module will be properly isolated and the resource will be semantically consistent with the REST API.

This task represents the first step in the 3-part modify path:

[#911](https://tree.taiga.io/project/luisvi-ita-challenges/taskboard/project/luisvi-ita-challenges/t/911)   Modify FavoriteController path on backend

[#912](https://tree.taiga.io/project/luisvi-ita-challenges/taskboard/project/luisvi-ita-challenges/t/912)   Change the acces path on Frontend

[#913](https://tree.taiga.io/project/luisvi-ita-challenges/taskboard/project/luisvi-ita-challenges/t/913) Actualize Postman Collection and Wiki

THIS TASK:
- Add Get favorites on **ITA-Challenges.postman_collection.json**
-Updated Documentation on https://tree.taiga.io/project/luisvi-ita-challenges/wiki/availabe-endpoints