### PR TITLE
[BE] PR 2/3: Implementation of service layer with score aggregation logic (#1123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated imports across `user` and `userinteraction` modules to use the unified exceptions.
 - Refactored `UserGlobalExceptionHandlerTest` to align with the new package structure.
 
-## [Unreleased] - 2026-03-11
+## [Unreleased] - 2026-03-13
 
 ### Added
 - New DTOs for leaderboard feature: `LeaderboardEntryDto` and `LeaderboardResponseDto`.
@@ -20,7 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal `LeaderboardAggregationResult` (`repository.projection` package) helper class for MongoDB aggregation results.
 - Integration tests for repository aggregation methods using Testcontainers.
 - Unit tests for DTO serialization/deserialization.
-
+- Implemented `LeaderboardService` with reactive business logic to generate leaderboard rankings from aggregated scores. (Closes #1123)
+- Added mapping from aggregation results to DTOs with null-safety (`username` → "Anonymous", `totalPoints` → 0).
+- Implemented error handling: repository failures are logged and propagated as `InternalServerErrorException` (500).
+- Added unit tests for mapping, null handling, empty results, and error propagation.
 
 ## [itachallenge-challenge-3.3.0] - 2026-03-05
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/LeaderboardService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/LeaderboardService.java
@@ -1,0 +1,8 @@
+package com.itachallenge.gamification.service;
+
+import com.itachallenge.challenge.dto.gamification.LeaderboardResponseDto;
+import reactor.core.publisher.Mono;
+
+public interface LeaderboardService {
+    Mono<LeaderboardResponseDto> getLeaderboard();
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/LeaderboardServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/LeaderboardServiceImpl.java
@@ -2,14 +2,14 @@ package com.itachallenge.gamification.service;
 
 import com.itachallenge.challenge.dto.gamification.LeaderboardEntryDto;
 import com.itachallenge.challenge.dto.gamification.LeaderboardResponseDto;
+import com.itachallenge.challenge.exception.InternalServerErrorException;
 import com.itachallenge.gamification.repository.UserScoreRepository;
+import com.itachallenge.gamification.repository.projection.LeaderboardAggregationResult;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
-
-import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
@@ -21,19 +21,23 @@ public class LeaderboardServiceImpl implements LeaderboardService {
     @Override
     public Mono<LeaderboardResponseDto> getLeaderboard() {
         return userScoreRepository.aggregateUserScores()
-                .map(aggregation -> LeaderboardEntryDto.builder()
-                        .username(aggregation.getUsername() != null ? aggregation.getUsername() : "Anonymous")
-                        .totalPoints(aggregation.getTotalPoints() !=null ? aggregation.getTotalPoints() : 0)
-                        .build())
+                .map(this::mapToEntryDto)
                 .collectList()
                 .map(entries -> LeaderboardResponseDto.builder()
                         .leaderboard(entries)
                         .build())
                 .onErrorResume(e -> {
-                    log.error("Error retrieving leaderboard data: {}", e.getMessage());
-                    return Mono.just(LeaderboardResponseDto.builder()
-                            .leaderboard(Collections.emptyList())
-                            .build());
+                    log.error("Critical error in leaderboard service - database unavailable. {}", e.getMessage());
+                    return Mono.error(new InternalServerErrorException(
+                            "Unable to retrieve leaderboard data. Please try again later."
+                    ));
                 });
+    }
+
+    private LeaderboardEntryDto mapToEntryDto(LeaderboardAggregationResult agg) {
+        return LeaderboardEntryDto.builder()
+                .username(agg.getUsername() != null ? agg.getUsername() : "Anonymous")
+                .totalPoints(agg.getTotalPoints() !=null ? agg.getTotalPoints() : 0)
+                .build();
     }
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/LeaderboardServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/LeaderboardServiceImpl.java
@@ -1,0 +1,28 @@
+package com.itachallenge.gamification.service;
+
+import com.itachallenge.challenge.dto.gamification.LeaderboardEntryDto;
+import com.itachallenge.challenge.dto.gamification.LeaderboardResponseDto;
+import com.itachallenge.gamification.repository.UserScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class LeaderboardServiceImpl implements LeaderboardService {
+
+    private final UserScoreRepository userScoreRepository;
+
+    @Override
+    public Mono<LeaderboardResponseDto> getLeaderboard() {
+        return userScoreRepository.aggregateUserScores()
+                .map(aggregation -> LeaderboardEntryDto.builder()
+                        .username(aggregation.getUsername() != null ? aggregation.getUsername() : "Anonymous")
+                        .totalPoints(aggregation.getTotalPoints())
+                        .build())
+                .collectList()
+                .map(entries -> LeaderboardResponseDto.builder()
+                        .leaderboard(entries)
+                        .build());
+    }
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/LeaderboardServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/LeaderboardServiceImpl.java
@@ -4,13 +4,18 @@ import com.itachallenge.challenge.dto.gamification.LeaderboardEntryDto;
 import com.itachallenge.challenge.dto.gamification.LeaderboardResponseDto;
 import com.itachallenge.gamification.repository.UserScoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+
+import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
 public class LeaderboardServiceImpl implements LeaderboardService {
 
+    private static final Logger log = LoggerFactory.getLogger(LeaderboardServiceImpl.class);
     private final UserScoreRepository userScoreRepository;
 
     @Override
@@ -18,11 +23,17 @@ public class LeaderboardServiceImpl implements LeaderboardService {
         return userScoreRepository.aggregateUserScores()
                 .map(aggregation -> LeaderboardEntryDto.builder()
                         .username(aggregation.getUsername() != null ? aggregation.getUsername() : "Anonymous")
-                        .totalPoints(aggregation.getTotalPoints())
+                        .totalPoints(aggregation.getTotalPoints() !=null ? aggregation.getTotalPoints() : 0)
                         .build())
                 .collectList()
                 .map(entries -> LeaderboardResponseDto.builder()
                         .leaderboard(entries)
-                        .build());
+                        .build())
+                .onErrorResume(e -> {
+                    log.error("Error retrieving leaderboard data: {}", e.getMessage());
+                    return Mono.just(LeaderboardResponseDto.builder()
+                            .leaderboard(Collections.emptyList())
+                            .build());
+                });
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/LeaderboardServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/LeaderboardServiceImplTest.java
@@ -57,4 +57,16 @@ class LeaderboardServiceImplTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    void getLeaderboard_whenRepositoryFails_returnsEmptyList() {
+        when(userScoreRepository.aggregateUserScores())
+                .thenReturn(Flux.error(new RuntimeException("Database connection failed.")));
+
+        StepVerifier.create(leaderboardServiceImpl.getLeaderboard())
+                .assertNext(response -> {
+                    assertThat(response.getLeaderboard()).isEmpty();
+                })
+                .verifyComplete();
+    }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/LeaderboardServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/LeaderboardServiceImplTest.java
@@ -33,18 +33,24 @@ class LeaderboardServiceImplTest {
     }
 
     @Test
-    void getLeaderboard_returnsSortedData() {
+    void getLeaderboard_mapsAggregationsWithFallbacks() {
         when(userScoreRepository.aggregateUserScores()).thenReturn(Flux.just(aggregate1, aggregate2));
 
         StepVerifier.create(leaderboardServiceImpl.getLeaderboard())
                 .assertNext(response -> {
-                    assertThat(response.getLeaderboard()).hasSize(2);
-                    assertThat(response.getLeaderboard().getFirst().getUsername()).isEqualTo("testUser");
-                    assertThat(response.getLeaderboard().getFirst().getTotalPoints()).isEqualTo(100);
-                    assertThat(response.getLeaderboard().get(1).getUsername()).isEqualTo("Anonymous");
-                    assertThat(response.getLeaderboard().get(1).getTotalPoints()).isEqualTo(50);
-                })
-                .verifyComplete();
+                    assertThat(response.getLeaderboard())
+                            .hasSize(2)
+                            .satisfiesExactlyInAnyOrder(
+                                    first -> {
+                                        assertThat(first.getUsername()).isEqualTo("testUser");
+                                        assertThat(first.getTotalPoints()).isEqualTo(100);
+                                    },
+                                    second -> {
+                                        assertThat(second.getUsername()).isEqualTo("Anonymous");
+                                        assertThat(second.getTotalPoints()).isEqualTo(50);
+                                    }
+                            );
+                });
     }
 
     @Test

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/LeaderboardServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/LeaderboardServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.itachallenge.gamification.service;
 
+import com.itachallenge.challenge.exception.InternalServerErrorException;
 import com.itachallenge.gamification.repository.UserScoreRepository;
 import com.itachallenge.gamification.repository.projection.LeaderboardAggregationResult;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +51,8 @@ class LeaderboardServiceImplTest {
                                         assertThat(second.getTotalPoints()).isEqualTo(50);
                                     }
                             );
-                });
+                })
+                .verifyComplete();
     }
 
     @Test
