### PR TITLE
PR 1/3 - feat(gamification): add ascending score history query to UserScoreRepository (#294)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/repository/UserScoreRepository.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/repository/UserScoreRepository.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 
 public interface UserScoreRepository extends ReactiveMongoRepository<UserScoreDocument, UUID> {
 
+    Flux<UserScoreDocument> findByUserIdOrderByCreatedAtAsc(UUID userId);
     Flux<UserScoreDocument> findByUserIdOrderByCreatedAtDesc(UUID userId);
 
     @Aggregation(pipeline = {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
@@ -169,7 +169,7 @@ class UserScoreRepositoryIntegrationTest {
                 .expectNextMatches(doc -> doc.getPointsEarned() == 10) // now
                 .verifyComplete();
     }
-    @SuppressWarnings("java:S2699") // to be extended with source_type when #275/#276 are merged
+    @SuppressWarnings("java:S2699") // to be extended with activityType when #275/#276 are merged
     @Test
     void givenMultipleUsersScores_whenFindByUserIdOrderByCreatedAtAsc_thenReturnsOnlyRequestedUser() {
         StepVerifier.create(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId1))

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
@@ -160,4 +160,32 @@ class UserScoreRepositoryIntegrationTest {
                 user3Score1
         )).blockLast();
     }
+
+    @Test
+    void givenUserWithMultipleScores_whenFindByUserIdOrderByCreatedAtAsc_thenReturnsInAscendingOrder() {
+        StepVerifier.create(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId1))
+                .expectNextMatches(doc -> doc.getPointsEarned() == 10) // minusDays(2)
+                .expectNextMatches(doc -> doc.getPointsEarned() == 15) // minusDays(1)
+                .expectNextMatches(doc -> doc.getPointsEarned() == 10) // now
+                .verifyComplete();
+    }
+    @SuppressWarnings("java:S2699") // to be extended with source_type when #275/#276 are merged
+    @Test
+    void givenMultipleUsersScores_whenFindByUserIdOrderByCreatedAtAsc_thenReturnsOnlyRequestedUser() {
+        StepVerifier.create(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId1))
+                .expectNextCount(3)
+                .verifyComplete();
+
+        StepVerifier.create(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId2))
+                .expectNextCount(2)
+                .verifyComplete();
+    }
+
+    @Test
+    void givenUserWithNoScores_whenFindByUserIdOrderByCreatedAtAsc_thenReturnsEmpty() {
+        UUID unknownUserId = UUID.randomUUID();
+
+        StepVerifier.create(userScoreRepository.findByUserIdOrderByCreatedAtAsc(unknownUserId))
+                .verifyComplete();
+    }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
@@ -163,12 +163,37 @@ class UserScoreRepositoryIntegrationTest {
 
     @Test
     void givenUserWithMultipleScores_whenFindByUserIdOrderByCreatedAtAsc_thenReturnsInAscendingOrder() {
-        StepVerifier.create(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId1))
-                .expectNextMatches(doc -> doc.getPointsEarned() == 10) // minusDays(2)
-                .expectNextMatches(doc -> doc.getPointsEarned() == 15) // minusDays(1)
-                .expectNextMatches(doc -> doc.getPointsEarned() == 10) // now
+        userScoreRepository.deleteAll().block();
+
+        UUID testUserId = UUID.randomUUID();
+
+        UserScoreDocument first = UserScoreDocument.builder()
+                .id(UUID.randomUUID()).userId(testUserId).username("testuser")
+                .challengeId(UUID.randomUUID()).pointsEarned(10)
+                .createdAt(LocalDateTime.of(2024, 3, 1, 10, 0))
+                .build();
+        UserScoreDocument second = UserScoreDocument.builder()
+                .id(UUID.randomUUID()).userId(testUserId).username("testuser")
+                .challengeId(UUID.randomUUID()).pointsEarned(15)
+                .createdAt(LocalDateTime.of(2024, 3, 5, 10, 0))
+                .build();
+        UserScoreDocument third = UserScoreDocument.builder()
+                .id(UUID.randomUUID()).userId(testUserId).username("testuser")
+                .challengeId(UUID.randomUUID()).pointsEarned(20)
+                .createdAt(LocalDateTime.of(2024, 3, 10, 10, 0))
+                .build();
+
+        mongoTemplate.insert(first, "user_score_history").block();
+        mongoTemplate.insert(second, "user_score_history").block();
+        mongoTemplate.insert(third, "user_score_history").block();
+
+        StepVerifier.create(userScoreRepository.findByUserIdOrderByCreatedAtAsc(testUserId))
+                .expectNextMatches(doc -> doc.getPointsEarned() == 10)
+                .expectNextMatches(doc -> doc.getPointsEarned() == 15)
+                .expectNextMatches(doc -> doc.getPointsEarned() == 20)
                 .verifyComplete();
     }
