### PR TITLE
[BE] PR 1/2: Define and create the ActivityType enum (#293)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/enums/ActivityType.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/enums/ActivityType.java
@@ -1,0 +1,17 @@
+package com.itachallenge.gamification.enums;
+
+public enum ActivityType {
+    CODE_REVIEW(5),
+    PRESENTATION(10),
+    CHALLENGE_COMPLETED(20);
+
+    private final int points;
+
+    ActivityType(int points) {
+        this.points = points;
+    }
+
+    public int getPoints() {
+        return points;
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/enums/ActivityTypeTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/enums/ActivityTypeTest.java
@@ -1,0 +1,25 @@
+package com.itachallenge.gamification.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActivityTypeTest {
+
+    @Test
+    void shouldExposeExpectedActivityTypesInDeclaredOrder() {
+        assertThat(ActivityType.values())
+                .containsExactly(
+                        ActivityType.CODE_REVIEW,
+                        ActivityType.PRESENTATION,
+                        ActivityType.CHALLENGE_COMPLETED
+                );
+    }
+
+    @Test
+    void shouldExposeConfiguredPointsForEachActivityType() {
+        assertThat(ActivityType.CODE_REVIEW.getPoints()).isEqualTo(5);
+        assertThat(ActivityType.PRESENTATION.getPoints()).isEqualTo(10);
+        assertThat(ActivityType.CHALLENGE_COMPLETED.getPoints()).isEqualTo(20);
+    }
+}


### PR DESCRIPTION
Closes #293

## Description

This PR introduces the `ActivityType` enum as a unified model for all point-generating events in the system.

Following the alignment across #275, #276 and #277, the enum includes both academy activities and challenge completion:

- CODE_REVIEW
- PRESENTATION
- CHALLENGE_COMPLETED

Each type includes its associated point value.

This enum will act as an explicit discriminator for all entries in `user_score_history`, avoiding implicit patterns based on fields like `challenge_id` and ensuring a consistent and maintainable data model.

## Changes

- Created `ActivityType` enum
- Added point values to each activity type
- Added unit tests to validate enum values and configuration

## Scope

**Included:**

- Definition of a unified activity type model
- Support for both academy activities and challenge completion
- Explicit discriminator for score history entries

**Not included:**

- Persistence logic
- Score calculation services
- Leaderboard or ranking logic

## Validation

- Project builds successfully
- Enum values and points are correctly defined
- Unit tests pass successfully

<img width="1780" height="1198" alt="TestPR1Enum" src="https://github.com/user-attachments/assets/eae69d11-27f9-4a8a-ac5a-7aa0d68c7346" />
