### PR TITLE
PR 1/3 – refactor(user): move bookmarks to userinteraction and add deprecation (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-3.1.4-RELEASE] - 2026-01-26
+
+### Changed
+
+- Refactored bookmark retrieval logic into the `userinteraction` module (GitHub Task [#65]).
+- Created new professional path: `/itachallenge/api/v1/userinteraction/bookmarks/{userId}`.
+- Updated `BookmarkControllerTest` to validate both the new path and the legacy path.
+
+### Deprecated
+
+- The path `/itachallenge/api/v1/user/users/{userId}/bookmarks` is now deprecated. It remains functional for backward compatibility but returns a `Deprecation: true` header.
+
 ### [itachallenge-challenge-3.1.0-RELEASE] - 2026-01-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-user-3.1.4-RELEASE] - 2026-01-26
+### [itachallenge-user-3.2.0-RELEASE] - 2026-02-05
 
 ### Changed
 

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=3.1.3-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=3.1.4-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.1.0-RELEASE

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -2,7 +2,7 @@ MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
 MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
-MICROSERVICE_VERSION_itachallenge-user=3.1.4-RELEASE
+MICROSERVICE_VERSION_itachallenge-user=3.2.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
 MICROSERVICE_VERSION_itachallenge-challenge=3.1.0-RELEASE

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkController.java
@@ -53,10 +53,13 @@ public class BookmarkController {
                     return ResponseEntity.ok(bookmarks);
                 });
     }
-
+    /**
+     * @deprecated This endpoint is deprecated because the domain logic has moved
+     * to userinteraction. Use {@link #getUserBookmarks(String)} instead.
+     */
     @Operation(summary = "DEPRECATED: Use /userinteraction/bookmarks/{userId}")
     @GetMapping("/user/users/{userId}/bookmarks")