@@ -65,14 +67,16 @@ class LeaderboardServiceImplTest {
     }
 
     @Test
-    void getLeaderboard_whenRepositoryFails_returnsEmptyList() {
+    void getLeaderboard_whenRepositoryFails_throwsInternalServiceException() {
         when(userScoreRepository.aggregateUserScores())
                 .thenReturn(Flux.error(new RuntimeException("Database connection failed.")));
 
         StepVerifier.create(leaderboardServiceImpl.getLeaderboard())
-                .assertNext(response -> {
-                    assertThat(response.getLeaderboard()).isEmpty();
+                .expectErrorSatisfies(throwable -> {
+                    assertThat(throwable)
+                            .isInstanceOf(InternalServerErrorException.class)
+                            .hasMessage("Unable to retrieve leaderboard data. Please try again later.");
                 })
-                .verifyComplete();
+                .verify();
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/LeaderboardServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/LeaderboardServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.itachallenge.gamification.service;
 
-import com.itachallenge.gamification.repository.UserScoreAggregation;
 import com.itachallenge.gamification.repository.UserScoreRepository;
+import com.itachallenge.gamification.repository.projection.LeaderboardAggregationResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,13 +23,13 @@ class LeaderboardServiceImplTest {
     @InjectMocks
     private LeaderboardServiceImpl leaderboardServiceImpl;
 
-    private UserScoreAggregation aggregate1;
-    private UserScoreAggregation aggregate2;
+    private LeaderboardAggregationResult aggregate1;
+    private LeaderboardAggregationResult aggregate2;
 
     @BeforeEach
     void setUp() {
-        aggregate1 = new UserScoreAggregation("testUser", 100);
-        aggregate2 = new UserScoreAggregation(null, 50);
+        aggregate1 = new LeaderboardAggregationResult("testUser", 100);
+        aggregate2 = new LeaderboardAggregationResult(null, 50);
     }
 
     @Test

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/LeaderboardServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/LeaderboardServiceImplTest.java
@@ -1,0 +1,60 @@
+package com.itachallenge.gamification.service;
+
+import com.itachallenge.gamification.repository.UserScoreAggregation;
+import com.itachallenge.gamification.repository.UserScoreRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeaderboardServiceImplTest {
+
+    @Mock
+    private UserScoreRepository userScoreRepository;
+
+    @InjectMocks
+    private LeaderboardServiceImpl leaderboardServiceImpl;
+
+    private UserScoreAggregation aggregate1;
+    private UserScoreAggregation aggregate2;
+
+    @BeforeEach
+    void setUp() {
+        aggregate1 = new UserScoreAggregation("testUser", 100);
+        aggregate2 = new UserScoreAggregation(null, 50);
+    }
+
+    @Test
+    void getLeaderboard_returnsSortedData() {
+        when(userScoreRepository.aggregateUserScores()).thenReturn(Flux.just(aggregate1, aggregate2));
+
+        StepVerifier.create(leaderboardServiceImpl.getLeaderboard())
+                .assertNext(response -> {
+                    assertThat(response.getLeaderboard()).hasSize(2);
+                    assertThat(response.getLeaderboard().getFirst().getUsername()).isEqualTo("testUser");
+                    assertThat(response.getLeaderboard().getFirst().getTotalPoints()).isEqualTo(100);
+                    assertThat(response.getLeaderboard().get(1).getUsername()).isEqualTo("Anonymous");
+                    assertThat(response.getLeaderboard().get(1).getTotalPoints()).isEqualTo(50);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void getLeaderboard_whenEmpty_returnsEmptyList() {
+        when(userScoreRepository.aggregateUserScores()).thenReturn(Flux.empty());
+
+        StepVerifier.create(leaderboardServiceImpl.getLeaderboard())
+                .assertNext(response -> {
+                    assertThat(response.getLeaderboard()).isEmpty();
+                })
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Feature: Implement service layer with score aggregation logic

**Closes sub-issue:** https://github.com/orgs/IT-Academy-BCN/projects/26/views/2?pane=issue&itemId=163756053&issue=IT-Academy-BCN%7Cita-challenges-backend%7C1123

### 📝 Description
Implementation of the business logic to transform MongoDB aggregation results into ranked leaderboar DTOs. This task focuses on the core business logic: mapping, sorting verification (delegated to repository), and handling user privacy (anonymous fallback). It also ensures data integrity through null-safety and implements proper error propagation for database failures.

A new LeaderboardService was created instead of reusing UserScoreService because:
- UserScoreService is designed to retrieve the score history of a specific user (filtered by userId) while the leaderboard requires a global aggregation of all users without filtering.
- The repository operations are different: findByUserIdOrderByCreatedAtDesc vs. aggregateUserScores(). Mixing both responsibilities would violate the single responsibility principle.
Therefore, keeping them separate facilitates independent maintenance and evolution of each feature.

### ✅ Acceptance Criteria
- [x] `LeaderboardService` interface created with `getLeaderboard()` method.
- [x] `LeaderboardServiceImpl` implements the interface with reactive stream processing, using Project Reactor.
- [x] Service correctly maps `LeaderboardAggregationResult` to `LeaderboardEntryDto`.
- [x] Null usernames are handled gracefully (use "Anonymous" as fallback).
- [x] Null total points default to 0.
- [x] Database errors propagate as `InternalServerErrorException` (500) with clear logging.

### 🔧 Technical Details
* `LeaderboardServiceImpl` in `com.itachallenge.gamification.service`.
* Reactive Flow: `Flux<LeaderboardAggregationResult>` -> map to DTO -> collectList() -> `Mono<LeaderboardResponseDto>`
* Error Handling: repository errors are caught, logged with ERROR level, and rethrown as `InternalServerErrorException`. This follows the project's pattern using existing exception hierarchy and allows the frontend to receive appropriate 500 status code for troubleshooting.
* Null-Safety:
       - username → "Anonymous" if null
       - totalPoints → 0 if null
* Unit Tests: implemented using `Mockito` and `StepVerifier` to ensure CI stability without Docker dependecies.

### 💰 Value Provided
Provides the bridge between raw database aggregations and the API contract, ensuring that user data is presented correctly and securely. The service properly distinguishes between:
- Success cases: Returns ranked leaderboard data (200 OK).
- Empty database: Returns empty list (200 OK) - graceful degradation.
- System errors: Propagates as 500 with descriptive message, enabling proper monitoring and troubleshooting.
This approach balances user experience with operational visibility, following the project's established error handling patterns.

### 🔓Unlocks
Backend PR3/3 https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1132 : Controller can now call a fully functional service.
QA: Can test the ranking logic with various data scenarios.

### 🔗 Dependencies
Depends on PR1/3 https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1129 - Requires repository methods and DTOs.

### 🧪 Testing Performed
* **Unit Tests** for `LeaderboardServiceImplTest` covers:
       - ✅ Successfull mapping of multiple score entries with null handling.
       - ✅ Transformation of null usernames to "Anonymous".
       - ✅ Proper handling of empty database results (returning an emptly list).
       - ✅Error propagation: when repository fails, service throws `InternalServerErrorException` with appropiate message. 

### 🔄 Definition of Done (DoD)
* Service interface and implementation updated and reviewed.
* All tests passing in CI pipeline.
* Code coverage >80% for new code.
* No SonarLint issues.
* CHANGELOG.md updated.

### 👨‍💻 Technical Debts
* Controller and Endpoint added in sub-task 3/3.
* No caching implemented yet - will be considered if performance becomes an issue.