### PR TITLE
[BE] PR 1/3 refact (user): move user exception handling to common.exception package ( #153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [UNRELEASE] - 2026-02-10
+
+### Changed
+- Refactor of UserGlobalExceptionHandler from `main/java/com/itachallenge/user/exception` to
+  `main/java/com/itachallenge/common/exception`.
+- Refactor of UserGlobalExceptionHandlerTest from `test/java/com/itachallenge/user/exception` to
+    `test/java/com/itachallenge/common/exception`.
+
 ## [Unreleased]
 
 ### Removed

--- a/itachallenge-user/src/main/java/com/itachallenge/common/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/common/exception/UserGlobalExceptionHandler.java
@@ -1,7 +1,8 @@
-package com.itachallenge.user.exception;
+package com.itachallenge.common.exception;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
+import com.itachallenge.user.exception.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/itachallenge-user/src/test/java/com/itachallenge/common/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/common/exception/UserGlobalExceptionHandlerTest.java
@@ -1,12 +1,12 @@
-package com.itachallenge.user.exception;
+package com.itachallenge.common.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
+import com.itachallenge.user.exception.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/AdminCreateUserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/AdminCreateUserControllerTest.java
@@ -1,5 +1,5 @@
 package com.itachallenge.user.controller;
-import com.itachallenge.user.exception.UserGlobalExceptionHandler;
+import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -4,7 +4,7 @@ import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.exception.BadUUIDException;
 import com.itachallenge.user.exception.NotFoundException;
-import com.itachallenge.user.exception.UserGlobalExceptionHandler;
+import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.service.IUserSolutionService;
 import com.itachallenge.user.service.UserService;
 import org.junit.jupiter.api.*;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## Foundation for Unified Exception Handling through micro User

### What This Does
Moves the UserGlobalExceptionHandler to a shared package (common.exception) and verifies it covers all controllers in both user and userinteraction modules.
### closes sub-issue [[BE] PR 1/3 refact (user): move user exception handling to common.exception package #153](https://github.com/IT-Academy-BCN/ita-challenges/issues/153)

### Changes Made
- Moved UserGlobalExceptionHandler from com.itachallenge.user.exception to com.itachallenge.common.exception package.
- Updated UserGlobalExceptionHandler's exception imports.
- Updated imports in all classes and tests needed.

### Testing Performed
- [x] All existing tests pass (regression check).
- [x] Compilation check: all imports updated successfully.

### Tech Debt Notes
- Exception behavior not yet aligned with Challenge micro.
- Old exception classes still in user.exception (will be addressed in PR 2/3 and 3/3).
- Response format remains String (not MessageDto).

### Unblocks
- PR 2/3 and 3/3: Can now move existing common exceptions from user.exeption to common package.
- Frontend: Can verify error formats are consistent across modules.

(I know it's super short, so will be the other 2, but just in case I prefere to keep them separate)