### PR TITLE
chore(contributors): add Adolfo Caicaguare to contributors.md 

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -113,6 +113,7 @@
 * Diego Balaguer Gálvez - https://github.com/DiegoBalaguer
 * Jose L Diaz I - https://github.com/jose-Diaz1002
 * Ana Beuzón Rodríguez - https://github.com/anaberod
+* Adolfo Caicaguare - https://github.com/adolcc
 
 
 


### PR DESCRIPTION
Added Adolfo Caicaguare to the contributor’s list as part of the onboarding process.