### PR TITLE
refactor(243): move global exceptions to common.exception package (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor: Moved `UserGlobalExceptionHandler`, `BadUUIDException`, and `NotFoundException` to the new package.
 - Updated imports across `user` and `userinteraction` modules to use the unified exceptions.
 - Refactored `UserGlobalExceptionHandlerTest` to align with the new package structure.
-- Ensured the GlobalExceptionHandler applies to controllers from both modules via component scanning.
 
 ## [itachallenge-challenge-3.3.0] - 2026-03-05
 
@@ -47,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - HTTP status codes
   - JSON response schema
   - error responses.
-
+  
 ### [itachallenge-user-3.2.3-RELEASE] - 2026-02-18
 
 ### Removed
@@ -112,12 +111,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Submission domain bootstrap (documents, repository, service layer and DTOs).
 - New `SubmissionController` exposing read endpoints for user submissions.
-
+ 
 ### [itachallenge-challenge-3.0.4-RELEASE] - 2025-12-17
 
 ### Fixed
 - Updated the favorites integration path to point to the new `FavoriteController` of the `user` micro.
-  (No changes to the public `challenge` API. Bookmarks remains the same.)
+(No changes to the public `challenge` API. Bookmarks remains the same.)
 
 ### [itachallenge-user-3.1.3-RELEASE] - 2025-12-12
 
@@ -155,11 +154,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Change
 - API Contract: Replaced the `status` field with action in UserSolutionRequestDto.
-  Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
+Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 - New SolutionAction enum : Action-based submission workflow: Implemented business logic to map user actions to internal solution statuses:
-  - SAVE → IN_PROGRESS
-  - GIVE_UP → SUBMITTED_UNCOMPLETED
-  - SUBMIT → SUBMITTED_COMPLETED
+    - SAVE → IN_PROGRESS
+    - GIVE_UP → SUBMITTED_UNCOMPLETED
+    - SUBMIT → SUBMITTED_COMPLETED
 - Updated OpenAPI documentation.
 
 ## [Unreleased]
@@ -230,10 +229,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Foundation for managing user favorites in a dedicated collection.
   - Favorite domain & persistence
-    - FavoriteDocument & FavoriteDocumentTest
+    - FavoriteDocument & FavoriteDocumentTest 
     - FavoriteRepository (ReactiveMongoRepository<FavoriteDocument, UUID>) ; Favorites collection starts empty.
     - FavoriteResponseDto & FavoriteResponseDtoTest
-
+ 
 
 ### Changed
 - UserServiceImpl
@@ -271,20 +270,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Now returns 503 Service Unavailable or 504 Gateway Timeout instead of a generic 500.
   - Introduced `GithubUnavailableException` to encapsulate timeout and unavailability causes.
   - Updated `UserGlobalExceptionHandler` to map these cases accordingly.
-  -
+  - 
 ### [itachallenge-user-3.0.0-RELEASE] - 2025-10-09
 
 ### Changed
-- Before: SolutionStatus enum only had two options `ENDED` and `IN_PROGRESS`, solutions with status `ENDED` could be modified,
+- Before: SolutionStatus enum only had two options `ENDED` and `IN_PROGRESS`, solutions with status `ENDED` could be modified, 
   leading to ambiguity in submission state.
 - After: SolutionStatus enum options can be marked as `IN_PROGRESS`, `SUBMITTED_COMPLETE` or `SUBMITTED_INCOMPLETE`.
   Solutions marked as `SUBMITTED_COMPLETE` or `SUBMITTED_INCOMPLETE` now throw `UnmodifiableSolutionException`
   when updated. Only `IN_PROGRESS` solutions remain editable.
 - This changes prevents accidental overwrites of finalized submissions.
 - this changes will break the communication between back and frontend, it is required to adjust the type of answer that can be submitted
-  by users ENDED is replaced with SUBMITTED_COMPLETE and SUBMITTED_INCOMPLETE has to be added to better reflect the status
+  by users ENDED is replaced with SUBMITTED_COMPLETE and SUBMITTED_INCOMPLETE has to be added to better reflect the status 
   in which challenges can be set (Taiga user story [#703])
-
+  
 ### [itachallenge-user-2.1.0-RELEASE] - 2025-10-03
 
 ### Added
@@ -301,8 +300,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added github username validation to user microservice upon creation of a new user (Taiga [#650], PR [#960])
-  - Before: POST /users/create accepted any githubUsername value and returned success (201/ok) even if that wasn't a GitHub username.
-  - After: POST /users/create now calls the GitHub API and rejects the request when the GitHub username does not exist.
+  - Before: POST /users/create accepted any githubUsername value and returned success (201/ok) even if that wasn't a GitHub username. 
+  - After: POST /users/create now calls the GitHub API and rejects the request when the GitHub username does not exist. 
   - Clients that previously relied on creating users with invalid GitHub usernames will now get errors for some requests that used to succeed.
 
 ### [itachallenge-githubcore-1.0.0-RELEASE] - 2025-09-11
@@ -414,15 +413,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add validation to verify that the provided user ID exists for the getAllSolutionsByUser endpoint. (Taiga [#437], PR [#889])
-- FavoriteController and extracted endpoints from ChallengeController. (Taiga [#418], PR [#886])
-- POST endpoint in Auth microservice to allow user role change at runtime (Taiga [#404], PR [#882])
-- Hardcoded GET endpoint to return all of a user’s challenge solutions (Taiga [#435], PR [#884])
-- JWT authentication to logout endpoint in User microservice (Taiga [#399], PR [#864])
-- Error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags (Taiga [#355], PR [#872])
-- Tag validation in the addChallenge endpoint (Taiga [#354], PR [#866])
+- FavoriteController and extracted endpoints from ChallengeController. (Taiga [#418], PR [#886]) 
+- POST endpoint in Auth microservice to allow user role change at runtime (Taiga [#404], PR [#882])  
+- Hardcoded GET endpoint to return all of a user’s challenge solutions (Taiga [#435], PR [#884])  
+- JWT authentication to logout endpoint in User microservice (Taiga [#399], PR [#864])  
+- Error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags (Taiga [#355], PR [#872]) 
+- Tag validation in the addChallenge endpoint (Taiga [#354], PR [#866])  
 - GET endpoint for retrieving resources from a challenge (Taiga [#281], PR [#852])
-- GET endpoint to retrieve all user's bookmarked challenges (Taiga [#255], PR [#849])
-- DELETE endpoint in Challenge microservice to unbookmark a challenge (Taiga [#205], PR [#843])
+- GET endpoint to retrieve all user's bookmarked challenges (Taiga [#255], PR [#849]) 
+- DELETE endpoint in Challenge microservice to unbookmark a challenge (Taiga [#205], PR [#843]) 
 - POST endpoint in Challenge microservice to bookmark a challenge (Taiga [#183], PR [#829])
 - POST endpoint in User microservice to bookmark a challenge (Taiga [#183], PR [#827])
 - DELETE endpoint for user's bookmarks in User microservice (Taiga [#205], PR [#831])
@@ -434,7 +433,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced Hardcoded GET endpoint to return all of a user’s challenge solutions with actual solutions (Taiga [#406], PR [#887])
 - POST endpoint for adding new challenges in Challenge microservice (PR #763)
 - Improved filtering at `/GET Challenges`: added DTO for filters (language, level, tags), refactored `filterByLanguage()`, `filterByLevel()`, and `filterByTags()` methods, and added `GET /allTags` endpoint (PR #180 & PR #185)
-- Modify method to increase times solved counter (Taiga [#415], PR [#885])
+- Modify method to increase times solved counter (Taiga [#415], PR [#885]) 
 
 ### Removed
 - Removed `score` attribute from `UserSolution` DTOs and cleaned up all score/solution-related code in User microservice (PR #825, PR #725)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [itachallenge-user-3.2.4-RELEASE] - 2026-03-16
 
-### Changed 
+### Changed
 
 - Introduced `common.exception` package to centralize cross-cutting exceptions in the User microservice.
 - Refactor: Moved `UserGlobalExceptionHandler`, `BadUUIDException`, and `NotFoundException` to the new package.
@@ -47,29 +47,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - HTTP status codes
   - JSON response schema
   - error responses.
-  
+
 ### [itachallenge-user-3.2.3-RELEASE] - 2026-02-18
 
 ### Removed
 - Removed deprecated legacy Bookmarks routes previously served by BookmarkLegacyController. (GitHub Task [#186], PR [#1106])
 ## [UNRELEASED]
 
-## [Unreleased]
-
 ### Added
-
 - New MongoDB collection `user_score_history` with compound indexing for efficient retrieval for gamification tracking.
 - Reactive Repository for user score transactions.
 
-### Changed
-
-#### User Microservice Exception Handling Refactor
-
-- Introduced `common.exception` package to centralize cross-cutting exceptions in the User microservice.
-- Moved `UserGlobalExceptionHandler`, `BadUUIDException`, and `NotFoundException` to the new package.
-- Updated imports across `user` and `userinteraction` modules to use the unified exceptions.
-- Refactored `UserGlobalExceptionHandlerTest` to align with the new package structure.
-- Ensured the GlobalExceptionHandler applies to controllers from both modules via component scanning.
+## [Unreleased]
 ### [itachallenge-user-3.2.2-RELEASE] - 2026-02-23
 
 ### Removed
@@ -123,12 +112,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Submission domain bootstrap (documents, repository, service layer and DTOs).
 - New `SubmissionController` exposing read endpoints for user submissions.
- 
+
 ### [itachallenge-challenge-3.0.4-RELEASE] - 2025-12-17
 
 ### Fixed
 - Updated the favorites integration path to point to the new `FavoriteController` of the `user` micro.
-(No changes to the public `challenge` API. Bookmarks remains the same.)
+  (No changes to the public `challenge` API. Bookmarks remains the same.)
 
 ### [itachallenge-user-3.1.3-RELEASE] - 2025-12-12
 
@@ -166,11 +155,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Change
 - API Contract: Replaced the `status` field with action in UserSolutionRequestDto.
-Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
+  Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 - New SolutionAction enum : Action-based submission workflow: Implemented business logic to map user actions to internal solution statuses:
-    - SAVE → IN_PROGRESS
-    - GIVE_UP → SUBMITTED_UNCOMPLETED
-    - SUBMIT → SUBMITTED_COMPLETED
+  - SAVE → IN_PROGRESS
+  - GIVE_UP → SUBMITTED_UNCOMPLETED
+  - SUBMIT → SUBMITTED_COMPLETED
 - Updated OpenAPI documentation.
 
 ## [Unreleased]
@@ -241,10 +230,10 @@ Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 ### Added
 - Foundation for managing user favorites in a dedicated collection.
   - Favorite domain & persistence
-    - FavoriteDocument & FavoriteDocumentTest 
+    - FavoriteDocument & FavoriteDocumentTest
     - FavoriteRepository (ReactiveMongoRepository<FavoriteDocument, UUID>) ; Favorites collection starts empty.
     - FavoriteResponseDto & FavoriteResponseDtoTest
- 
+
 
 ### Changed
 - UserServiceImpl
@@ -282,20 +271,20 @@ Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
   - Now returns 503 Service Unavailable or 504 Gateway Timeout instead of a generic 500.
   - Introduced `GithubUnavailableException` to encapsulate timeout and unavailability causes.
   - Updated `UserGlobalExceptionHandler` to map these cases accordingly.
-  - 
+  -
 ### [itachallenge-user-3.0.0-RELEASE] - 2025-10-09
 
 ### Changed
-- Before: SolutionStatus enum only had two options `ENDED` and `IN_PROGRESS`, solutions with status `ENDED` could be modified, 
+- Before: SolutionStatus enum only had two options `ENDED` and `IN_PROGRESS`, solutions with status `ENDED` could be modified,
   leading to ambiguity in submission state.
 - After: SolutionStatus enum options can be marked as `IN_PROGRESS`, `SUBMITTED_COMPLETE` or `SUBMITTED_INCOMPLETE`.
   Solutions marked as `SUBMITTED_COMPLETE` or `SUBMITTED_INCOMPLETE` now throw `UnmodifiableSolutionException`
   when updated. Only `IN_PROGRESS` solutions remain editable.
 - This changes prevents accidental overwrites of finalized submissions.
 - this changes will break the communication between back and frontend, it is required to adjust the type of answer that can be submitted
-  by users ENDED is replaced with SUBMITTED_COMPLETE and SUBMITTED_INCOMPLETE has to be added to better reflect the status 
+  by users ENDED is replaced with SUBMITTED_COMPLETE and SUBMITTED_INCOMPLETE has to be added to better reflect the status
   in which challenges can be set (Taiga user story [#703])
-  
+
 ### [itachallenge-user-2.1.0-RELEASE] - 2025-10-03
 
 ### Added
@@ -312,8 +301,8 @@ Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 
 ### Changed
 - Added github username validation to user microservice upon creation of a new user (Taiga [#650], PR [#960])
-  - Before: POST /users/create accepted any githubUsername value and returned success (201/ok) even if that wasn't a GitHub username. 
-  - After: POST /users/create now calls the GitHub API and rejects the request when the GitHub username does not exist. 
+  - Before: POST /users/create accepted any githubUsername value and returned success (201/ok) even if that wasn't a GitHub username.
+  - After: POST /users/create now calls the GitHub API and rejects the request when the GitHub username does not exist.
   - Clients that previously relied on creating users with invalid GitHub usernames will now get errors for some requests that used to succeed.
 
 ### [itachallenge-githubcore-1.0.0-RELEASE] - 2025-09-11
@@ -425,15 +414,15 @@ Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 
 ### Added
 - Add validation to verify that the provided user ID exists for the getAllSolutionsByUser endpoint. (Taiga [#437], PR [#889])
-- FavoriteController and extracted endpoints from ChallengeController. (Taiga [#418], PR [#886]) 
-- POST endpoint in Auth microservice to allow user role change at runtime (Taiga [#404], PR [#882])  
-- Hardcoded GET endpoint to return all of a user’s challenge solutions (Taiga [#435], PR [#884])  
-- JWT authentication to logout endpoint in User microservice (Taiga [#399], PR [#864])  
-- Error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags (Taiga [#355], PR [#872]) 
-- Tag validation in the addChallenge endpoint (Taiga [#354], PR [#866])  
+- FavoriteController and extracted endpoints from ChallengeController. (Taiga [#418], PR [#886])
+- POST endpoint in Auth microservice to allow user role change at runtime (Taiga [#404], PR [#882])
+- Hardcoded GET endpoint to return all of a user’s challenge solutions (Taiga [#435], PR [#884])
+- JWT authentication to logout endpoint in User microservice (Taiga [#399], PR [#864])
+- Error handling for malformed tag UUIDs and duplicate UUID detection in TagServiceImpl.getValidatedTags (Taiga [#355], PR [#872])
+- Tag validation in the addChallenge endpoint (Taiga [#354], PR [#866])
 - GET endpoint for retrieving resources from a challenge (Taiga [#281], PR [#852])
-- GET endpoint to retrieve all user's bookmarked challenges (Taiga [#255], PR [#849]) 
-- DELETE endpoint in Challenge microservice to unbookmark a challenge (Taiga [#205], PR [#843]) 
+- GET endpoint to retrieve all user's bookmarked challenges (Taiga [#255], PR [#849])
+- DELETE endpoint in Challenge microservice to unbookmark a challenge (Taiga [#205], PR [#843])
 - POST endpoint in Challenge microservice to bookmark a challenge (Taiga [#183], PR [#829])
 - POST endpoint in User microservice to bookmark a challenge (Taiga [#183], PR [#827])
 - DELETE endpoint for user's bookmarks in User microservice (Taiga [#205], PR [#831])
@@ -445,7 +434,7 @@ Supported actions: SAVE, GIVE_UP, SUBMIT. (Taiga [#871], PR [#1043])
 - Replaced Hardcoded GET endpoint to return all of a user’s challenge solutions with actual solutions (Taiga [#406], PR [#887])
 - POST endpoint for adding new challenges in Challenge microservice (PR #763)
 - Improved filtering at `/GET Challenges`: added DTO for filters (language, level, tags), refactored `filterByLanguage()`, `filterByLevel()`, and `filterByTags()` methods, and added `GET /allTags` endpoint (PR #180 & PR #185)
-- Modify method to increase times solved counter (Taiga [#415], PR [#885]) 
+- Modify method to increase times solved counter (Taiga [#415], PR [#885])
 
 ### Removed
 - Removed `score` attribute from `UserSolution` DTOs and cleaned up all score/solution-related code in User microservice (PR #825, PR #725)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed deprecated legacy Bookmarks routes previously served by BookmarkLegacyController. (GitHub Task [#186], PR [#1106])
 ## [UNRELEASED]
 
+## [Unreleased]
+
 ### Added
+
 - New MongoDB collection `user_score_history` with compound indexing for efficient retrieval for gamification tracking.
 - Reactive Repository for user score transactions.
 
-## [Unreleased]
+### Changed
+
+#### User Microservice Exception Handling Refactor
+
+- Introduced `common.exception` package to centralize cross-cutting exceptions in the User microservice.
+- Moved `UserGlobalExceptionHandler`, `BadUUIDException`, and `NotFoundException` to the new package.
+- Updated imports across `user` and `userinteraction` modules to use the unified exceptions.
+- Refactored `UserGlobalExceptionHandlerTest` to align with the new package structure.
+- Ensured the GlobalExceptionHandler applies to controllers from both modules via component scanning.
 ### [itachallenge-user-3.2.2-RELEASE] - 2026-02-23
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-user-3.2.4-RELEASE] - 2026-03-16
+
+### Changed 
+
+- Introduced `common.exception` package to centralize cross-cutting exceptions in the User microservice.
+- Refactor: Moved `UserGlobalExceptionHandler`, `BadUUIDException`, and `NotFoundException` to the new package.
+- Updated imports across `user` and `userinteraction` modules to use the unified exceptions.
+- Refactored `UserGlobalExceptionHandlerTest` to align with the new package structure.
+- Ensured the GlobalExceptionHandler applies to controllers from both modules via component scanning.
+
 ## [itachallenge-challenge-3.3.0] - 2026-03-05
 
 ### Added

--- a/itachallenge-user/src/main/java/com/itachallenge/common/exception/BadUUIDException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/common/exception/BadUUIDException.java
@@ -1,4 +1,4 @@
-package com.itachallenge.user.exception;
+package com.itachallenge.common.exception;
 
 public class BadUUIDException extends RuntimeException {
 

--- a/itachallenge-user/src/main/java/com/itachallenge/common/exception/NotFoundException.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/common/exception/NotFoundException.java
@@ -1,4 +1,4 @@
-package com.itachallenge.user.exception;
+package com.itachallenge.common.exception;
 
 public class NotFoundException extends RuntimeException {
 

--- a/itachallenge-user/src/main/java/com/itachallenge/common/exception/UserGlobalExceptionHandler.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/common/exception/UserGlobalExceptionHandler.java
@@ -1,7 +1,8 @@
-package com.itachallenge.user.exception;
+package com.itachallenge.common.exception;
 
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
+import com.itachallenge.user.exception.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/AdminCreateUserService.java
@@ -5,7 +5,7 @@ import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.springframework.stereotype.Service;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/ChallengeServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/ChallengeServiceImpl.java
@@ -1,7 +1,7 @@
 package com.itachallenge.user.service;
 
 import com.itachallenge.user.dto.SolvedDto;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;

--- a/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/service/UserServiceImpl.java
@@ -1,8 +1,8 @@
 package com.itachallenge.user.service;
 
 import com.itachallenge.user.document.UserDocument;
-import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.BadUUIDException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;
 import org.springframework.stereotype.Service;

--- a/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImpl.java
@@ -1,7 +1,7 @@
 package com.itachallenge.userinteraction.service.bookmark;
 
-import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.BadUUIDException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;
 import com.itachallenge.userinteraction.repository.bookmark.BookmarkRepository;

--- a/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImpl.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImpl.java
@@ -1,7 +1,7 @@
 package com.itachallenge.userinteraction.service.favorite;
 
-import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.BadUUIDException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.favorite.FavoriteDocument;
 import com.itachallenge.userinteraction.repository.favorite.FavoriteRepository;

--- a/itachallenge-user/src/test/java/com/itachallenge/common/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/common/exception/UserGlobalExceptionHandlerTest.java
@@ -1,11 +1,12 @@
-package com.itachallenge.user.exception;
+package com.itachallenge.common.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import com.itachallenge.user.exception.BadRequestException;
+import com.itachallenge.user.exception.DatabaseException;
+import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 
-import com.itachallenge.common.exception.NotFoundException;
-import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/AdminCreateUserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/AdminCreateUserControllerTest.java
@@ -1,5 +1,5 @@
 package com.itachallenge.user.controller;
-import com.itachallenge.user.exception.UserGlobalExceptionHandler;
+import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -2,9 +2,9 @@ package com.itachallenge.user.controller;
 
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
-import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
-import com.itachallenge.user.exception.UserGlobalExceptionHandler;
+import com.itachallenge.common.exception.BadUUIDException;
+import com.itachallenge.common.exception.NotFoundException;
+import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.service.UserService;
 import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
@@ -1,7 +1,7 @@
 package com.itachallenge.user.controller.userinteraction.bookmark;
 
-import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.BadUUIDException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.userinteraction.service.bookmark.BookmarkService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/favorite/FavoriteControllerTest.java
@@ -1,7 +1,7 @@
 package com.itachallenge.user.controller.userinteraction.favorite;
 
-import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.BadUUIDException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.userinteraction.service.favorite.FavoriteService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/exception/UserGlobalExceptionHandlerTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.itachallenge.common.exception.NotFoundException;
+import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.githubcore.exception.GithubUnavailableException;
 import com.itachallenge.user.dto.APIErrorResponse;
 import org.junit.jupiter.api.BeforeEach;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/AdminCreateUserServiceTest.java
@@ -4,7 +4,7 @@ import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
 import com.itachallenge.user.dto.AdminCreateUserRequestDto;
 import com.itachallenge.user.dto.AdminCreateUserResponseDto;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.exception.UsernameAlreadyExistsException;
 import com.itachallenge.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/ChallengeServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/ChallengeServiceImplTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenge.user.dto.SolvedDto;
 import com.itachallenge.user.exception.BadRequestException;
 import com.itachallenge.user.exception.InternalServerErrorException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.NotFoundException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;

--- a/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/service/UserServiceImplTest.java
@@ -2,8 +2,8 @@ package com.itachallenge.user.service;
 
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
-import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.BadUUIDException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;
 import com.itachallenge.userinteraction.repository.bookmark.BookmarkRepository;

--- a/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/bookmark/BookmarkServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.itachallenge.userinteraction.service.bookmark;
-import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.BadUUIDException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.bookmark.BookmarkDocument;
 import com.itachallenge.userinteraction.repository.bookmark.BookmarkRepository;

--- a/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImplTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/userinteraction/service/favorite/FavoriteServiceImplTest.java
@@ -1,8 +1,8 @@
 package com.itachallenge.userinteraction.service.favorite;
 
 import com.itachallenge.user.document.UserDocument;
-import com.itachallenge.user.exception.BadUUIDException;
-import com.itachallenge.user.exception.NotFoundException;
+import com.itachallenge.common.exception.BadUUIDException;
+import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.user.repository.UserRepository;
 import com.itachallenge.userinteraction.document.favorite.FavoriteDocument;
 import com.itachallenge.userinteraction.repository.favorite.FavoriteRepository;


### PR DESCRIPTION
Closes #261

## Description

The User microservice currently contains exception classes distributed across the `user.exception` package. Some of these exceptions represent cross-cutting concerns that should be accessible from multiple modules within the microservice.

In particular, the `GlobalExceptionHandler` was located under `user.exception`, while the microservice also contains the `userinteraction` module. This structure could make the global error handling conceptually tied only to the `user` module.

To improve consistency and maintainability, a shared `common.exception` package has been introduced. This package hosts cross-cutting exceptions and the global exception handler so they can be used across the entire User microservice.

## Changes

- Created `com.itachallenge.common.exception`
- Moved `UserGlobalExceptionHandler`
- Moved `BadUUIDException`
- Moved `NotFoundException`
- Updated imports across the microservice

## Scope

Included:
- Structural refactor of cross-cutting exceptions
- Centralization of the global exception handler

Not included:
- Business logic changes
- Endpoint changes
- Controller refactoring

## Validation

- Project builds successfully
- Imports updated across modules
- No duplicate exception classes remain

Next I would add a screenshot to show that:
-Gradel builds
-Tests passes correctly

<img width="1734" height="962" alt="image" src="https://github.com/user-attachments/assets/800b6e0a-4369-40b1-b2c6-b3ea537ff889" />