+
     @SuppressWarnings("java:S2699") // to be extended with activityType when #275/#276 are merged
     @Test
     void givenMultipleUsersScores_whenFindByUserIdOrderByCreatedAtAsc_thenReturnsOnlyRequestedUser() {

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryTest.java
@@ -19,9 +19,10 @@ class UserScoreRepositoryTest {
     @Mock
     private UserScoreRepository userScoreRepository;
 
+    private final UUID userId = UUID.randomUUID();
+
     @Test
     void givenExistingScores_whenFindByUsername_thenReturnsSortedByDescendingDates() {
-        UUID userId = UUID.randomUUID();
         UserScoreDocument score1 = UserScoreDocument.builder()
                 .id(UUID.randomUUID())
                 .userId(userId)
@@ -48,6 +49,28 @@ class UserScoreRepositoryTest {
                 .expectNextMatches(s -> s.getPointsEarned() == 3)
                 .expectNextMatches(s -> s.getPointsEarned() == 2)
                 .expectNextMatches(s -> s.getPointsEarned() == 1)
+                .verifyComplete();
+    }
+
+    @Test
+    void givenExistingScores_whenFindByUserIdOrderByCreatedAtAsc_thenReturnsSortedByAscendingDates() {
+        UserScoreDocument score1 = UserScoreDocument.builder()
+                .id(UUID.randomUUID()).userId(userId)
+                .pointsEarned(3).createdAt(LocalDateTime.now()).build();
+        UserScoreDocument score2 = UserScoreDocument.builder()
+                .id(UUID.randomUUID()).userId(userId)
+                .pointsEarned(1).createdAt(LocalDateTime.now().minusDays(3)).build();
+        UserScoreDocument score3 = UserScoreDocument.builder()
+                .id(UUID.randomUUID()).userId(userId)
+                .pointsEarned(2).createdAt(LocalDateTime.now().minusDays(1)).build();
+
+        when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
+                .thenReturn(Flux.just(score2, score3, score1));
+
+        StepVerifier.create(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
+                .expectNextMatches(s -> s.getPointsEarned() == 1)
+                .expectNextMatches(s -> s.getPointsEarned() == 2)
+                .expectNextMatches(s -> s.getPointsEarned() == 3)
                 .verifyComplete();
     }
 }


### PR DESCRIPTION
## Description

Adds `findByUserIdOrderByCreatedAtAsc` to `UserScoreRepository` to support the upcoming weekly score history chart (parent issue #281).

## Analysis of existing behavior

`findByUserIdOrderByCreatedAtDesc(UUID userId)` already exists and returns all score history records for a user ordered by `created_at` descending (newest first). This order is not suitable for building a chronological chart.

The existing DESC method is kept untouched as it may be used by other callers.

## What this PR adds

`findByUserIdOrderByCreatedAtAsc(UUID userId)` — same query with ascending order, resolved automatically by Spring Data naming convention. No custom query needed.

## Tests

- Unit test (Mockito): verifies records are returned in ascending chronological order
- Integration tests (Testcontainers + MongoDB):
  - records are returned in ascending chronological order
  - all records are returned regardless of source (no exclusions)
  - user with no history returns empty result, no exception

Screenshot of tests passing:
<img width="1821" height="609" alt="test-results-repository-asc-query-pr1" src="https://github.com/user-attachments/assets/17b72ed7-5720-4a77-9fa2-d210a3151ac3" />

## Out of scope
Filtering history by activityType — tracked as technical debt in #311 
Service or controller changes
Any modification to the existing findByUserIdOrderByCreatedAtDesc query

## Known limitations

The test `givenMultipleUsersScores_whenFindByUserIdOrderByCreatedAtAsc_thenReturnsOnlyRequestedUser` 
currently simulates multiple point sources using distinct `challengeId` values, as the `activityType` 
field is not yet available in `UserScoreDocument`.

The `@SuppressWarnings("java:S2699")` annotation has been added to suppress the Sonar warning temporarily.
This test must be extended once #275 and #276 are merged to explicitly verify that records with different 
`activityType` values are all returned without exclusions.

Agreed `activityType` values (coordinated with #275, #276 and #277):
- `CHALLENGE_COMPLETED` (20 points)
- `CODE_REVIEW` (5 points)
- `PRESENTATION` (10 points)

## Technical debt

The history endpoint currently returns all point sources aggregated together. In a future sprint, 
an `activityType` filter may be needed to support per-activity charts 
(e.g. CHALLENGE_COMPLETED, CODE_REVIEW, PRESENTATION). Out of scope this sprint — added the issue #[311](https://github.com/orgs/IT-Academy-BCN/projects/26/views/11?pane=issue&itemId=173747713&issue=IT-Academy-BCN%7Cita-challenges%7C311)


## Self-checklist

- [X] I tested my changes locally and verified they work as expected
- [X] The PR has a clear and focused purpose (only one feature, fix or refactor)
- [X] Title, description, and changelog (if needed) are filled in correctly
- [X] There are no leftover merge conflicts or unrelated changes from previous branches
- [X] All automated checks (like SonarCloud) have passed
- [X] I responded to all previous review comments and only resolved those I truly addressed
- [X] I ran SonarLint locally on the modified files and confirmed there are no warnings or errors
