### PR TITLE
[BE] PR 2/3 refact (user) : move NotFoundException User class to common.exception package (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-3.2.1-UNRELEASE] - 2026-02-10
+
+### Changed
+- Refactor of UserGlobalExceptionHandler from `main/java/com/itachallenge/user/exception` to
+  `main/java/com/itachallenge/common/exception`.
+- Refactor of UserGlobalExceptionHandlerTest from `test/java/com/itachallenge/user/exception` to
+    `test/java/com/itachallenge/common/exception`.
+
 ### [itachallenge-user-3.2.1-RELEASE] - 2026-02-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `main/java/com/itachallenge/common/exception`.
 - Refactor of UserGlobalExceptionHandlerTest from `test/java/com/itachallenge/user/exception` to
     `test/java/com/itachallenge/common/exception`.
+- Refactor of `NotFoundException` from `main/java/com/itachallenge/user/exception` to
+  `main/java/com/itachallenge/common/exception`.
 
 ### [itachallenge-user-3.2.1-RELEASE] - 2026-02-10
 

--- a/itachallenge-user/src/main/java/com/itachallenge/common/exception/NotFoundException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/common/exception/NotFoundException.java
@@ -1,4 +1,4 @@
-package com.itachallenge.user.exception;
+package com.itachallenge.common.exception;
 
 public class NotFoundException extends RuntimeException {
 

--- a/itachallenge-user/src/main/java/com/itachallenge/common/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/common/exception/UserGlobalExceptionHandler.java
@@ -1,7 +1,8 @@
-package com.itachallenge.user.exception;
+package com.itachallenge.common.exception;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
+import com.itachallenge.user.exception.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -5,7 +5,7 @@ import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/ChallengeServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/ChallengeServiceImpl.java
@@ -1,7 +1,7 @@
 package com.itachallenge.user.service;
 
 import com.itachallenge.user.dto.SolvedDto;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,7 +11,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.stereotype.Service;
 
-import com.itachallenge.user.document.enums.ChallengeStatus;
 import com.itachallenge.user.exception.BadRequestException;
 import com.itachallenge.user.exception.InternalServerErrorException;
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -2,7 +2,7 @@ package com.itachallenge.user.service;
 
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;
 import org.springframework.stereotype.Service;

--- a/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImpl.java
@@ -1,7 +1,7 @@
 package com.itachallenge.userinteraction.service.bookmark;
 
 import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;
 import com.itachallenge.userinteraction.repository.bookmark.BookmarkRepository;

--- a/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImpl.java
@@ -1,7 +1,7 @@
 package com.itachallenge.userinteraction.service.favorite;
 
 import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.favorite.FavoriteDocument;
 import com.itachallenge.userinteraction.repository.favorite.FavoriteRepository;

--- a/itachallenge-user/src/test/java/com/itachallenge/common/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/common/exception/UserGlobalExceptionHandlerTest.java
@@ -6,7 +6,10 @@ import static org.mockito.Mockito.mock;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
-import com.itachallenge.user.exception.*;
+import com.itachallenge.user.exception.BadRequestException;
+import com.itachallenge.user.exception.DatabaseException;
+import com.itachallenge.user.exception.UnmodificableSolutionException;
+import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;

--- a/itachallenge-user/src/test/java/com/itachallenge/common/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/common/exception/UserGlobalExceptionHandlerTest.java
@@ -1,12 +1,12 @@
-package com.itachallenge.user.exception;
+package com.itachallenge.common.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
+import com.itachallenge.user.exception.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/AdminCreateUserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/AdminCreateUserControllerTest.java
@@ -1,5 +1,5 @@
 package com.itachallenge.user.controller;
-import com.itachallenge.user.exception.UserGlobalExceptionHandler;
+import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -4,7 +4,7 @@ import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.UserSolutionResponseDto;
 import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.service.IUserSolutionService;
 import com.itachallenge.user.service.UserService;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -5,7 +5,7 @@ import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.UserSolutionResponseDto;
 import com.itachallenge.user.exception.BadUUIDException;
 import com.itachallenge.user.exception.NotFoundException;
-import com.itachallenge.user.exception.UserGlobalExceptionHandler;
+import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.service.IUserSolutionService;
 import com.itachallenge.user.service.UserService;
 import org.junit.jupiter.api.*;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
@@ -1,7 +1,7 @@
 package com.itachallenge.user.controller.userinteraction.bookmark;
 
 import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.userinteraction.service.bookmark.BookmarkService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
@@ -1,7 +1,7 @@
 package com.itachallenge.user.controller.userinteraction.favorite;
 
 import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.userinteraction.service.favorite.FavoriteService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -4,7 +4,7 @@ import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/ChallengeServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/ChallengeServiceImplTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenge.user.dto.SolvedDto;
 import com.itachallenge.user.exception.BadRequestException;
 import com.itachallenge.user.exception.InternalServerErrorException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -3,7 +3,7 @@ package com.itachallenge.user.service;
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;
 import com.itachallenge.userinteraction.repository.bookmark.BookmarkRepository;

--- a/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.itachallenge.userinteraction.service.bookmark;
 import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;
 import com.itachallenge.userinteraction.repository.bookmark.BookmarkRepository;

--- a/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImplTest.java
@@ -2,7 +2,7 @@ package com.itachallenge.userinteraction.service.favorite;
 
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.favorite.FavoriteDocument;
 import com.itachallenge.userinteraction.repository.favorite.FavoriteRepository;


### PR DESCRIPTION
## Relocation of NotFoundException User's Class

### Related with PR #1084

### What This Does
- Moved `NotFoundException` from `com.itachallenge.user.exception` to `com.itachallenge.common.exception`,  with no modification of HTTP codes and formats (404/String).
- Updated GlobalExceptionHandler to handle NotFoundException from it's new location.
- Updated imports from all needed classes and tests to point to the new location.

closes [#154](https://github.com/orgs/IT-Academy-BCN/projects/26/views/2?pane=issue&itemId=154445868&issue=IT-Academy-BCN%7Cita-challenges%7C154)

### Changes Made
- Moved NotFoundException from com.itachallenge.user.exception to com.itachallenge.common.exception. 
- Updated GlobalExceptionHandler to handle NotFoundException from it's new location.
- Updated imports from all needed classes and tests to use point the new location.

### Key Decisions Implemented
1. **NotFoundException:** HTTP 404 (not 200 like Challenge) - documented as tech debt.
2. **Error Format:** Plain String (not MessageDto) - documented as tech debt.
3. **Package:** common.exception (shared location).

### Testing Performed
- [x] All existing tests still pass.
- [x] Handler catches exceptions from new locations during transition.

### Tech Debt
1. **HTTP Code Discrepancy:** Challenge returns 200 for NotFound (we use 404).
2. **Format Discrepancy:** Challenge uses MessageDto (we use String).

### Unblocks
- PR #1086 : Can now migrate BadUUIDException.
- QA: Can test error formats are consistent.