-    @Deprecated
+    @Deprecated(since = "3.1.4-RELEASE", forRemoval = true)
     public Mono<ResponseEntity<Set<UUID>>> getUserBookmarksLegacy(@PathVariable String userId) {
         return getUserBookmarks(userId)
                 .map(response -> ResponseEntity.status(response.getStatusCode())

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkController.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/itachallenge/api/v1/user")
+@RequestMapping("/itachallenge/api/v1")
 public class BookmarkController {
 
     private static final Logger log = LoggerFactory.getLogger(BookmarkController.class);
@@ -44,12 +44,23 @@ public class BookmarkController {
                     @ApiResponse(responseCode = "500", description = "Unexpected error")
             }
     )
-    @GetMapping("/users/{userId}/bookmarks")
+
+    @GetMapping("/userinteraction/bookmarks/{userId}")
     public Mono<ResponseEntity<Set<UUID>>> getUserBookmarks(@PathVariable String userId) {
         return bookmarkService.getUserBookmarks(userId)
                 .map(bookmarks -> {
                     log.info("Retrieved {} bookmark challenges for user {}", bookmarks.size(), userId);
                     return ResponseEntity.ok(bookmarks);
                 });
+    }
+
+    @Operation(summary = "DEPRECATED: Use /userinteraction/bookmarks/{userId}")
+    @GetMapping("/user/users/{userId}/bookmarks")
+    @Deprecated
+    public Mono<ResponseEntity<Set<UUID>>> getUserBookmarksLegacy(@PathVariable String userId) {
+        return getUserBookmarks(userId)
+                .map(response -> ResponseEntity.status(response.getStatusCode())
+                        .header("Deprecation", "true")
+                        .body(response.getBody()));
     }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkController.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/itachallenge/api/v1")
+@RequestMapping("/itachallenge/api/v1/users/{userId}/bookmarks")
 public class BookmarkController {
 
     private static final Logger log = LoggerFactory.getLogger(BookmarkController.class);
@@ -45,25 +45,12 @@ public class BookmarkController {
             }
     )
 
-    @GetMapping("/userinteraction/bookmarks/{userId}")
+    @GetMapping
     public Mono<ResponseEntity<Set<UUID>>> getUserBookmarks(@PathVariable String userId) {
         return bookmarkService.getUserBookmarks(userId)
                 .map(bookmarks -> {
                     log.info("Retrieved {} bookmark challenges for user {}", bookmarks.size(), userId);
                     return ResponseEntity.ok(bookmarks);
                 });
-    }
-    /**
-     * @deprecated This endpoint is deprecated because the domain logic has moved
-     * to userinteraction. Use {@link #getUserBookmarks(String)} instead.
-     */
-    @Operation(summary = "DEPRECATED: Use /userinteraction/bookmarks/{userId}")
-    @GetMapping("/user/users/{userId}/bookmarks")
-    @Deprecated(since = "3.1.4-RELEASE", forRemoval = true)
-    public Mono<ResponseEntity<Set<UUID>>> getUserBookmarksLegacy(@PathVariable String userId) {
-        return getUserBookmarks(userId)
-                .map(response -> ResponseEntity.status(response.getStatusCode())
-                        .header("Deprecation", "true")
-                        .body(response.getBody()));
     }
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkLegacyController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkLegacyController.java
@@ -1,0 +1,31 @@
+package com.itachallenge.user.controller.userinteraction.bookmark;
+
+import com.itachallenge.userinteraction.service.bookmark.BookmarkService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+import java.util.Set;
+import java.util.UUID;
+
+public class BookmarkLegacyController {
+    private final BookmarkService bookmarkService;
+
+    public BookmarkLegacyController(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
+
+    /**
+     * @deprecated This endpoint is deprecated because the domain logic has moved
+     * to a subresource structure. Use {@link BookmarkController#getUserBookmarks(String)} instead.
+     */
+    @Operation(summary = "DEPRECATED: Use /itachallenge/api/v1/users/{userId}/bookmarks")
+    @GetMapping("/{userId}/bookmarks")
+    @Deprecated(since = "3.1.4-RELEASE", forRemoval = true)
+    public Mono<ResponseEntity<Set<UUID>>> getUserBookmarksLegacy(@PathVariable String userId) {
+        return bookmarkService.getUserBookmarks(userId)
+                .map(bookmarks -> ResponseEntity.ok()
+                        .header("Deprecation", "true")
+                        .body(bookmarks));
+    }
+}

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkLegacyController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkLegacyController.java
@@ -8,6 +8,8 @@ import reactor.core.publisher.Mono;
 import java.util.Set;
 import java.util.UUID;
 
+@RestController
+@RequestMapping("/itachallenge/api/v1/user/users")
 public class BookmarkLegacyController {
     private final BookmarkService bookmarkService;
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
@@ -39,7 +39,27 @@ class BookmarkControllerTest {
     }
 
     @Test
-    @DisplayName("GET /users/{userId}/bookmarks returns bookmarked challenges")
+    @DisplayName("GET /userinteraction/bookmarks/{userId} returns bookmarked challenges - NEW PATH")
+    void getUserBookmarks_NewPath_Success() {
+        UUID userId = UUID.randomUUID();
+        Set<UUID> expectedBookmarks = Set.of(UUID.randomUUID(), UUID.randomUUID());
+
+        when(bookmarkService.getUserBookmarks(userId.toString()))
+                .thenReturn(Mono.just(expectedBookmarks));
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/userinteraction/bookmarks/{userId}", userId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(UUID.class)
+                .hasSize(expectedBookmarks.size())
+                .contains(expectedBookmarks.toArray(new UUID[0]));
+
+        verify(bookmarkService, times(1)).getUserBookmarks(userId.toString());
+    }
+
+    @Test
+    @DisplayName("GET /users/{userId}/bookmarks returns bookmarked challenges - LEGACY")
     void getUserBookmarks_returnsBookmarks() {
         UUID userId = UUID.randomUUID();
         Set<UUID> expectedBookmarks = Set.of(UUID.randomUUID(), UUID.randomUUID());
@@ -51,6 +71,7 @@ class BookmarkControllerTest {
                 .uri("/itachallenge/api/v1/user/users/{userId}/bookmarks", userId)
                 .exchange()
                 .expectStatus().isOk()
+                .expectHeader().valueEquals("Deprecation", "true")
                 .expectBodyList(UUID.class)
                 .hasSize(expectedBookmarks.size())
                 .contains(expectedBookmarks.toArray(new UUID[0]));

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 
 import static org.mockito.Mockito.*;
 
-@WebFluxTest(controllers = BookmarkController.class)
+@WebFluxTest(controllers = {BookmarkController.class, BookmarkLegacyController.class})
 class BookmarkControllerTest {
 
     @MockBean
@@ -39,7 +39,7 @@ class BookmarkControllerTest {
     }
 
     @Test
-    @DisplayName("GET /userinteraction/bookmarks/{userId} returns bookmarked challenges - NEW PATH")
+    @DisplayName("GET /users/{userId}/bookmarks returns bookmarked challenges")
     void getUserBookmarks_NewPath_Success() {
         UUID userId = UUID.randomUUID();
         Set<UUID> expectedBookmarks = Set.of(UUID.randomUUID(), UUID.randomUUID());
@@ -48,7 +48,7 @@ class BookmarkControllerTest {
                 .thenReturn(Mono.just(expectedBookmarks));
 
         webTestClient.get()
-                .uri("/itachallenge/api/v1/userinteraction/bookmarks/{userId}", userId)
+                .uri("/itachallenge/api/v1/users/{userId}/bookmarks", userId)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBodyList(UUID.class)
@@ -59,7 +59,7 @@ class BookmarkControllerTest {
     }
 
     @Test
-    @DisplayName("GET /users/{userId}/bookmarks returns bookmarked challenges - LEGACY")
+    @DisplayName("GET /user/users/{userId}/bookmarks returns bookmarked challenges - LEGACY")
     void getUserBookmarks_returnsBookmarks() {
         UUID userId = UUID.randomUUID();
         Set<UUID> expectedBookmarks = Set.of(UUID.randomUUID(), UUID.randomUUID());


### PR DESCRIPTION
**Overview**
This PR implements the refactoring of the bookmark retrieval logic, moving it to the userinteraction domain as part of the API restructuration. To ensure backward compatibility during this sprint, the legacy endpoint has been maintained but marked as deprecated.

**Changes Made**
New Endpoint: Created /itachallenge/api/v1/userinteraction/bookmarks/{userId} in BookmarkController.

Legacy Support: Maintained /itachallenge/api/v1/user/users/{userId}/bookmarks with a Deprecation: true response header.

Testing: Updated BookmarkControllerTest to validate both paths and the presence of the deprecation header.

Versioning:

Updated CHANGELOG.md to version 3.1.4-RELEASE.

Updated conf/.env.CI.dev to version 3.1.4-RELEASE for CI/CD deployment.

**Evidence (Postman)**
1. New Path (Success 200 OK)
Successfully retrieved bookmarks using the new isolated path.

URL: /itachallenge/api/v1/userinteraction/bookmarks/{userId}

Result: 200 OK
<img width="1460" height="896" alt="Captura de pantalla 2026-01-25 a las 22 03 49" src="https://github.com/user-attachments/assets/5555b720-b888-4459-9254-18c063ee186e" />

2. Backward Compatibility (Legacy Path with Header)
The old path still works but correctly notifies consumers about its future removal.

URL: /itachallenge/api/v1/user/users/{userId}/bookmarks

Header: Deprecation: true

<img width="1463" height="849" alt="Captura de pantalla 2026-01-25 a las 22 05 30" src="https://github.com/user-attachments/assets/5a3f34b7-8bad-45f8-9243-983be8c492ce" />

**Definition of Done**
[x] New RequestMapping on BookmarkController.

[x] Unit tests covering the new path and legacy deprecation.

[x] Version bumped to 3.1.4-RELEASE.

[x] Documentation updated in CHANGELOG.md.