### PR TITLE
PR 2/2 - Refactor (auth): Delegate authentication to Github-core (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [itachallenge-auth-2.1.0-RELEASE] - 2026-01-30
 
 ### Added - Github-core
-- Introduced GithubProperties to encapsulate configuration parameters required for GitHub API integration.
-- Added GithubAuthRequestDto and GithubAuthResponseDto to standardize the GitHub validation process.
+- Introduced GithubProperties to encapsulate configuration parameters required for GitHub API integration. (Github Task [#23], SubTask [#53], PR [#1068])
+- Added GithubAuthRequestDto and GithubAuthResponseDto to standardize the GitHub validation process. (Github Task [#23], SubTask [#53], PR [#1068])
 
 ### Changed - Github-core
-- Refactored GithubServiceConfig and GithubApiService to centralize GitHub validation logic within the core library.
-- Updated GithubApiServiceImplTest to ensure full coverage of the newly implemented validation features.
+- Refactored GithubServiceConfig and GithubApiService to centralize GitHub validation logic within the core library. (Github Task [#23], SubTask [#53], PR [#1068])
+- Updated GithubApiServiceImplTest to ensure full coverage of the newly implemented validation features. (Github Task [#23], SubTask [#53], PR [#1068])
 
 ### Changed - Auth
-- Refactored AuthController and AuthService to leverage the github-core library for authentication, removing legacy code and direct GitHub API configurations.
-- Updated AuthControllerTest and AuthServiceTest to align with the new implementation and dependency structure.
+- Refactored AuthController and AuthService to leverage the github-core library for authentication, removing legacy code and direct GitHub API configurations. (Github Task [#23], SubTask [#69], PR [#1075])
+- Updated AuthControllerTest and AuthServiceTest to align with the new implementation and dependency structure. (task 23, subtask 69) (Github Task [#23], SubTask [#69], PR [#1075])
 
 ### [itachallenge-challenge-3.2.0-RELEASE] - 2026-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-auth-2.1.0-RELEASE] - 2026-01-30
+
+### Added - Github-core
+- Introduced GithubProperties to encapsulate configuration parameters required for GitHub API integration.
+- Added GithubAuthRequestDto and GithubAuthResponseDto to standardize the GitHub validation process.
+
+### Changed - Github-core
+- Refactored GithubServiceConfig and GithubApiService to centralize GitHub validation logic within the core library.
+- Updated GithubApiServiceImplTest to ensure full coverage of the newly implemented validation features.
+
+### Changed - Auth
+- Refactored AuthController and AuthService to leverage the github-core library for authentication, removing legacy code and direct GitHub API configurations.
+- Updated AuthControllerTest and AuthServiceTest to align with the new implementation and dependency structure.
+
 ### [itachallenge-challenge-3.2.0-RELEASE] - 2026-01-27
 
 ### Added

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -1,5 +1,5 @@
 MICROSERVICE_DEPLOY_itachallenge-auth=itachallenge-auth
-MICROSERVICE_VERSION_itachallenge-auth=2.0.5-RELEASE
+MICROSERVICE_VERSION_itachallenge-auth=2.1.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
 MICROSERVICE_VERSION_itachallenge-user=3.1.3-RELEASE

--- a/itachallenge-auth/build.gradle
+++ b/itachallenge-auth/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'org.projectlombok:lombok:1.18.30'
     implementation project(':jwt-core')
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    implementation project(':github-core')
 
     testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '4.12.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.6'
@@ -59,6 +60,7 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
     testImplementation 'org.junit.platform:junit-platform-suite-engine:1.8.1'
     testImplementation project(':jwt-core')
+    testImplementation project(':github-core')
 
 }
 

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/App.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/App.java
@@ -1,11 +1,14 @@
 package com.itachallenge.auth;
 
+import com.itachallenge.githubcore.config.GithubServiceConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@Import(GithubServiceConfig.class)
 @EnableDiscoveryClient
 @ComponentScan(basePackages = {
         "com.itachallenge.auth",

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/controller/AuthController.java
@@ -70,8 +70,7 @@ public class AuthController {
 
     @PostMapping("/github/authenticate")
     public Mono<ResponseEntity<Map<String, Object>>> authenticateWithGithub(@RequestBody Map<String, String> codeRequest) {
-        return authService.exchangeCodeForToken(codeRequest.get("code"))
-                .flatMap(authService::validateTokenWithGithub)
+        return authService.authenticateWithGithub(codeRequest.get("code"))
                 .flatMap(response -> {
                     if (!(boolean) response.get(KEY_IS_VALID)) {
                         return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/AuthService.java
@@ -1,15 +1,10 @@
 package com.itachallenge.auth.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itachallenge.githubcore.dto.GithubAuthRequestDto;
+import com.itachallenge.githubcore.service.GithubApiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
@@ -19,136 +14,35 @@ import java.util.Map;
 public class AuthService implements IAuthService {
 
     private static final Logger log = LoggerFactory.getLogger(AuthService.class);
-    private final WebClient.Builder webClientBuilder;
+    private final GithubApiService githubApiService;
 
     private static final String KEY_IS_VALID = "isValid";
     private static final String KEY_USERNAME = "username";
-    private static final String KEY_TOKEN = "token";
-    private static final String CLIENT_ID_KEY = "client_id";
-    private static final String CLIENT_SECRET_KEY = "client_secret";
-    private static final String CODE_KEY = "code";
-    private static final String ACCESS_TOKEN_KEY = "access_token";
-    private static final String GITHUB_LOGIN_KEY = "login";
 
-    private final String githubUserInfoUri;
-
-    private final String githubTokenUri;
-
-    private final String clientId;
-
-    private final String clientSecret;
-
-    public AuthService(WebClient.Builder webClientBuilder,
-                       @Value("${spring.security.oauth2.client.provider.github.token-uri}") String githubTokenUri,
-                       @Value("${spring.security.oauth2.client.provider.github.user-info-uri}") String githubUserInfoUri,
-                       @Value("${spring.security.oauth2.client.registration.github.client-id}") String clientId,
-                       @Value("${spring.security.oauth2.client.registration.github.client-secret}") String clientSecret
-                       ) {
-        this.webClientBuilder = webClientBuilder;
-        this.githubTokenUri = githubTokenUri;
-        this.githubUserInfoUri = githubUserInfoUri;
-        this.clientId = clientId;
-        this.clientSecret = clientSecret;
-    }
-
-    public Mono<String> exchangeCodeForToken(String code) {
-        WebClient webClient = webClientBuilder.build();
-
-        return webClient
-                .post()
-                .uri(githubTokenUri)
-                .header("Accept", "application/json")
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(createRequestBody(clientId, clientSecret, code))
-                .retrieve()
-                .bodyToMono(String.class)
-                .flatMap(this::processTokenResponse)
-                .onErrorResume(this::handleTokenError);
-    }
-
-    private Map<String, String> createRequestBody(String clientId, String clientSecret, String code) {
-        Map<String, String> requestBody = new HashMap<>();
-        requestBody.put(CLIENT_ID_KEY, clientId);
-        requestBody.put(CLIENT_SECRET_KEY, clientSecret);
-        requestBody.put(CODE_KEY, code);
-        return requestBody;
-    }
-
-    private Mono<String> processTokenResponse(String response) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode jsonNode = objectMapper.readTree(response);
-
-            if (jsonNode.has(ACCESS_TOKEN_KEY)) {
-                String accessToken = jsonNode.get(ACCESS_TOKEN_KEY).asText();
-                log.info("Access token obtained successfully");
-                return Mono.just(accessToken);
-            } else {
-                log.error("GitHub OAuth error: {}", response);
-                return Mono.error(new IllegalStateException("Failed to obtain access token"));
-            }
-        } catch (JsonProcessingException e) {
-            log.error("Error processing GitHub OAuth response", e);
-            return Mono.error(e);
-        }
-    }
-
-    private Mono<String> handleTokenError(Throwable ex) {
-        log.error("Error exchanging code for token: {}", ex.getMessage());
-        return Mono.error(ex);
+    public AuthService(GithubApiService githubApiService) {
+        this.githubApiService = githubApiService;
     }
 
     @Override
-    public Mono<Map<String, Object>> validateTokenWithGithub(String token) {
-        WebClient webClient = webClientBuilder.build();
-
-        return webClient
-                .get()
-                .uri(githubUserInfoUri)
-                .header("Authorization", "token " + token)
-                .retrieve()
-                .bodyToMono(String.class)
-                .flatMap(response -> processGithubResponse(response, token))
-
-                .onErrorResume(WebClientResponseException.class, this::handleGithubApiError)
-                .onErrorResume(this::handleUnexpectedError);
+    public Mono<Map<String, Object>> authenticateWithGithub(String code) {
+        return githubApiService.authenticate(new GithubAuthRequestDto(code))
+                .map(authResponse -> {
+                    if (authResponse.username() == null || authResponse.username().isBlank()) {
+                        log.warn("GitHub returned a response with no username");
+                        return createErrorResult();
+                    }
+                    return createSuccessResult(authResponse.username());
+                })
+                .onErrorResume(ex -> {
+                    log.error("Authentication error with the GitHub library: {}", ex.getMessage());
+                    return Mono.just(createErrorResult());
+                });
     }
 
-    private Mono<Map<String, Object>> processGithubResponse(String response, String token) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode jsonNode = objectMapper.readTree(response);
-
-            if (jsonNode.has(GITHUB_LOGIN_KEY)) {
-                String githubUsername = jsonNode.get(GITHUB_LOGIN_KEY).asText();
-                log.info("GitHub username extracted: {}", githubUsername);
-
-                return Mono.just(createSuccessResult(githubUsername, token));
-            } else {
-                log.error("GitHub response does not contain a username: {}", response);
-                return Mono.just(createErrorResult());
-            }
-        } catch (JsonProcessingException e) {
-            log.error("Error processing GitHub response", e);
-            return Mono.error(e);
-        }
-    }
-
-    private Mono<Map<String, Object>> handleGithubApiError(WebClientResponseException ex) {
-        log.error("GitHub API error: {}", ex.getStatusCode());
-        return Mono.just(createErrorResult());
-    }
-
-    private Mono<Map<String, Object>> handleUnexpectedError(Throwable ex) {
-        log.error("Unexpected error: {}", ex.getMessage());
-        return Mono.just(createErrorResult());
-    }
-
-    private Map<String, Object> createSuccessResult(String username, String token) {
+    private Map<String, Object> createSuccessResult(String username) {
         Map<String, Object> result = new HashMap<>();
         result.put(KEY_IS_VALID, true);
         result.put(KEY_USERNAME, username);
-        result.put(KEY_TOKEN, token);
         return result;
     }
 
@@ -158,5 +52,4 @@ public class AuthService implements IAuthService {
         errorResult.put(KEY_USERNAME, null);
         return errorResult;
     }
-
 }

--- a/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IAuthService.java
+++ b/itachallenge-auth/src/main/java/com/itachallenge/auth/service/IAuthService.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 public interface IAuthService {
 
-    Mono<Map<String, Object>> validateTokenWithGithub(String token);
-    Mono<String> exchangeCodeForToken(String code);
+    Mono<Map<String, Object>> authenticateWithGithub(String token);
 
 }

--- a/itachallenge-auth/src/main/resources/application.yml
+++ b/itachallenge-auth/src/main/resources/application.yml
@@ -7,19 +7,6 @@ spring:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
   jmx:
     enabled: true
-  security:
-    oauth2:
-      client:
-        registration:
-          github:
-            client-id: ${GITHUB_CLIENT_ID}
-            client-secret: ${GITHUB_CLIENT_SECRET}
-        provider:
-          github:
-            authorization-uri: https://github.com/login/oauth/authorize
-            token-uri: https://github.com/login/oauth/access_token
-            user-info-uri: https://api.github.com/user
-            user-name-attribute: login
 
 springdoc:
   swagger-ui:

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/controller/AuthControllerTest.java
@@ -8,8 +8,9 @@ import com.itachallenge.auth.exception.InvalidRoleChangeRequestException;
 import com.itachallenge.auth.service.IAuthService;
 import com.itachallenge.auth.service.IAuthJwtFacade;
 import com.itachallenge.auth.service.IUserService;
+import com.itachallenge.githubcore.config.GithubProperties;
+import com.itachallenge.githubcore.service.GithubApiService;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
@@ -20,6 +21,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -31,7 +33,11 @@ import java.util.Map;
 import static org.mockito.Mockito.when;
 
 @WebFluxTest(AuthController.class)
-@TestPropertySource(properties = "token.expiration.minutes=60")
+@TestPropertySource(properties = {
+        "token.expiration.minutes=60",
+        "spring.application.version=1.0.0",
+        "spring.application.name=itachallenge-auth"
+})
 @Import(TestAuthConfig.class)
 @ActiveProfiles("test")
 class AuthControllerTest {
@@ -50,8 +56,14 @@ class AuthControllerTest {
     @MockBean
     private IUserService userService;
 
-    @InjectMocks
-    private AuthController authController;
+    @MockBean
+    private WebClient.Builder webClientBuilder;
+
+    @MockBean
+    private GithubProperties githubProperties;
+
+    @MockBean
+    private GithubApiService githubApiService;
 
     @MockBean
     private IAuthJwtFacade authJwtFacade;
@@ -59,7 +71,6 @@ class AuthControllerTest {
     @Test
     void authenticateWithGithub_ValidCode_ReturnsJwt() {
         String validCode = "valid-code";
-        String accessToken = "valid-token";
         String githubUsername = "octocat";
         User user = new User("1234", githubUsername, "ADMIN");
         String jwtToken = "generatedJwt";
@@ -69,8 +80,7 @@ class AuthControllerTest {
         validationResult.put("username", githubUsername);
         validationResult.put("token", jwtToken);
 
-        when(authService.exchangeCodeForToken(validCode)).thenReturn(Mono.just(accessToken));
-        when(authService.validateTokenWithGithub(accessToken)).thenReturn(Mono.just(validationResult));
+        when(authService.authenticateWithGithub(validCode)).thenReturn(Mono.just(validationResult));
         when(userService.fetchUserData(githubUsername)).thenReturn(Mono.just(user));
         when(authJwtFacade.generateToken(user.getUsername(), user.getRole(), user.getUuid())).thenReturn(jwtToken);
 
@@ -88,13 +98,11 @@ class AuthControllerTest {
     @Test
     void authenticateWithGithub_InvalidCode_ReturnsUnauthorized() {
         String invalidCode = "invalid-code";
-        String accessToken = "invalid-token";
         Map<String, Object> validationResult = new HashMap<>();
         validationResult.put("isValid", false);
         validationResult.put("username", null);
 
-        when(authService.exchangeCodeForToken(invalidCode)).thenReturn(Mono.just(accessToken));
-        when(authService.validateTokenWithGithub(accessToken)).thenReturn(Mono.just(validationResult));
+        when(authService.authenticateWithGithub(invalidCode)).thenReturn(Mono.just(validationResult));
 
         webTestClient.post()
                 .uri("/itachallenge/api/v1/auth/github/authenticate")
@@ -107,29 +115,10 @@ class AuthControllerTest {
     }
 
     @Test
-    void authenticateWithGithub_TokenExchangeError_ReturnsInternalServerError() {
-        String invalidCode = "invalid-code";
-
-        when(authService.exchangeCodeForToken(invalidCode))
-                .thenReturn(Mono.error(new RuntimeException("Token exchange failed")));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/auth/github/authenticate")
-                .bodyValue(Map.of("code", invalidCode))
-                .exchange()
-                .expectStatus().is5xxServerError()
-                .expectBody()
-                .jsonPath("$.isValid").isEqualTo(false)
-                .jsonPath("$.username").isEmpty();
-    }
-
-    @Test
     void authenticateWithGithub_TokenValidationError_ReturnsInternalServerError() {
         String validCode = "valid-code";
-        String accessToken = "valid-token";
 
-        when(authService.exchangeCodeForToken(validCode)).thenReturn(Mono.just(accessToken));
-        when(authService.validateTokenWithGithub(accessToken))
+        when(authService.authenticateWithGithub(validCode))
                 .thenReturn(Mono.error(new RuntimeException("Token validation failed")));
 
         webTestClient.post()
@@ -145,14 +134,12 @@ class AuthControllerTest {
     @Test
     void authenticateWithGithub_UserDoesNotExist_ReturnsForbidden() {
         String validCode = "valid-code";
-        String accessToken = "valid-token";
         String githubUsername = "octocat";
         Map<String, Object> validationResult = new HashMap<>();
         validationResult.put("isValid", true);
         validationResult.put("username", githubUsername);
 
-        when(authService.exchangeCodeForToken(validCode)).thenReturn(Mono.just(accessToken));
-        when(authService.validateTokenWithGithub(accessToken)).thenReturn(Mono.just(validationResult));
+        when(authService.authenticateWithGithub(validCode)).thenReturn(Mono.just(validationResult));
         when(userService.fetchUserData(githubUsername)).thenReturn(Mono.empty());
 
         webTestClient.post()
@@ -170,14 +157,12 @@ class AuthControllerTest {
     @Test
     void authenticateWithGithub_UserValidationError_ReturnsInternalServerError() {
         String validCode = "valid-code";
-        String accessToken = "valid-token";
         String githubUsername = "octocat";
         Map<String, Object> validationResult = new HashMap<>();
         validationResult.put("isValid", true);
         validationResult.put("username", githubUsername);
 
-        when(authService.exchangeCodeForToken(validCode)).thenReturn(Mono.just(accessToken));
-        when(authService.validateTokenWithGithub(accessToken)).thenReturn(Mono.just(validationResult));
+        when(authService.authenticateWithGithub(validCode)).thenReturn(Mono.just(validationResult));
         when(userService.fetchUserData(githubUsername)).thenReturn(Mono.error(new RuntimeException("Database error")));
 
         webTestClient.post()

--- a/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
+++ b/itachallenge-auth/src/test/java/com/itachallenge/auth/service/AuthServiceTest.java
@@ -1,114 +1,40 @@
 package com.itachallenge.auth.service;
 
-
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import com.itachallenge.githubcore.dto.GithubAuthRequestDto;
+import com.itachallenge.githubcore.dto.GithubAuthResponseDto;
+import com.itachallenge.githubcore.service.GithubApiService;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
+    @Mock
+    private GithubApiService githubApiService;
 
-    private MockWebServer mockWebServer;
+    @InjectMocks
     private AuthService authService;
 
-    @BeforeEach
-    void setUp() throws IOException {
-        mockWebServer = new MockWebServer();
-        mockWebServer.start();
-
-        String baseUrl = mockWebServer.url("").toString();
-        String githubTokenUri = baseUrl + "login/oauth/access_token";
-        String githubUserInfoUri = baseUrl + "user";
-
-        authService = new AuthService(
-                WebClient.builder(),
-                githubTokenUri,
-                githubUserInfoUri,
-                "test-client-id",
-                "test-client-secret");
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        mockWebServer.shutdown();
-    }
+    private final String testCode = "test-auth-code";
+    private final String githubUsername = "octocat";
 
     @Test
-    void exchangeCodeForToken_Successful() throws InterruptedException {
-        String code = "auth-code";
-        String accessToken = "github-access-token";
-        String mockResponse = "{\"access_token\": \"" + accessToken + "\"}";
+    void authenticateWithGithub_Successful() {
+        GithubAuthResponseDto mockResponse = new GithubAuthResponseDto(githubUsername);
+        when(githubApiService.authenticate(any(GithubAuthRequestDto.class)))
+                .thenReturn(Mono.just(mockResponse));
 
-        mockWebServer.enqueue(new MockResponse()
-                .setBody(mockResponse)
-                .setResponseCode(200)
-                .addHeader("Content-Type", "application/json"));
-
-        Mono<String> result = authService.exchangeCodeForToken(code);
-
-        StepVerifier.create(result)
-                .expectNext(accessToken)
-                .verifyComplete();
-
-        RecordedRequest request = mockWebServer.takeRequest();
-        assertEquals("/login/oauth/access_token", request.getRequestUrl().encodedPath());
-        assertEquals("application/json", request.getHeader("Accept"));
-    }
-
-    @Test
-    void exchangeCodeForToken_InvalidCode_ReturnsError() {
-        String code = "invalid-code";
-        String mockResponse = "{\"error\": \"bad_verification_code\"}";
-
-        mockWebServer.enqueue(new MockResponse()
-                .setBody(mockResponse)
-                .setResponseCode(400) // Simulate GitHub rejecting the code
-                .addHeader("Content-Type", "application/json"));
-
-        Mono<String> result = authService.exchangeCodeForToken(code);
-
-        StepVerifier.create(result)
-                .expectError(WebClientResponseException.BadRequest.class)
-                .verify();
-    }
-
-    @Test
-    void exchangeCodeForToken_NetworkFailure_ReturnsError() {
-        String code = "auth-code";
-
-        mockWebServer.enqueue(new MockResponse()
-                .setResponseCode(500));
-
-        Mono<String> result = authService.exchangeCodeForToken(code);
-
-        StepVerifier.create(result)
-                .expectError(WebClientResponseException.class)
-                .verify();
-    }
-
-    @Test
-    void validateTokenWithGithub_ValidToken_ReturnsUsername() throws Exception {
-        String validToken = "valid-token";
-        String githubUsername = "octocat";
-        String mockResponse = "{\"login\": \"" + githubUsername + "\"}";
-
-        mockWebServer.enqueue(new MockResponse()
-                .setBody(mockResponse)
-                .setResponseCode(200)
-                .addHeader("Content-Type", "application/json"));
-
-        Mono<Map<String, Object>> result = authService.validateTokenWithGithub(validToken);
+        Mono<Map<String, Object>> result = authService.authenticateWithGithub(testCode);
 
         StepVerifier.create(result)
                 .assertNext(response -> {
@@ -116,44 +42,90 @@ class AuthServiceTest {
                     assertEquals(githubUsername, response.get("username"));
                 })
                 .verifyComplete();
-
-        RecordedRequest request = mockWebServer.takeRequest();
-        assertEquals("/user", request.getRequestUrl().encodedPath());
-        assertEquals("token " + validToken, request.getHeader("Authorization"));
     }
 
     @Test
-    void validateTokenWithGithub_ExpiredToken_ReturnsInvalid() {
-        String expiredToken = "expired-token";
-        String mockResponse = "{\"message\": \"Bad credentials\"}";
+    void authenticateWithGithub_ErrorInLibrary_ReturnsInvalid() {
+        when(githubApiService.authenticate(any(GithubAuthRequestDto.class)))
+                .thenReturn(Mono.error(new RuntimeException("GitHub error")));
 
-        mockWebServer.enqueue(new MockResponse()
-                .setBody(mockResponse)
-                .setResponseCode(401)
-                .addHeader("Content-Type", "application/json"));
-
-        Mono<Map<String, Object>> result = authService.validateTokenWithGithub(expiredToken);
+        Mono<Map<String, Object>> result = authService.authenticateWithGithub(testCode);
 
         StepVerifier.create(result)
-                .assertNext(response -> assertEquals(false, response.get("isValid")))
+                .assertNext(response -> {
+                    assertEquals(false, response.get("isValid"));
+                    assertEquals(null, response.get("username"));
+                })
                 .verifyComplete();
     }
 
     @Test
-    void validateTokenWithGithub_UnexpectedResponse_ReturnsError() {
-        String token = "valid-token";
-        String mockResponse = "{\"unexpected_key\": \"unexpected_value\"}";
+    void authenticateWithGithub_NullUsername_ReturnsInvalid() {
+        GithubAuthResponseDto mockResponse = new GithubAuthResponseDto(null);
+        when(githubApiService.authenticate(any(GithubAuthRequestDto.class)))
+                .thenReturn(Mono.just(mockResponse));
 
-        mockWebServer.enqueue(new MockResponse()
-                .setBody(mockResponse)
-                .setResponseCode(200)
-                .addHeader("Content-Type", "application/json"));
-
-        Mono<Map<String, Object>> result = authService.validateTokenWithGithub(token);
+        Mono<Map<String, Object>> result = authService.authenticateWithGithub(testCode);
 
         StepVerifier.create(result)
-                .assertNext(response -> assertEquals(false, response.get("isValid")))
+                .assertNext(response -> {
+                    assertEquals(false, response.get("isValid"));
+                    assertEquals(null, response.get("username"));
+                })
                 .verifyComplete();
     }
 
+    @Test
+    void login_ReturnsUsernameG() {
+        String validCode = "valid-code";
+        String githubUsername = "octocat";
+        GithubAuthResponseDto mockResponse = new GithubAuthResponseDto(githubUsername);
+
+        when(githubApiService.authenticate(any(GithubAuthRequestDto.class)))
+                .thenReturn(Mono.just(mockResponse));
+
+        Mono<Map<String, Object>> result = authService.authenticateWithGithub(validCode);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    assertEquals(true, response.get("isValid"));
+                    assertEquals(githubUsername, response.get("username"));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void login_ReturnsInvalidG() {
+        String expiredCode = "expired-code";
+        when(githubApiService.authenticate(any(GithubAuthRequestDto.class)))
+                .thenReturn(Mono.error(new RuntimeException("Bad credentials")));
+
+        Mono<Map<String, Object>> result = authService.authenticateWithGithub(expiredCode);
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    // El onErrorResume del Service debe capturar esto y devolver isValid: false
+                    assertEquals(false, response.get("isValid"));
+                    assertEquals(null, response.get("username"));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void authenticateWithGithub_UnexpectedResponse_ReturnsError() {
+        GithubAuthResponseDto mockResponse = new GithubAuthResponseDto(null);
+
+        when(githubApiService.authenticate(any(GithubAuthRequestDto.class)))
+                .thenReturn(Mono.just(mockResponse));
+
+        Mono<Map<String, Object>> result = authService.authenticateWithGithub("any-code");
+
+        StepVerifier.create(result)
+                .assertNext(response -> {
+                    // Gracias a la nueva lógica, esto ahora será false
+                    assertEquals(false, response.get("isValid"));
+                    assertEquals(null, response.get("username"));
+                })
+                .verifyComplete();
+    }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -107,6 +107,7 @@ class AdminCreateUserServiceTest {
         AdminCreateUserRequestDto request = new AdminCreateUserRequestDto();
         request.setUsername("newUser");
 
+        when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
         when(externalGithubService.userExists("newUser"))
                 .thenReturn(Mono.error(new GithubUnavailableException("GitHub timeout")));
 

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -107,7 +107,6 @@ class AdminCreateUserServiceTest {
         AdminCreateUserRequestDto request = new AdminCreateUserRequestDto();
         request.setUsername("newUser");
 
-        when(userRepository.findByUsername("newUser")).thenReturn(Mono.empty());
         when(externalGithubService.userExists("newUser"))
                 .thenReturn(Mono.error(new GithubUnavailableException("GitHub timeout")));
 


### PR DESCRIPTION
Context / Problem

Auth currently performs direct HTTP calls to GitHub for the code→token exchange and user validation, duplicating logic and maintaining explicit knowledge of GitHub URLs and credentials.

Objective

• Keep the public contract unchanged:
  POST /itachallenge/api/v1/auth/github/authenticate
• Fully delegate GitHub authentication to github-core.
• Preserve the current error-handling model in Auth (AuthService / AuthController).
• Maintain existing response structure and headers.

Scope

• Replace all direct GitHub HTTP calls in the endpoint flow with calls to the github-core public interface.
• Remove from Auth:
  ◦ GitHub-specific WebClient
  ◦ GitHub URLs (api.github.com, login/oauth, token-uri, user-info-uri)
  ◦ client-id and client-secret configuration
• Preserve existing headers:
  ◦ X-Authentication-Status
  ◦ X-GitHub-Username
• Translate errors coming from github-core into the same error schema currently used by Auth (no error-response-core).

Out of scope

• Changes to endpoint routes, HTTP verbs, or payloads.
• Changes to other Auth endpoints (/logout, /switch-role, etc.).

Acceptance Criteria (DoD)

• POST /itachallenge/api/v1/auth/github/authenticate contains no direct HTTP calls to GitHub.
• Auth contains no references to:
  ◦ api.github.com
  ◦ login/oauth
  ◦ token-uri
  ◦ user-info-uri
• The externally visible error behavior (status codes and headers) remains unchanged.
• The GitHub access_token is neither exposed nor logged.
• Unit tests for the endpoint flow mock the github-core interface and cover:
  ◦ happy path
  ◦ 401
  ◦ 403 (user not present in domain)
  ◦ 429
  ◦ 5xx
• Authentication-related code coverage ≥ 80% in the affected package.
• Auth README updated to indicate that GitHub authentication is performed via github-core.

