### PR TITLE
Disable Testcontainers when Docker is unavailable in CI

### DIFF
--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/config/dbchangelog/DataBaseRollBackTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/config/dbchangelog/DataBaseRollBackTest.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @SpringBootTest
 class DataBaseRollBackTest {
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/config/dbchangelog/MongockTestContainer.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/config/dbchangelog/MongockTestContainer.java
@@ -18,7 +18,7 @@ import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @SpringBootTest
 class MongockTestContainer {
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/ChallengeIntegrationTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @Import(GlobalExceptionHandler.class)
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/MongockIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/integration/MongockIntegrationTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 class MongockIntegrationTest {
     @Mock
     MongoDatabase mongoDatabase;

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ChallengeRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ChallengeRepositoryTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.*;
 import static org.springframework.test.util.AssertionErrors.fail;
 
 @DataMongoTest
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ChallengeRepositoryTest {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/LanguageRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/LanguageRepositoryTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.springframework.test.util.AssertionErrors.fail;
 
 @DataMongoTest
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class LanguageRepositoryTest {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ResourceRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/ResourceRepositoryTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @DataMongoTest
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/SolutionRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/SolutionRepositoryTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.springframework.test.util.AssertionErrors.fail;
 
 @DataMongoTest
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class SolutionRepositoryTest {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/repository/TagRepositoryTest.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 import static org.junit.Assert.*;
 
 @DataMongoTest
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class TagRepositoryTest {

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerIntegrationTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerIntegrationTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @AutoConfigureWebTestClient
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 class FavoriteControllerIntegrationTest {
 
     @Container


### PR DESCRIPTION
Problem:
Integration tests using Testcontainers were failing in CI with:
"Could not find a valid Docker environment".

Cause:
CI runners may not always have Docker available or accessible.

Solution:
Use @Testcontainers(disabledWithoutDocker = true) so integration tests are skipped instead of failing when Docker is unavailable.

Impact:
- No change in local development behavior
- CI pipelines no longer fail due to missing Docker
- Integration tests still run when Docker is available
