### PR TITLE
Fix(submission) 400 Bad Request on "Show Solution" with Empty Input (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-user-3.1.3-RELEASE] - 2026-01-27
+### [itachallenge-user-3.1.4-RELEASE] - 2026-01-27
 
 ### Changed
 - Updated UserSolutionRequestDto to include blank solution possibility to the User

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-user-3.1.4-RELEASE] - 2026-01-27
+### [itachallenge-user-3.2.1-RELEASE] - 2026-02-10
 
 ### Changed
 - Updated UserSolutionRequestDto to include blank solution possibility to the User
+- 
 ### [itachallenge-user-3.2.0-RELEASE] - 2026-02-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-3.1.3-RELEASE] - 2026-01-27
+
+### Changed
+- Updated UserSolutionRequestDto to include blank solution possibility to the User
+
 ### [itachallenge-challenge-3.1.0-RELEASE] - 2026-01-14
 
 ### Changed

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/UserSolutionRequestDto.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/UserSolutionRequestDto.java
@@ -3,7 +3,6 @@ package com.itachallenge.user.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.itachallenge.user.annotations.GenericUUIDValid;
 import com.itachallenge.user.document.enums.SolutionAction;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/UserSolutionRequestDto.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/UserSolutionRequestDto.java
@@ -33,7 +33,7 @@ public class UserSolutionRequestDto {
     private SolutionAction action;
 
     @JsonProperty(value ="solution_text")
-    @NotBlank(message = "Solution text is required")
+    @NotNull(message = "Solution cannot be null")
     private String solutionText;
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/dto/UserSolutionRequestDto.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/dto/UserSolutionRequestDto.java
@@ -32,7 +32,6 @@ public class UserSolutionRequestDto {
     private SolutionAction action;
 
     @JsonProperty(value ="solution_text")
-    @NotNull(message = "Solution cannot be null")
     private String solutionText;
 
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -127,7 +127,6 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
                                         .build())
                 );
     }
