### PR TITLE
[BE] PR1/3 — Prepare weekly leaderboard data aggregation (#280)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/repository/UserScoreRepository.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/repository/UserScoreRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import reactor.core.publisher.Flux;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public interface UserScoreRepository extends ReactiveMongoRepository<UserScoreDocument, UUID> {
@@ -28,4 +29,21 @@ public interface UserScoreRepository extends ReactiveMongoRepository<UserScoreDo
             "{$sort: {totalPoints: -1}}"
     })
     Flux<LeaderboardAggregationResult> aggregateUserScores();
+
+    @Aggregation(pipeline = {
+            "{ $match: { created_at: { $gte: ?0, $lte: ?1 } } }",
+            "{$sort: {user_id: 1, created_at: -1}}",
+            """
+             {
+               $group: {
+                 _id: '$user_id',
+                 username: {$first: '$username'},
+                 totalPoints: {$sum: '$points_earned'}
+               }
+             }
+            """,
+            "{$project: {_id: 0, username: 1, totalPoints: 1}}",
+            "{$sort: {totalPoints: -1}}"
+    })
+    Flux<LeaderboardAggregationResult> aggregateUserScoresByPeriod(LocalDateTime fromInclusive, LocalDateTime toInclusive);
 }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/util/WeeklyWindow.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/util/WeeklyWindow.java
