### PR TITLE
feat(challenge): Secure Delete Challenge Endpoint with JWT validation #150

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-challenge-3.2.2-RELEASE] - 2026-02-12
+
+### Added
+- New com.itachallenge.challenge.exception.UnauthorizedException to represent authentication/token failures in the Challenge API. (GitHub Task [#132], Subtask [#150], PR [#1092])
+- Added global handling for UnauthorizedException to return 401 Unauthorized with a consistent message DTO payload. (GitHub Task [#132], Subtask [#150], PR [#1092]
+
+### Changed
+- Updated ChallengeController to convert token parsing/validation failures into UnauthorizedException so the API returns 401 instead of 500. (GitHub Task [#132], Subtask [#150], PR [#1092])
+  * DELETE /challenges/{id} → 401 Unauthorized when the Authorization header/token is missing, invalid, or expired
+
 ### [itachallenge-user-3.2.1-RELEASE] - 2026-02-10
 
 ### Changed

--- a/conf/.env.CI.dev
+++ b/conf/.env.CI.dev
@@ -5,7 +5,7 @@ MICROSERVICE_DEPLOY_itachallenge-user=itachallenge-user
 MICROSERVICE_VERSION_itachallenge-user=3.2.0-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-challenge=itachallenge-challenge
-MICROSERVICE_VERSION_itachallenge-challenge=3.2.1-RELEASE
+MICROSERVICE_VERSION_itachallenge-challenge=3.2.2-RELEASE
 
 MICROSERVICE_DEPLOY_itachallenge-document=itachallenge-document
 MICROSERVICE_VERSION_itachallenge-document=1.0.2-RELEASE

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -3,6 +3,7 @@ package com.itachallenge.challenge.controller;
 import com.itachallenge.challenge.annotations.ValidGenericPattern;
 import com.itachallenge.challenge.config.PropertiesConfig;
 import com.itachallenge.challenge.dto.*;
+import com.itachallenge.challenge.exception.UnauthorizedException;
 import com.itachallenge.common.exception.BadRequestException;
 import com.itachallenge.challenge.exception.JwtException;
 import com.itachallenge.challenge.service.IChallengeService;
@@ -291,7 +292,7 @@ public class ChallengeController {
             @RequestHeader(name = "Authorization", required = false) String authHeader
     ) {
         return Mono.fromCallable(() -> challengeJwtFacade.getUserUuIdFromAuthenticationHeader(authHeader))
-                .onErrorMap(io.jsonwebtoken.JwtException.class, e -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing or invalid authorization token", e))
+                .onErrorMap(e -> new UnauthorizedException("Missing or invalid authorization token"))
                 .flatMap(userId -> challengeService.deleteChallengeById(challengeId))
                 .map(ResponseEntity::ok)
                 .doOnError(error -> log.error("Error deleting challenge: {}", error.getMessage()));

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -20,6 +20,8 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -285,10 +287,14 @@ public class ChallengeController {
             }
     )
     public Mono<ResponseEntity<DeleteResponseDto>> deleteChallenge(
-            @PathVariable String challengeId) {
-
-        return challengeService.deleteChallengeById(challengeId)
-                .map(ResponseEntity::ok);
+            @PathVariable String challengeId,
+            @RequestHeader(name = "Authorization", required = false) String authHeader
+    ) {
+        return Mono.fromCallable(() -> challengeJwtFacade.getUserUuIdFromAuthenticationHeader(authHeader))
+                .onErrorMap(io.jsonwebtoken.JwtException.class, e -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing or invalid authorization token", e))
+                .flatMap(userId -> challengeService.deleteChallengeById(challengeId))
+                .map(ResponseEntity::ok)
+                .doOnError(error -> log.error("Error deleting challenge: {}", error.getMessage()));
     }
 
     @PostMapping("/challenges/{challengeId}/bookmarks")

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/ChallengeController.java
@@ -21,8 +21,6 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/UnauthorizedException.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.itachallenge.challenge.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/common/exception/GlobalExceptionHandler.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/common/exception/GlobalExceptionHandler.java
@@ -192,4 +192,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(new MessageDto(ex.getMessage()));
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<MessageDto> handleUnauthorized(UnauthorizedException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new MessageDto(ex.getMessage()));
+    }
+
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerErrorTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerErrorTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.challenge.controller;
 
 import com.itachallenge.challenge.dto.MessageDto;
 import com.itachallenge.challenge.exception.ChallengeNotFoundException;
+import com.itachallenge.challenge.exception.UnauthorizedException;
 import com.itachallenge.challenge.service.IChallengeService;
 import com.itachallenge.challenge.service.IChallengeJwtFacade;
 import org.junit.jupiter.api.Assertions;
@@ -51,18 +52,24 @@ class ChallengeControllerErrorTest {
     @Test
     void deleteOneChallenge_notFound() {
         String id = "non_existing_id";
+        String authHeader = "Bearer valid.token";
+        String userId = "existing_userId";
 
+        when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
         when(challengeService.deleteChallengeById(id))
-                .thenReturn(Mono.error(
-                        new ChallengeNotFoundException(String.format("Challenge with id: %s not found", id))));
+                .thenReturn(Mono.error(new ChallengeNotFoundException(
+                        String.format("Challenge with id: %s not found", id)
+                )));
 
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/challenge/challenges/" + id)
+                .header("Authorization", authHeader)
                 .exchange()
                 .expectStatus().isNotFound()
                 .expectBody()
-                .jsonPath("$.message")
-                .isEqualTo("Challenge with id: non_existing_id not found");
+                .jsonPath("$.message").isEqualTo("Challenge with id: non_existing_id not found");
+
+        verify(challengeService, times(1)).deleteChallengeById(id);
     }
 
     @Test
@@ -107,5 +114,19 @@ class ChallengeControllerErrorTest {
                 .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
 
         verify(challengeService, times(1)).removeChallengeFromBookmarks(challengeId, userId);
+    }
+
+    @Test
+    void deleteOneChallenge_missingHeader_shouldReturn401() {
+        String id = "non_existing_id";
+
+        when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(null))
+                .thenThrow(new UnauthorizedException("Missing or invalid authorization token"));
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + id)
+                .exchange()
+                .expectStatus().isUnauthorized();
+
+        verify(challengeService, never()).deleteChallengeById(anyString());
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -582,16 +582,39 @@ class ChallengeControllerTest {
     @Test
     void deleteOneChallenge_notFound() {
         String id = "non_existing_id";
+        String authHeader = "Bearer valid.token";
+        String userId = "existing_userId";
 
+        when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
         when(challengeService.deleteChallengeById(id))
-                .thenReturn(Mono.error(new ChallengeNotFoundException(String.format("Challenge with id: %s not found", id))));
+                .thenReturn(Mono.error(new ChallengeNotFoundException(
+                        String.format("Challenge with id: %s not found", id)
+                )));
 
         webTestClient.delete()
                 .uri("/itachallenge/api/v1/challenge/challenges/" + id)
+                .header("Authorization", authHeader)
                 .exchange()
                 .expectStatus().isNotFound()
                 .expectBody()
                 .jsonPath("$.message").isEqualTo("Challenge with id: non_existing_id not found");
+
+        verify(challengeService, times(1)).deleteChallengeById(id);
+    }
+
+    @Test
+    void deleteOneChallenge_missingHeader_shouldReturn401() {
+        String id = "non_existing_id";
+
+        when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(null))
+                .thenThrow(new io.jsonwebtoken.JwtException("Missing or bad formatted Authorization header"));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + id)
+                .exchange()
+                .expectStatus().isUnauthorized();
+
+        verify(challengeService, never()).deleteChallengeById(anyString());
     }
 
     @Test

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -292,21 +292,6 @@ class ChallengeControllerTest {
     }
 
     @Test
-    void getRelatedChallenges_NotFound_Returns404() {
-        String uuid = UUID.randomUUID().toString();
-
-        when(challengeService.getRelatedChallenges(uuid))
-                .thenReturn(Mono.error(new ChallengeNotFoundException("Challenge not found")));
-
-        webTestClient.get()
-                .uri("/itachallenge/api/v1/challenge/challenges/{challengeId}/related", uuid)
-                .exchange()
-                .expectStatus().isNotFound()
-                .expectBody(MessageDto.class)
-                .consumeWith(response -> assertNotNull(response.getResponseBody()));
-    }
-
-    @Test
     void getRelatedChallenges_NoContent_Returns204() {
         String uuid = UUID.randomUUID().toString();
 
@@ -580,44 +565,6 @@ class ChallengeControllerTest {
     }
 
     @Test
-    void deleteOneChallenge_notFound() {
-        String id = "non_existing_id";
-        String authHeader = "Bearer valid.token";
-        String userId = "existing_userId";
-
-        when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-        when(challengeService.deleteChallengeById(id))
-                .thenReturn(Mono.error(new ChallengeNotFoundException(
-                        String.format("Challenge with id: %s not found", id)
-                )));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + id)
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus().isNotFound()
-                .expectBody()
-                .jsonPath("$.message").isEqualTo("Challenge with id: non_existing_id not found");
-
-        verify(challengeService, times(1)).deleteChallengeById(id);
-    }
-
-    @Test
-    void deleteOneChallenge_missingHeader_shouldReturn401() {
-        String id = "non_existing_id";
-
-        when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(null))
-                .thenThrow(new io.jsonwebtoken.JwtException("Missing or bad formatted Authorization header"));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + id)
-                .exchange()
-                .expectStatus().isUnauthorized();
-
-        verify(challengeService, never()).deleteChallengeById(anyString());
-    }
-
-    @Test
     void addChallengeToBookmarks_Success_Returns200() {
         String challengeId = "existing_challengeId";
         String userId = "existing_userId";
@@ -635,28 +582,6 @@ class ChallengeControllerTest {
                 .expectStatus().isOk()
                 .expectBody(BookmarkDto.class)
                 .isEqualTo(expectedResponse);
-
-        verify(challengeService, times(1)).addChallengeToBookmarks(challengeId, userId);
-    }
-
-    @Test
-    void addChallengeToBookmarks_ChallengeNotFound_Returns404() {
-        String challengeId = "nonExisting_challengeId";
-        String userId = "existing_userId";
-        String authHeader = "validAuthHeader";
-
-        String errorMessage = "ErrorMessage";
-
-        when(challengeService.addChallengeToBookmarks(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundException(errorMessage)));
-        when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/bookmarks")
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus().isNotFound()
-                .expectBody(MessageDto.class)
-                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
 
         verify(challengeService, times(1)).addChallengeToBookmarks(challengeId, userId);
     }
@@ -893,28 +818,6 @@ class ChallengeControllerTest {
                 .expectStatus().isOk()
                 .expectBody(BookmarkDto.class)
                 .isEqualTo(expectedResponse);
-
-        verify(challengeService, times(1)).removeChallengeFromBookmarks(challengeId, userId);
-    }
-
-    @Test
-    void removeChallengeFromBookmarks_ChallengeNotFound_Returns404() {
-        String challengeId = "nonExisting_challengeId";
-        String userId = "existing_userId";
-        String authHeader = "validAuthHeader";
-
-        String errorMessage = "ErrorMessage";
-
-        when(challengeService.removeChallengeFromBookmarks(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundException(errorMessage)));
-        when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/bookmarks")
-                .header("Authorization", authHeader)
-                .exchange()
-                .expectStatus().isNotFound()
-                .expectBody(MessageDto.class)
-                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
 
         verify(challengeService, times(1)).removeChallengeFromBookmarks(challengeId, userId);
     }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/ChallengeControllerTest.java
@@ -292,6 +292,21 @@ class ChallengeControllerTest {
     }
 
     @Test
+    void getRelatedChallenges_NotFound_Returns404() {
+        String uuid = UUID.randomUUID().toString();
+
+        when(challengeService.getRelatedChallenges(uuid))
+                .thenReturn(Mono.error(new ChallengeNotFoundException("Challenge not found")));
+
+        webTestClient.get()
+                .uri("/itachallenge/api/v1/challenge/challenges/{challengeId}/related", uuid)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(MessageDto.class)
+                .consumeWith(response -> assertNotNull(response.getResponseBody()));
+    }
+
+    @Test
     void getRelatedChallenges_NoContent_Returns204() {
         String uuid = UUID.randomUUID().toString();
 
@@ -625,6 +640,28 @@ class ChallengeControllerTest {
     }
 
     @Test
+    void addChallengeToBookmarks_ChallengeNotFound_Returns404() {
+        String challengeId = "nonExisting_challengeId";
+        String userId = "existing_userId";
+        String authHeader = "validAuthHeader";
+
+        String errorMessage = "ErrorMessage";
+
+        when(challengeService.addChallengeToBookmarks(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundException(errorMessage)));
+        when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/bookmarks")
+                .header("Authorization", authHeader)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(MessageDto.class)
+                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
+
+        verify(challengeService, times(1)).addChallengeToBookmarks(challengeId, userId);
+    }
+
+    @Test
     void addChallengeToBookmarks_InternalServerError_Returns500() {
         String challengeId = "Existing_challengeId";
         String userId = "existing_userId";
@@ -856,6 +893,28 @@ class ChallengeControllerTest {
                 .expectStatus().isOk()
                 .expectBody(BookmarkDto.class)
                 .isEqualTo(expectedResponse);
+
+        verify(challengeService, times(1)).removeChallengeFromBookmarks(challengeId, userId);
+    }
+
+    @Test
+    void removeChallengeFromBookmarks_ChallengeNotFound_Returns404() {
+        String challengeId = "nonExisting_challengeId";
+        String userId = "existing_userId";
+        String authHeader = "validAuthHeader";
+
+        String errorMessage = "ErrorMessage";
+
+        when(challengeService.removeChallengeFromBookmarks(challengeId, userId)).thenReturn(Mono.error(new ChallengeNotFoundException(errorMessage)));
+        when(challengeJwtFacade.getUserUuIdFromAuthenticationHeader(authHeader)).thenReturn(userId);
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/challenge/challenges/" + challengeId + "/bookmarks")
+                .header("Authorization", authHeader)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(MessageDto.class)
+                .value(messageDto -> Assertions.assertEquals(errorMessage, messageDto.getMessage()));
 
         verify(challengeService, times(1)).removeChallengeFromBookmarks(challengeId, userId);
     }


### PR DESCRIPTION
## 📌 Summary ##
Secures the DELETE challenge endpoint in the Challenge microservice by reusing the existing JWT validation approach already used in this controller (bookmarks/update).

The endpoint now requires a valid Authorization: Bearer <token> and returns 401 Unauthorized when the header is missing or invalid, without introducing Spring Security or new auth mechanisms.

## 🎯 Scope ##
MVP (required):

Protect DELETE /itachallenge/api/v1/challenge/challenges/{challengeId}

Manually read the Authorization header (same pattern as bookmarks/update)

Validate JWT using ChallengeJwtFacade + jwt-core

Extract UUID from JWT (via the facade)

Return 401 if Authorization header is missing/invalid

## 🧱 Architecture ##

No Spring Security Resource Server introduced.

No new security layers or mechanisms added.

To enforce the MVP behavior (401 when Authorization header is missing/invalid), the controller maps JWT validation errors to an HTTP status using Spring Web utilities:

- org.springframework.http.HttpStatus
- org.springframework.web.server.ResponseStatusException

Implementation stays at controller level and matches the pattern already present:

- Read Authorization header
- Delegate parsing/validation to ChallengeJwtFacade (backed by jwt-core)

JWT validation uses the JJWT exception type (io.jsonwebtoken.JwtException). To avoid conflicts with similarly named/custom exceptions, the code references the JJWT exception explicitly where needed.

## 🔒 Validations ##

A request is authorized only if:

Header exists and starts with Bearer

ChallengeJwtFacade.getUserUuIdFromAuthenticationHeader(...) successfully extracts a UUID

Missing/invalid header/token → 401 Unauthorized

## 🧪 Tests ##

Controller tests were updated to reflect the new DELETE JWT requirement and to avoid false positives:

### Updated deleteOneChallenge_notFound ###

This test now includes a valid Authorization: Bearer ... header and mocks the UUID extraction with ChallengeJwtFacade.
Reason: once DELETE is protected, a request without a token will return 401 before reaching the service, so to assert the real 404 Not Found path, the request must pass JWT validation first.
The test verifies:

JWT UUID extraction is successful (challengeJwtFacade.getUserUuIdFromAuthenticationHeader(authHeader) returns a userId)

The service is called once

The endpoint returns 404 with the expected error message when the challenge does not exist

### Added deleteOneChallenge_missingHeader_shouldReturn401 ###

New coverage for the MVP behavior: calling DELETE without the Authorization header must return 401 Unauthorized.
The test mocks the facade to throw io.jsonwebtoken.JwtException when the header is missing, and asserts:

Response status is 401

The service is never invoked (verify(..., never())) ensuring the request is blocked at the JWT validation step

## 🧹 Refactor suggestion (follow-up / tech debt) ##
It would be useful to refactor the controller to extract the repeated JWT validation logic into a small helper method (or shared utility), so we don’t duplicate the same pattern across endpoints (bookmarks/update/delete and others).

Example idea:

- Create a private method in the controller like requireUserId(authHeader) that:
- validates Authorization: Bearer ...
- delegates to ChallengeJwtFacade
- maps JWT errors to the expected HTTP status (401)
- Then each endpoint can simply call .flatMap(userId -> ...) and keep the business flow clean.

This keeps the sprint implementation unchanged, but improves readability, reduces duplication, and makes future changes to JWT handling safer and faster.