-
     private Mono<UUID> validateAndParseUuid(String userId) {
         if (userId == null || userId.trim().isEmpty()) {
             return Mono.error(new BadRequestException("The 'userId' parameter cannot be null or empty."));

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -102,7 +102,15 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
                             .isSolved(solvedDto.isSolved())
                             .timesSolved(solvedDto.getTimesSolved())
                             .status(status.name())
-                            .build());
+                            .build())
+                    .onErrorResume(e -> {
+                        log.error("Error connecting Challenges{}", e.getMessage());
+                        return Mono.just(SubmitSolutionResponseDto.builder()
+                                .solutionText(solutionText)
+                                .isSolved(true)
+                                .status(status.name())
+                                .build());
+                    });
         } else {
             // TODO: Enhance the response for non-ended statuses like IN_PROGRESS if additional info is needed
             return Mono.just(SubmitSolutionResponseDto.builder()

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -102,15 +102,7 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
                             .isSolved(solvedDto.isSolved())
                             .timesSolved(solvedDto.getTimesSolved())
                             .status(status.name())
-                            .build())
-                    .onErrorResume(e -> {
-                        log.error("Error connecting Challenges{}", e.getMessage());
-                        return Mono.just(SubmitSolutionResponseDto.builder()
-                                .solutionText(solutionText)
-                                .isSolved(true)
-                                .status(status.name())
-                                .build());
-                    });
+                            .build());
         } else {
             // TODO: Enhance the response for non-ended statuses like IN_PROGRESS if additional info is needed
             return Mono.just(SubmitSolutionResponseDto.builder()

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserSolutionServiceImpl.java
@@ -34,6 +34,11 @@ public class UserSolutionServiceImpl implements IUserSolutionService {
     //TODO : to be moved to the challenge micro when we do the entire solutions refactor
     @Override
     public Mono<SubmitSolutionResponseDto> addSolution(UserSolutionRequestDto userSolutionDto) {
+        if (SolutionAction.SUBMIT.equals(userSolutionDto.getAction())) {
+            if (userSolutionDto.getSolutionText() == null || userSolutionDto.getSolutionText().isBlank()) {
+                return Mono.error(new BadRequestException("Solution text is required when finalizing (SUBMIT)."));
+            }
+        }
         UUID challengeUuid = UUID.fromString(userSolutionDto.getChallengeId());
         UUID languageUuid = UUID.fromString(userSolutionDto.getLanguageId());
         UUID userUuid = UUID.fromString(userSolutionDto.getUserId());

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -394,7 +394,7 @@ class UserSolutionServiceImplTest {
         StepVerifier.create(result)
                 .assertNext(dto -> {
                     assertEquals(solutionText, dto.getSolutionText());
-                    assertTrue(dto.getIsSolved()); // El fallback devuelve true
+                    assertTrue(dto.getIsSolved()); 
                     assertEquals("SUBMITTED_COMPLETE", dto.getStatus());
                 })
                 .verifyComplete();

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -344,4 +344,62 @@ class UserSolutionServiceImplTest {
         verify(userSolutionRepository).save(any(UserSolutionDocument.class));
         verifyNoInteractions(challengeService);
     }
+    @Test
+    @DisplayName("addSolution SUBMIT action with blank solution text throws BadRequestException")
+    void addSolution_SubmitAction_BlankText_ThrowsException() {
+        UserSolutionRequestDto request = UserSolutionRequestDto.builder()
+                .userId(userUuid.toString())
+                .challengeId(challengeUuid.toString())
+                .languageId(languageUuid.toString())
+                .action(SolutionAction.SUBMIT)
+                .solutionText("   ") // Texto en blanco
+                .build();
+
+        StepVerifier.create(userSolutionService.addSolution(request))
+                .expectErrorMatches(throwable ->
+                        throwable instanceof BadRequestException &&
+                                throwable.getMessage().equals("Solution text is required when finalizing (SUBMIT)."))
+                .verify();
+
+        verifyNoInteractions(userSolutionRepository);
+    }
+
+    @Test
+    @DisplayName("addSolution SUBMIT action returns success fallback when challengeService fails")
+    void addSolution_ChallengeServiceFails_ReturnsFallback() {
+        UserSolutionRequestDto request = UserSolutionRequestDto.builder()
+                .userId(userUuid.toString())
+                .challengeId(challengeUuid.toString())
+                .languageId(languageUuid.toString())
+                .action(SolutionAction.SUBMIT)
+                .solutionText(solutionText)
+                .build();
+
+        UserSolutionDocument savedDoc = UserSolutionDocument.builder()
+                .status(ChallengeStatus.SUBMITTED_COMPLETE)
+                .challengeId(challengeUuid)
+                .solutionAttemptDocument(SolutionAttemptDocument.builder().solutionText(solutionText).build())
+                .build();
+
+        when(userSolutionRepository.findByUserIdAndChallengeIdAndLanguageId(userUuid, challengeUuid, languageUuid))
+                .thenReturn(Mono.empty());
+        when(userSolutionRepository.save(any(UserSolutionDocument.class)))
+                .thenReturn(Mono.just(savedDoc));
+
+        when(challengeService.addChallengeToSolved(challengeUuid.toString()))
+                .thenReturn(Mono.error(new RuntimeException("Service Unavailable")));
+
+        Mono<SubmitSolutionResponseDto> result = userSolutionService.addSolution(request);
+
+        StepVerifier.create(result)
+                .assertNext(dto -> {
+                    assertEquals(solutionText, dto.getSolutionText());
+                    assertTrue(dto.getIsSolved()); // El fallback devuelve true
+                    assertEquals("SUBMITTED_COMPLETE", dto.getStatus());
+                })
+                .verifyComplete();
+
+        verify(userSolutionRepository).save(any(UserSolutionDocument.class));
+        verify(challengeService).addChallengeToSolved(challengeUuid.toString());
+    }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -352,7 +352,7 @@ class UserSolutionServiceImplTest {
                 .challengeId(challengeUuid.toString())
                 .languageId(languageUuid.toString())
                 .action(SolutionAction.SUBMIT)
-                .solutionText("   ") // Texto en blanco
+                .solutionText("   ") 
                 .build();
 
         StepVerifier.create(userSolutionService.addSolution(request))
@@ -394,7 +394,7 @@ class UserSolutionServiceImplTest {
         StepVerifier.create(result)
                 .assertNext(dto -> {
                     assertEquals(solutionText, dto.getSolutionText());
-                    assertTrue(dto.getIsSolved()); 
+                    assertTrue(dto.getIsSolved());
                     assertEquals("SUBMITTED_COMPLETE", dto.getStatus());
                 })
                 .verifyComplete();

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserSolutionServiceImplTest.java
@@ -363,43 +363,4 @@ class UserSolutionServiceImplTest {
 
         verifyNoInteractions(userSolutionRepository);
     }
-
-    @Test
-    @DisplayName("addSolution SUBMIT action returns success fallback when challengeService fails")
-    void addSolution_ChallengeServiceFails_ReturnsFallback() {
-        UserSolutionRequestDto request = UserSolutionRequestDto.builder()
-                .userId(userUuid.toString())
-                .challengeId(challengeUuid.toString())
-                .languageId(languageUuid.toString())
-                .action(SolutionAction.SUBMIT)
-                .solutionText(solutionText)
-                .build();
-
-        UserSolutionDocument savedDoc = UserSolutionDocument.builder()
-                .status(ChallengeStatus.SUBMITTED_COMPLETE)
-                .challengeId(challengeUuid)
-                .solutionAttemptDocument(SolutionAttemptDocument.builder().solutionText(solutionText).build())
-                .build();
-
-        when(userSolutionRepository.findByUserIdAndChallengeIdAndLanguageId(userUuid, challengeUuid, languageUuid))
-                .thenReturn(Mono.empty());
-        when(userSolutionRepository.save(any(UserSolutionDocument.class)))
-                .thenReturn(Mono.just(savedDoc));
-
-        when(challengeService.addChallengeToSolved(challengeUuid.toString()))
-                .thenReturn(Mono.error(new RuntimeException("Service Unavailable")));
-
-        Mono<SubmitSolutionResponseDto> result = userSolutionService.addSolution(request);
-
-        StepVerifier.create(result)
-                .assertNext(dto -> {
-                    assertEquals(solutionText, dto.getSolutionText());
-                    assertTrue(dto.getIsSolved());
-                    assertEquals("SUBMITTED_COMPLETE", dto.getStatus());
-                })
-                .verifyComplete();
-
-        verify(userSolutionRepository).save(any(UserSolutionDocument.class));
-        verify(challengeService).addChallengeToSolved(challengeUuid.toString());
-    }
 }


### PR DESCRIPTION
**Context:**

In the current implementation of the Challenges module, users have the option to Save, Finish, or Show Solution. Currently, when a user clicks on "Show Solution" without having typed any text in the input field, the server returns a 400 Bad Request error. This happens because the backend (Java MVC) expects a non-empty string or a specific data structure that is not being met when the field is blank.

**Objective:**

1. Modify the validation logic in the Controller and/or the Request DTO and implements on UserSolutionServiceImpl and allow null or empty string values specifically for the "Show Solution" action. The system should process the request successfully and display the solution regardless of whether the user has provided a draft answer.

With this changes:

SHOW_SOLUTION → doesn't require text

SAVE → can be empty (save progress)

FINISH → should require text

2. Now, the request is vinculated to Challenge Microservice and if it is down, the request save correctly to finish button but we have the 500 server internal error. To avoid this, this pr implements OnErrorResume.

3. Actualize Tests and postman works correctly

**Impact:**

User Experience: Improves the flow by allowing users to skip a challenge and see the solution immediately without being forced to type placeholder text.

Stability: Eliminates unhandled 400 errors in the frontend logs, leading to a cleaner and more professional application behavior.

API Consistency: Aligns the API behavior with the functional requirement that "Show Solution" is an informative action, not necessarily dependent on prior input.

This improve will be apply on the branch fix(submission)-invalid-blank-submission-showsolution


<img width="1838" height="858" alt="Captura de pantalla 2026-01-28 a las 11 50 20" src="https://github.com/user-attachments/assets/b44621c0-c212-4174-a4d3-6f5b40ac4582" />

<img width="1828" height="853" alt="Captura de pantalla 2026-01-28 a las 11 51 36" src="https://github.com/user-attachments/assets/10a02de0-cf1b-4fde-92a3-c1bf90a07aad" />
<img width="1830" height="859" alt="Captura de pantalla 2026-01-28 a las 12 52 59" src="https://github.com/user-attachments/assets/4674f685-2f85-4a5d-adbb-d0d32faf8527" />



<img width="962" height="665" alt="image" src="https://github.com/user-attachments/assets/88386c6b-19f7-4fcb-9e9b-fb5b6825df0e" />

<img width="939" height="668" alt="image" src="https://github.com/user-attachments/assets/e48a886c-41c5-407a-aa5d-0ec92b9bec8d" />
<img width="953" height="668" alt="image" src="https://github.com/user-attachments/assets/471fa1a9-7e51-4f60-8958-ab9084f2a7e8" />
<img width="956" height="620" alt="image" src="https://github.com/user-attachments/assets/8e918662-f4e1-4f29-b9ab-9944433bc839" />
