### PR TITLE
[BE] PR 3/3 refact (user) : move BadUUIDException User class to common.exception package (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [itachallenge-user-3.2.1-UNRELEASE] - 2026-02-10
+### [itachallenge-user-3.2.2-RELEASE] - 2026-02-10
 
 ### Changed
 - Refactor of UserGlobalExceptionHandler from `main/java/com/itachallenge/user/exception` to
-  `main/java/com/itachallenge/common/exception`.
+ `main/java/com/itachallenge/common/exception`.
 - Refactor of UserGlobalExceptionHandlerTest from `test/java/com/itachallenge/user/exception` to
-    `test/java/com/itachallenge/common/exception`.
+  `test/java/com/itachallenge/common/exception`.
 - Refactor of `NotFoundException` from `main/java/com/itachallenge/user/exception` to
+  `main/java/com/itachallenge/common/exception`.
+- Refactor `BadUUIDException` from `main/java/com/itachallenge/user/exception` to
   `main/java/com/itachallenge/common/exception`.
 
 ### [itachallenge-user-3.2.1-RELEASE] - 2026-02-10

--- a/itachallenge-user/src/main/java/com/itachallenge/common/exception/BadUUIDException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/common/exception/BadUUIDException.java
@@ -1,4 +1,4 @@
-package com.itachallenge.user.exception;
+package com.itachallenge.common.exception;
 
 public class BadUUIDException extends RuntimeException {
 

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -1,7 +1,7 @@
 package com.itachallenge.user.service;
 
 import com.itachallenge.user.document.UserDocument;
-import com.itachallenge.user.exception.BadUUIDException;
+import com.itachallenge.common.exception.BadUUIDException;
 import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;

--- a/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImpl.java
@@ -1,6 +1,6 @@
 package com.itachallenge.userinteraction.service.bookmark;
 
-import com.itachallenge.user.exception.BadUUIDException;
+import com.itachallenge.common.exception.BadUUIDException;
 import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;

--- a/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImpl.java
@@ -1,6 +1,6 @@
 package com.itachallenge.userinteraction.service.favorite;
 
-import com.itachallenge.user.exception.BadUUIDException;
+import com.itachallenge.common.exception.BadUUIDException;
 import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.favorite.FavoriteDocument;

--- a/itachallenge-user/src/test/java/com/itachallenge/common/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/common/exception/UserGlobalExceptionHandlerTest.java
@@ -6,10 +6,7 @@ import static org.mockito.Mockito.mock;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
-import com.itachallenge.user.exception.BadRequestException;
-import com.itachallenge.user.exception.DatabaseException;
-import com.itachallenge.user.exception.UnmodificableSolutionException;
-import com.itachallenge.user.exception.UsernameAlreadyExistsException;
+import com.itachallenge.user.exception.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -3,7 +3,7 @@ package com.itachallenge.user.controller;
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.UserSolutionResponseDto;
-import com.itachallenge.user.exception.BadUUIDException;
+import com.itachallenge.common.exception.BadUUIDException;
 import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.service.IUserSolutionService;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
@@ -1,6 +1,6 @@
 package com.itachallenge.user.controller.userinteraction.bookmark;
 
-import com.itachallenge.user.exception.BadUUIDException;
+import com.itachallenge.common.exception.BadUUIDException;
 import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.userinteraction.service.bookmark.BookmarkService;
 import org.junit.jupiter.api.DisplayName;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
@@ -1,6 +1,6 @@
 package com.itachallenge.user.controller.userinteraction.favorite;
 
-import com.itachallenge.user.exception.BadUUIDException;
+import com.itachallenge.common.exception.BadUUIDException;
 import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.userinteraction.service.favorite.FavoriteService;
 import org.junit.jupiter.api.DisplayName;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -2,7 +2,7 @@ package com.itachallenge.user.service;
 
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
-import com.itachallenge.user.exception.BadUUIDException;
+import com.itachallenge.common.exception.BadUUIDException;
 import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;

--- a/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImplTest.java
@@ -1,5 +1,5 @@
 package com.itachallenge.userinteraction.service.bookmark;
-import com.itachallenge.user.exception.BadUUIDException;
+import com.itachallenge.common.exception.BadUUIDException;
 import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;

--- a/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.itachallenge.userinteraction.service.favorite;
 
 import com.itachallenge.user.document.UserDocument;
-import com.itachallenge.user.exception.BadUUIDException;
+import com.itachallenge.common.exception.BadUUIDException;
 import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.favorite.FavoriteDocument;


### PR DESCRIPTION
## Relocation of BadUUIDException User's Class

### Related with PR #1085

### What This Does
- Moves BadUUIDException from the User micro to common package, with no modification of HTTP codes and formats (400/String).

closes https://github.com/orgs/IT-Academy-BCN/projects/26/views/2?pane=issue&itemId=154447930&issue=IT-Academy-BCN%7Cita-challenges%7C155

### Migration Safety
- **Only import changes:** No logic or error message changes.
- **Git diff verification:** Only package names changed, no behavior changes.
- **Message preservation:** All error messages kept identical (e.g., "The provided IDs are not valid.").

### Changes Made
- Moved BadUUIDException from com.itachallenge.user.exception to com.itachallenge.common.exception.
- Updated GlobalExceptionHandler to handle BadUUIDException from it's new location.
- Updated imports from all needed classes to point the exception's new location.

### Key Decisions Implemented
1. **Error Format:** Plain String (not MessageDto) - documented as tech debt.
2. **Package:** common.exception (shared location).

### Testing Performed
- [x] Updated all existing classes and tests with new imports.
- [x] All existing tests still pass.
- [x] Handler catches exceptions from new locations during transition.
- [x] Single GlobalExceptionHandler covers all controllers.
- [x] No compilation errors after cleanup.

### Tech Debt
1. **0Format Discrepancy:** Challenge uses MessageDto (we use String).

### Final State
✅ UserGlobalExceptionHandler in common.exception.
✅ Standardized NotFoundException (404) and BadUUIDException (400).
✅ All code uses common exceptions.
✅ Acceptance criteria fully verified.