### PR TITLE
[BE] PR 2/4 feat(challenge): migrate favorites calls to new user favorites endpoint (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reactive Repository for user score transactions.
 
 ## [Unreleased]
-### Refactored
+
+### Changed
 - Refactored Favorites API endpoints to a more REST-style subresource path under users.
+- Updated challenge service test configuration and UserServiceImplTest path templates to match the new Favorites endpoint path.
+- - Updated the challenge microservice favorites integration path to use the new User Favorites endpoint: /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}.
+- Updated APISIX routes (dev and pro configs) to proxy Favorites requests through /itachallenge/api/v1/user/users/**.
 ### Removed
 - Removed legacy GET endpoint for user solutions from User microservice.
 ### Added
-- Added new Favorites routes:
-GET /itachallenge/api/v1/user/users/{userId}/favorites
-POST /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}
-DELETE /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}
+  - Added new Favorites routes:
+  GET /itachallenge/api/v1/user/users/{userId}/favorites
+  POST /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}
+  DELETE /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}
 - Added config properties in application.yml for successor endpoint paths used by legacy deprecation headers.
 - Added/updated unit and integration tests to cover both the new Favorites endpoints and the legacy deprecated endpoints.
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed legacy GET endpoint for user solutions from User microservice.
 ### Added
   - Added new Favorites routes:
-  GET /itachallenge/api/v1/user/users/{userId}/favorites
-  POST /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}
-  DELETE /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}
+  GET /itachallenge/api/v1/users/{userId}/favorites
+  POST /itachallenge/api/v1/users/{userId}/favorites/{challengeId}
+  DELETE /itachallenge/api/v1/users/{userId}/favorites/{challengeId}
 - Added config properties in application.yml for successor endpoint paths used by legacy deprecation headers.
 - Added/updated unit and integration tests to cover both the new Favorites endpoints and the legacy deprecated endpoints.
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Refactored Favorites API endpoints to a more REST-style subresource path under users.
 - Updated challenge service test configuration and UserServiceImplTest path templates to match the new Favorites endpoint path.
-- - Updated the challenge microservice favorites integration path to use the new User Favorites endpoint: /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}.
+- Updated the challenge microservice favorites integration path to use the new User Favorites endpoint: /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}.
 - Updated APISIX routes (dev and pro configs) to proxy Favorites requests through /itachallenge/api/v1/user/users/**.
 ### Removed
 - Removed legacy GET endpoint for user solutions from User microservice.

--- a/contributors.md
+++ b/contributors.md
@@ -120,3 +120,4 @@
 * Lois González Alonso - https://github.com/pantalois
 * Pol Serrano Franquesa - https://github.com/polserrano8
 * Andrea Pan i Ubiergo - https://github.com/Apani13
+* Pol Serrano Franquesa - https://github.com/polserrano8

--- a/docker/apisix_conf/apisix_standalone_dev.yaml
+++ b/docker/apisix_conf/apisix_standalone_dev.yaml
@@ -37,7 +37,7 @@ routes:
       - GET
     upstream_id: 6
   -
-      uri: /itachallenge/api/v1/userinteraction/favorites/**
+      uri: /itachallenge/api/v1/user/users/**
       methods:
         - GET, POST, DELETE
       upstream_id: 6

--- a/docker/apisix_conf/apisix_standalone_dev.yaml
+++ b/docker/apisix_conf/apisix_standalone_dev.yaml
@@ -37,7 +37,7 @@ routes:
       - GET
     upstream_id: 6
   -
-      uri: /itachallenge/api/v1/user/users/**
+      uri: /itachallenge/api/v1/users/**
       methods:
         - GET, POST, DELETE
       upstream_id: 6

--- a/docker/apisix_conf/apisix_standalone_pro.yaml
+++ b/docker/apisix_conf/apisix_standalone_pro.yaml
@@ -28,7 +28,7 @@ routes:
     upstream_id: 2
 
   -
-    uri: /itachallenge/api/v1/user/users/**
+    uri: /itachallenge/api/v1/users/**
     methods:
       - GET, POST, DELETE
     upstream_id: 2

--- a/docker/apisix_conf/apisix_standalone_pro.yaml
+++ b/docker/apisix_conf/apisix_standalone_pro.yaml
@@ -28,7 +28,7 @@ routes:
     upstream_id: 2
 
   -
-    uri: /itachallenge/api/v1/userinteraction/favorites/**
+    uri: /itachallenge/api/v1/user/users/**
     methods:
       - GET, POST, DELETE
     upstream_id: 2

--- a/itachallenge-challenge/src/main/resources/application.yml
+++ b/itachallenge-challenge/src/main/resources/application.yml
@@ -71,8 +71,8 @@ user:
     url: http://apisix-gateway:9080 # IN PRODUCTION
     #url: http://172.17.0.2:8764 # LOCAL IP
   endpoints:
-    favorites: /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}
-    bookmarks: /itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}
+    favorites: /itachallenge/api/v1/users/{userId}/favorites/{challengeId}
+    bookmarks: /itachallenge/api/v1/users/{userId}/bookmarks/{challengeId}
 
 token:
   signing:

--- a/itachallenge-challenge/src/main/resources/application.yml
+++ b/itachallenge-challenge/src/main/resources/application.yml
@@ -71,7 +71,7 @@ user:
     url: http://apisix-gateway:9080 # IN PRODUCTION
     #url: http://172.17.0.2:8764 # LOCAL IP
   endpoints:
-    favorites: /itachallenge/api/v1/userinteraction/favorites/users/{userId}/favorites/{challengeId}
+    favorites: /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}
     bookmarks: /itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}
 
 token:

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/UserServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/UserServiceImplTest.java
@@ -22,11 +22,11 @@ public class UserServiceImplTest {
     private MockWebServer mockWebServer;
     private UserServiceImpl userService;
     private static final String FAVORITES_URL =
-            "/itachallenge/api/v1/user/users/%s/favorites/%s";
+            "/itachallenge/api/v1/users/%s/favorites/%s";
     private static final String BOOKMARKS_URL =
             "/itachallenge/api/v1/user/users/%s/bookmarks/%s";
     private static final String FAVORITES_TEMPLATE =
-            "/itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}";
+            "/itachallenge/api/v1/users/{userId}/favorites/{challengeId}";
     private static final String BOOKMARKS_TEMPLATE =
             "/itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}";
     private static final String SOLVED_URL = "/itachallenge/api/v1/user/users/%s/solved/%s";

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/UserServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/service/UserServiceImplTest.java
@@ -22,11 +22,11 @@ public class UserServiceImplTest {
     private MockWebServer mockWebServer;
     private UserServiceImpl userService;
     private static final String FAVORITES_URL =
-            "/itachallenge/api/v1/userinteraction/favorites/users/%s/favorites/%s";
+            "/itachallenge/api/v1/user/users/%s/favorites/%s";
     private static final String BOOKMARKS_URL =
             "/itachallenge/api/v1/user/users/%s/bookmarks/%s";
     private static final String FAVORITES_TEMPLATE =
-            "/itachallenge/api/v1/userinteraction/favorites/users/{userId}/favorites/{challengeId}";
+            "/itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}";
     private static final String BOOKMARKS_TEMPLATE =
             "/itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}";
     private static final String SOLVED_URL = "/itachallenge/api/v1/user/users/%s/solved/%s";

--- a/itachallenge-challenge/src/test/resources/application.yml
+++ b/itachallenge-challenge/src/test/resources/application.yml
@@ -55,7 +55,7 @@ user:
   service:
     url: http://notreallymatters
   endpoints:
-    favorites: /itachallenge/api/v1/userinteraction/favorites/users/{userId}/favorites/{challengeId}
+    favorites: /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}
     bookmarks: /itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}
 
 token:

--- a/itachallenge-challenge/src/test/resources/application.yml
+++ b/itachallenge-challenge/src/test/resources/application.yml
@@ -55,8 +55,8 @@ user:
   service:
     url: http://notreallymatters
   endpoints:
-    favorites: /itachallenge/api/v1/user/users/{userId}/favorites/{challengeId}
-    bookmarks: /itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}
+    favorites: /itachallenge/api/v1/users/{userId}/favorites/{challengeId}
+    bookmarks: /itachallenge/api/v1/users/{userId}/bookmarks/{challengeId}
 
 token:
   signing:


### PR DESCRIPTION
Update the Challenge -> User favorites route configuration to use the new User Favorites contract while keeping Challenge public favorites endpoints unchanged.

Changes:
- update `user.endpoints.favorites` in challenge main config
- update `user.endpoints.favorites` in challenge test config
- update `UserServiceImplTest` favorites URL/template expectations
- update APISIX dev/pro routes to allow the new favorites path (`GET, POST, DELETE`)
- keep legacy route available during staged migration (if still needed)

This aligns the challenge microservice with the User favorites endpoint refactor and prevents route mismatches in runtime/tests.

Merge Order / Dependency (Important)
This PR must be merged after PR #199.

PR #199 introduced the new Favorites endpoints in the user microservice (while keeping legacy compatibility). This PR depends on that new contract being available.

All test have passed. 
<img width="1767" height="783" alt="image" src="https://github.com/user-attachments/assets/36aa4283-6b18-4699-b1d9-84b73bf07c05" />