@@ -1,0 +1,37 @@
+package com.itachallenge.gamification.util;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Objects;
+
+public class WeeklyWindow {
+    private final LocalDateTime fromInclusive;
+    private final LocalDateTime toInclusive;
+
+    public WeeklyWindow(LocalDateTime fromInclusive, LocalDateTime toInclusive) {
+        this.fromInclusive = Objects.requireNonNull(fromInclusive, "fromInclusive must not be null");
+        this.toInclusive = Objects.requireNonNull(toInclusive, "toInclusive must not be null");
+    }
+
+    public static WeeklyWindow fromReferenceDateTime(ZonedDateTime referenceDateTime) {
+        Objects.requireNonNull(referenceDateTime, "referenceDateTime must not be null");
+        ZonedDateTime startOfWeek = referenceDateTime
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                .with(LocalTime.MIN);
+        ZonedDateTime endOfWeek = startOfWeek
+                .plusDays(6)
+                .with(LocalTime.MAX);
+        return new WeeklyWindow(startOfWeek.toLocalDateTime(), endOfWeek.toLocalDateTime());
+    }
+
+    public LocalDateTime getFromInclusive() {
+        return fromInclusive;
+    }
+
+    public LocalDateTime getToInclusive() {
+        return toInclusive;
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
@@ -97,6 +97,19 @@ class UserScoreRepositoryIntegrationTest {
     }
 
     @Test
+    void givenEmptyDatabase_whenAggregateUserScoresByPeriod_thenReturnsEmpty() {
+        userScoreRepository.deleteAll().block();
+
+        WeeklyWindow window = WeeklyWindow.fromReferenceDateTime(
+                ZonedDateTime.of(2026, 4, 8, 12, 0, 0, 0, ZoneId.of("Europe/Madrid")));
+        LocalDateTime from = window.getFromInclusive();
+        LocalDateTime to = window.getToInclusive();
+
+        StepVerifier.create(userScoreRepository.aggregateUserScoresByPeriod(from, to))
+                .verifyComplete();
+    }
+
+    @Test
     void givenScoresInsideAndOutsidePeriod_whenAggregateUserScoresByPeriod_thenReturnsOnlyInsideRange() {
         userScoreRepository.deleteAll().block();
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
@@ -2,6 +2,7 @@ package com.itachallenge.gamification.repository;
 
 import com.itachallenge.gamification.document.UserScoreDocument;
 import com.itachallenge.gamification.repository.projection.LeaderboardAggregationResult;
+import com.itachallenge.gamification.util.WeeklyWindow;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,8 @@ import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 @DataMongoTest
@@ -99,8 +102,10 @@ class UserScoreRepositoryIntegrationTest {
 
         UUID weeklyUserId = UUID.randomUUID();
         UUID outsideUserId = UUID.randomUUID();
-        LocalDateTime from = LocalDateTime.of(2026, 4, 6, 0, 0);
-        LocalDateTime to = LocalDateTime.of(2026, 4, 12, 23, 59, 59);
+        WeeklyWindow window = WeeklyWindow.fromReferenceDateTime(
+                ZonedDateTime.of(2026, 4, 8, 10, 0, 0, 0, ZoneId.of("Europe/Madrid")));
+        LocalDateTime from = window.getFromInclusive();
+        LocalDateTime to = window.getToInclusive();
 
         UserScoreDocument insideFirst = UserScoreDocument.builder()
                 .id(UUID.randomUUID())
@@ -140,6 +145,32 @@ class UserScoreRepositoryIntegrationTest {
                 .verifyComplete();
     }
 
+    @Test
+    void givenScoreAtSundayLastNanosecond_whenAggregateUserScoresByPeriod_thenIncluded() {
+        userScoreRepository.deleteAll().block();
+
+        UUID userId = UUID.randomUUID();
+        WeeklyWindow window = WeeklyWindow.fromReferenceDateTime(
+                ZonedDateTime.of(2026, 4, 8, 12, 0, 0, 0, ZoneId.of("Europe/Madrid")));
+        LocalDateTime from = window.getFromInclusive();
+        LocalDateTime to = window.getToInclusive();
+
+        UserScoreDocument atEndOfSunday = UserScoreDocument.builder()
+                .id(UUID.randomUUID())
+                .userId(userId)
+                .username("edge_user")
+                .challengeId(UUID.randomUUID())
+                .pointsEarned(7)
+                .createdAt(to)
+                .build();
+
+        mongoTemplate.insert(atEndOfSunday).block();
+
+        StepVerifier.create(userScoreRepository.aggregateUserScoresByPeriod(from, to))
+                .expectNextMatches(agg ->
+                        agg.getUsername().equals("edge_user") && agg.getTotalPoints() == 7)
+                .verifyComplete();
+    }
 
     private void createTestData() {
         LocalDateTime now = LocalDateTime.now();

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MongoDBContainer;
@@ -20,6 +19,7 @@ import java.util.UUID;
 
 @DataMongoTest
 @Testcontainers(disabledWithoutDocker = true)
+@SuppressWarnings("resource")
 class UserScoreRepositoryIntegrationTest {
 
     @Container
@@ -38,9 +38,6 @@ class UserScoreRepositoryIntegrationTest {
 
     @Autowired
     private UserScoreRepository userScoreRepository;
-
-    @Autowired
-    private ReactiveMongoTemplate mongoTemplate;
 
     private UUID userId1, userId2, userId3;
     private static final String USERNAME_1 = "user1";
@@ -89,6 +86,50 @@ class UserScoreRepositoryIntegrationTest {
 
         StepVerifier.create(result)
                 .expectNextCount(0)
+                .verifyComplete();
+    }
+
+    @Test
+    void givenScoresInsideAndOutsidePeriod_whenAggregateUserScoresByPeriod_thenReturnsOnlyInsideRange() {
+        userScoreRepository.deleteAll().block();
+
+        UUID weeklyUserId = UUID.randomUUID();
+        UUID outsideUserId = UUID.randomUUID();
+        LocalDateTime from = LocalDateTime.of(2026, 4, 6, 0, 0);
+        LocalDateTime to = LocalDateTime.of(2026, 4, 12, 23, 59, 59);
+
+        UserScoreDocument insideFirst = UserScoreDocument.builder()
+                .id(UUID.randomUUID())
+                .userId(weeklyUserId)
+                .username("weekly_user")
+                .challengeId(UUID.randomUUID())
+                .pointsEarned(25)
+                .createdAt(LocalDateTime.of(2026, 4, 8, 10, 0))
+                .build();
+
+        UserScoreDocument insideSecond = UserScoreDocument.builder()
+                .id(UUID.randomUUID())
+                .userId(weeklyUserId)
+                .username("weekly_user")
+                .challengeId(UUID.randomUUID())
+                .pointsEarned(15)
+                .createdAt(LocalDateTime.of(2026, 4, 10, 19, 30))
+                .build();
+
+        UserScoreDocument outside = UserScoreDocument.builder()
+                .id(UUID.randomUUID())
+                .userId(outsideUserId)
+                .username("outside_user")
+                .challengeId(UUID.randomUUID())
+                .pointsEarned(99)
+                .createdAt(LocalDateTime.of(2026, 4, 20, 12, 0))
+                .build();
+
+        userScoreRepository.saveAll(Flux.just(insideFirst, insideSecond, outside)).blockLast();
+
+        StepVerifier.create(userScoreRepository.aggregateUserScoresByPeriod(from, to))
+                .expectNextMatches(agg ->
+                        agg.getUsername().equals("weekly_user") && agg.getTotalPoints() == 40)
                 .verifyComplete();
     }
 

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/repository/UserScoreRepositoryIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MongoDBContainer;
@@ -38,6 +39,9 @@ class UserScoreRepositoryIntegrationTest {
 
     @Autowired
     private UserScoreRepository userScoreRepository;
+
+    @Autowired
+    private ReactiveMongoTemplate mongoTemplate;
 
     private UUID userId1, userId2, userId3;
     private static final String USERNAME_1 = "user1";
@@ -125,7 +129,10 @@ class UserScoreRepositoryIntegrationTest {
                 .createdAt(LocalDateTime.of(2026, 4, 20, 12, 0))
                 .build();
 
-        userScoreRepository.saveAll(Flux.just(insideFirst, insideSecond, outside)).blockLast();
+        // insert() keeps fixed createdAt; save/saveAll triggers @CreatedDate auditing and overwrites dates
+        mongoTemplate.insert(insideFirst).block();
+        mongoTemplate.insert(insideSecond).block();
+        mongoTemplate.insert(outside).block();
 
         StepVerifier.create(userScoreRepository.aggregateUserScoresByPeriod(from, to))
                 .expectNextMatches(agg ->

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/util/WeeklyWindowTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/util/WeeklyWindowTest.java
@@ -1,0 +1,34 @@
+package com.itachallenge.gamification.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WeeklyWindowTest {
+
+    @Test
+    void fromReferenceDateTime_whenMidWeek_thenReturnsMondayToSundayRange() {
+        ZonedDateTime reference = ZonedDateTime.of(
+                2026, 4, 8, 15, 30, 0, 0, ZoneId.of("Europe/Madrid"));
+
+        WeeklyWindow window = WeeklyWindow.fromReferenceDateTime(reference);
+
+        assertEquals(LocalDateTime.of(2026, 4, 6, 0, 0, 0, 0), window.getFromInclusive());
+        assertEquals(LocalDateTime.of(2026, 4, 12, 23, 59, 59, 999_999_999), window.getToInclusive());
+    }
+
+    @Test
+    void fromReferenceDateTime_whenBoundaryWeek_thenKeepsCorrectYearWeekRange() {
+        ZonedDateTime reference = ZonedDateTime.of(
+                2026, 1, 1, 8, 0, 0, 0, ZoneId.of("Europe/Madrid"));
+
+        WeeklyWindow window = WeeklyWindow.fromReferenceDateTime(reference);
+
+        assertEquals(LocalDateTime.of(2025, 12, 29, 0, 0, 0, 0), window.getFromInclusive());
+        assertEquals(LocalDateTime.of(2026, 1, 4, 23, 59, 59, 999_999_999), window.getToInclusive());
+    }
+}


### PR DESCRIPTION
https://github.com/IT-Academy-BCN/ita-challenges-backend/pull/1146

📅 Weekly leaderboard data — technical description

📌 Scope
- Add groundwork for the weekly leaderboard without changing public API contracts.
- Add `WeeklyWindow` helper for ISO week bounds (Monday 00:00 inclusive → Sunday inclusive through end of day, `LocalTime.MAX` / 23:59:59.999999999).
- Add `UserScoreRepository.aggregateUserScoresByPeriod(fromInclusive, toInclusive)`.
- Leave the existing global aggregation (`aggregateUserScores`) unchanged.
- Add/extend tests for: weekly window calculation; inclusion/exclusion of records inside/outside the weekly range.

🚫 Out of scope
- Controller changes.
- Public route/DTO changes.
- HTTP/JSON contract changes.
- League assignment and level calculation (PR2).
- OpenAPI updates (PR3).

🧪 Tests
- `WeeklyWindowTest`: ISO window (incl. year/week boundary cases).
- `UserScoreRepositoryIntegrationTest`: period derived from `WeeklyWindow`; data inside and outside the range; edge case at the last instant of Sunday (`toInclusive`); `ReactiveMongoTemplate.insert()` where fixed timestamps are needed (`@CreatedDate` auditing).
- - `UserScoreRepositoryIntegrationTest`: also covers **zero results** for `aggregateUserScoresByPeriod` when the collection is empty (regression guard).
- Local build and tests passed.

📝 Technical notes
- Weekly period follows the ISO calendar (Monday–Sunday).
- Range generation is intended for the service layer; the repository only filters/aggregates by `created_at`.
- Week bounds are computed in the reference `ZonedDateTime`’s zone; the service should use the agreed league timezone.
- If the PO confirms a different week definition, it will be adjusted in PR2/PR3.
- **Date/time library choice:** PR1 keeps `WeeklyWindow` on `java.time` only (no new dependencies; narrow ISO Monday–Sunday bounds with tests). Follow-up: evaluate **ThreeTen-Extra** / `YearWeek` if PR2/PR3 adds heavier timezone/DST or more aggregation windows — see review discussion.

📄 CHANGELOG
Not updated in this PR (no public API changes or user-visible behavior).

<img width="1632" height="400" alt="image" src="https://github.com/user-attachments/assets/ea405648-87bb-45d4-831a-cc53a172efb9" />
