### PR TITLE
PR 2/3 - feat(gamification): group user score history by week and calculate accumulated points (#296)

### DIFF
--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/gamification/ScoresHistoryChartDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/gamification/ScoresHistoryChartDto.java
@@ -1,0 +1,25 @@
+package com.itachallenge.challenge.dto.gamification;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@Jacksonized
+@AllArgsConstructor
+public class ScoresHistoryChartDto {
+    @JsonProperty("user_id")
+    private UUID userId;
+
+    @JsonProperty("total_points")
+    private int totalPoints;
+
+    @JsonProperty("aggregation_type")
+    private String aggregationType;
+
+    private List<WeeklyPointsDto> history;
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/gamification/ScoresHistoryResponseDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/gamification/ScoresHistoryResponseDto.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Builder
 @Jacksonized
 @AllArgsConstructor
-public class ScoresHistoryChartDto {
+public class ScoresHistoryResponseDto {
     @JsonProperty("user_id")
     private UUID userId;
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/gamification/WeeklyPointsDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/gamification/WeeklyPointsDto.java
@@ -1,0 +1,19 @@
+package com.itachallenge.challenge.dto.gamification;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@Builder
+@Jacksonized
+@AllArgsConstructor
+public class WeeklyPointsDto {
+    private String period;
+
+    @JsonProperty("points_earned")
+    private int pointsEarned;
+
+    @JsonProperty("accumulated_at_end")
+    private int accumulatedAtEnd;
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreService.java
@@ -1,7 +1,7 @@
 package com.itachallenge.gamification.service;
 
 import com.itachallenge.challenge.dto.gamification.PointsHistoryResponseDto;
-import com.itachallenge.challenge.dto.gamification.ScoresHistoryChartDto;
+import com.itachallenge.challenge.dto.gamification.ScoresHistoryResponseDto;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
@@ -9,7 +9,7 @@ import java.util.UUID;
 public interface UserScoreService {
 
     Mono<PointsHistoryResponseDto> getUserPointsHistory(UUID userId);
-    Mono<ScoresHistoryChartDto> getUserScoresHistoryChart(UUID userId);
+    Mono<ScoresHistoryResponseDto> getUserScoresHistoryChart(UUID userId);
 
 }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreService.java
@@ -1,6 +1,7 @@
 package com.itachallenge.gamification.service;
 
 import com.itachallenge.challenge.dto.gamification.PointsHistoryResponseDto;
+import com.itachallenge.challenge.dto.gamification.ScoresHistoryChartDto;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
@@ -8,5 +9,7 @@ import java.util.UUID;
 public interface UserScoreService {
 
     Mono<PointsHistoryResponseDto> getUserPointsHistory(UUID userId);
+    Mono<ScoresHistoryChartDto> getUserScoresHistoryChart(UUID userId);
+
 }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.*;
 public class UserScoreServiceImpl implements UserScoreService {
 
     private final UserScoreRepository userScoreRepository;
+    private static final String AGGREGATION_TYPE_WEEKLY = "WEEKLY";
 
     @Override
     public Mono<PointsHistoryResponseDto> getUserPointsHistory(UUID userId) {
@@ -61,7 +62,7 @@ public class UserScoreServiceImpl implements UserScoreService {
             return ScoresHistoryResponseDto.builder()
                     .userId(userId)
                     .totalPoints(0)
-                    .aggregationType("WEEKLY")
+                    .aggregationType(AGGREGATION_TYPE_WEEKLY)
                     .history(List.of())
                     .build();
         }
@@ -90,7 +91,7 @@ public class UserScoreServiceImpl implements UserScoreService {
         return ScoresHistoryResponseDto.builder()
                 .userId(userId)
                 .totalPoints(accumulated)
-                .aggregationType("WEEKLY")
+                .aggregationType(AGGREGATION_TYPE_WEEKLY)
                 .history(history)
                 .build();
     }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreServiceImpl.java
@@ -2,16 +2,17 @@ package com.itachallenge.gamification.service;
 
 import com.itachallenge.challenge.dto.gamification.PointHistoryEntryDto;
 import com.itachallenge.challenge.dto.gamification.PointsHistoryResponseDto;
+import com.itachallenge.challenge.dto.gamification.ScoresHistoryChartDto;
+import com.itachallenge.challenge.dto.gamification.WeeklyPointsDto;
 import com.itachallenge.gamification.document.UserScoreDocument;
 import com.itachallenge.gamification.repository.UserScoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +25,13 @@ public class UserScoreServiceImpl implements UserScoreService {
         return userScoreRepository.findByUserIdOrderByCreatedAtDesc(userId)
                 .collectList()
                 .map(this::buildHistoryResponse);
+    }
+
+    @Override
+    public Mono<ScoresHistoryChartDto> getUserScoresHistoryChart(UUID userId) {
+        return userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId)
+                .collectList()
+                .map(docs -> buildChartResponse(userId, docs));
     }
 
     private PointsHistoryResponseDto buildHistoryResponse(List<UserScoreDocument> docs) {
@@ -45,6 +53,46 @@ public class UserScoreServiceImpl implements UserScoreService {
         return PointsHistoryResponseDto.builder()
                 .username(docs.isEmpty() ? "" : docs.getFirst().getUsername())
                 .totalPoints(totalPoints)
+                .history(history)
+                .build();
+    }
+
+    private ScoresHistoryChartDto buildChartResponse(UUID userId, List<UserScoreDocument> docs) {
+        if (docs.isEmpty()) {
+            return ScoresHistoryChartDto.builder()
+                    .userId(userId)
+                    .totalPoints(0)
+                    .aggregationType("WEEKLY")
+                    .history(List.of())
+                    .build();
+        }
+
+        DateTimeFormatter weekFormatter = DateTimeFormatter.ofPattern("YYYY-'W'ww")
+                .withLocale(Locale.getDefault())
+                .withResolverStyle(ResolverStyle.STRICT);
+
+        Map<String, Integer> pointsByWeek = new LinkedHashMap<>();
+        for (UserScoreDocument doc : docs) {
+            if (doc.getCreatedAt() == null || doc.getPointsEarned() == null) continue;
+            String week = doc.getCreatedAt().format(weekFormatter);
+            pointsByWeek.merge(week, doc.getPointsEarned(), Integer::sum);
+        }
+
+        List<WeeklyPointsDto> history = new ArrayList<>();
+        int accumulated = 0;
+        for (Map.Entry<String, Integer> entry : pointsByWeek.entrySet()) {
+            accumulated += entry.getValue();
+            history.add(WeeklyPointsDto.builder()
+                    .period(entry.getKey())
+                    .pointsEarned(entry.getValue())
+                    .accumulatedAtEnd(accumulated)
+                    .build());
+        }
+
+        return ScoresHistoryChartDto.builder()
+                .userId(userId)
+                .totalPoints(accumulated)
+                .aggregationType("WEEKLY")
                 .history(history)
                 .build();
     }

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreServiceImpl.java
@@ -10,8 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-import java.time.format.DateTimeFormatter;
-import java.time.format.ResolverStyle;
+import java.time.temporal.WeekFields;
 import java.util.*;
 
 @Service
@@ -67,14 +66,13 @@ public class UserScoreServiceImpl implements UserScoreService {
                     .build();
         }
 
-        DateTimeFormatter weekFormatter = DateTimeFormatter.ofPattern("YYYY-'W'ww")
-                .withLocale(Locale.getDefault())
-                .withResolverStyle(ResolverStyle.STRICT);
-
         Map<String, Integer> pointsByWeek = new LinkedHashMap<>();
+
         for (UserScoreDocument doc : docs) {
             if (doc.getCreatedAt() == null || doc.getPointsEarned() == null) continue;
-            String week = doc.getCreatedAt().format(weekFormatter);
+            int weekYear = doc.getCreatedAt().get(WeekFields.ISO.weekBasedYear());
+            int weekNumber = doc.getCreatedAt().get(WeekFields.ISO.weekOfWeekBasedYear());
+            String week = String.format("%d-W%02d", weekYear, weekNumber);
             pointsByWeek.merge(week, doc.getPointsEarned(), Integer::sum);
         }
 

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/UserScoreServiceImpl.java
@@ -2,7 +2,7 @@ package com.itachallenge.gamification.service;
 
 import com.itachallenge.challenge.dto.gamification.PointHistoryEntryDto;
 import com.itachallenge.challenge.dto.gamification.PointsHistoryResponseDto;
-import com.itachallenge.challenge.dto.gamification.ScoresHistoryChartDto;
+import com.itachallenge.challenge.dto.gamification.ScoresHistoryResponseDto;
 import com.itachallenge.challenge.dto.gamification.WeeklyPointsDto;
 import com.itachallenge.gamification.document.UserScoreDocument;
 import com.itachallenge.gamification.repository.UserScoreRepository;
@@ -28,7 +28,7 @@ public class UserScoreServiceImpl implements UserScoreService {
     }
 
     @Override
-    public Mono<ScoresHistoryChartDto> getUserScoresHistoryChart(UUID userId) {
+    public Mono<ScoresHistoryResponseDto> getUserScoresHistoryChart(UUID userId) {
         return userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId)
                 .collectList()
                 .map(docs -> buildChartResponse(userId, docs));
@@ -57,9 +57,9 @@ public class UserScoreServiceImpl implements UserScoreService {
                 .build();
     }
 
-    private ScoresHistoryChartDto buildChartResponse(UUID userId, List<UserScoreDocument> docs) {
+    private ScoresHistoryResponseDto buildChartResponse(UUID userId, List<UserScoreDocument> docs) {
         if (docs.isEmpty()) {
-            return ScoresHistoryChartDto.builder()
+            return ScoresHistoryResponseDto.builder()
                     .userId(userId)
                     .totalPoints(0)
                     .aggregationType("WEEKLY")
@@ -89,7 +89,7 @@ public class UserScoreServiceImpl implements UserScoreService {
                     .build());
         }
 
-        return ScoresHistoryChartDto.builder()
+        return ScoresHistoryResponseDto.builder()
                 .userId(userId)
                 .totalPoints(accumulated)
                 .aggregationType("WEEKLY")

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/UserScoreServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/UserScoreServiceImplTest.java
@@ -25,6 +25,11 @@ class UserScoreServiceImplTest {
     private UserScoreServiceImpl userScoreService;
 
     private final UUID userId = UUID.randomUUID();
+    private static final LocalDateTime WEEK_10_MONDAY    = LocalDateTime.of(2024, 3, 4,  10, 0);
+    private static final LocalDateTime WEEK_10_WEDNESDAY = LocalDateTime.of(2024, 3, 6,  10, 0);
+    private static final LocalDateTime WEEK_10_TUESDAY   = LocalDateTime.of(2024, 3, 5,  10, 0);
+    private static final LocalDateTime WEEK_10_SUNDAY    = LocalDateTime.of(2024, 3, 10, 23, 59);
+    private static final LocalDateTime WEEK_11_MONDAY    = LocalDateTime.of(2024, 3, 11, 0, 1);
 
     @Test
     void givenMultipleScores_whenGetUserPointsHistory_thenTotalPointsIsCorrectlySummed() {
@@ -133,13 +138,11 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScoresInSameWeek_whenGetUserScoresHistoryChart_thenWeeklyPointsEarnedIsCorrect() {
-        LocalDateTime week1Day1 = LocalDateTime.of(2024, 3, 4, 10, 0);
-        LocalDateTime week1Day2 = LocalDateTime.of(2024, 3, 6, 10, 0);
 
         UserScoreDocument score1 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(50).challengeId(UUID.randomUUID()).createdAt(week1Day1).build();
+                .userId(userId).pointsEarned(50).challengeId(UUID.randomUUID()).createdAt(WEEK_10_MONDAY).build();
         UserScoreDocument score2 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(100).challengeId(UUID.randomUUID()).createdAt(week1Day2).build();
+                .userId(userId).pointsEarned(100).challengeId(UUID.randomUUID()).createdAt(WEEK_10_WEDNESDAY).build();
 
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
                 .thenReturn(Flux.just(score1, score2));
@@ -153,13 +156,10 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScoresAcrossMultipleWeeks_whenGetUserScoresHistoryChart_thenAccumulatedAtEndIsProgressiveSum() {
-        LocalDateTime week10 = LocalDateTime.of(2024, 3, 4, 10, 0);
-        LocalDateTime week11 = LocalDateTime.of(2024, 3, 11, 10, 0);
-
         UserScoreDocument score1 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(150).challengeId(UUID.randomUUID()).createdAt(week10).build();
+                .userId(userId).pointsEarned(150).challengeId(UUID.randomUUID()).createdAt(WEEK_10_MONDAY).build();
         UserScoreDocument score2 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(75).challengeId(UUID.randomUUID()).createdAt(week11).build();
+                .userId(userId).pointsEarned(75).challengeId(UUID.randomUUID()).createdAt(WEEK_11_MONDAY).build();
 
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
                 .thenReturn(Flux.just(score1, score2));
@@ -173,10 +173,8 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScores_whenGetUserScoresHistoryChart_thenPeriodFormatIsIsoWeek() {
-        LocalDateTime week10 = LocalDateTime.of(2024, 3, 4, 10, 0);
-
         UserScoreDocument score = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(50).challengeId(UUID.randomUUID()).createdAt(week10).build();
+                .userId(userId).pointsEarned(50).challengeId(UUID.randomUUID()).createdAt(WEEK_10_MONDAY).build();
 
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
                 .thenReturn(Flux.just(score));
@@ -189,13 +187,10 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScoresAcrossMultipleWeeks_whenGetUserScoresHistoryChart_thenTotalPointsEqualsLastAccumulatedAtEnd() {
-        LocalDateTime week10 = LocalDateTime.of(2024, 3, 4, 10, 0);
-        LocalDateTime week11 = LocalDateTime.of(2024, 3, 11, 10, 0);
-
         UserScoreDocument score1 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(150).challengeId(UUID.randomUUID()).createdAt(week10).build();
+                .userId(userId).pointsEarned(150).challengeId(UUID.randomUUID()).createdAt(WEEK_10_MONDAY).build();
         UserScoreDocument score2 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(75).challengeId(UUID.randomUUID()).createdAt(week11).build();
+                .userId(userId).pointsEarned(75).challengeId(UUID.randomUUID()).createdAt(WEEK_11_MONDAY).build();
 
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
                 .thenReturn(Flux.just(score1, score2));
@@ -223,13 +218,10 @@ class UserScoreServiceImplTest {
     @SuppressWarnings("java:S2699") // to be extended with activityType when #275/#276 are merged
     @Test
     void givenMixedSourcesInSameWeek_whenGetUserScoresHistoryChart_thenAllPointsAreSummedTogether() {
-        LocalDateTime week10 = LocalDateTime.of(2024, 3, 4, 10, 0);
-        LocalDateTime week10b = LocalDateTime.of(2024, 3, 5, 10, 0);
-
         UserScoreDocument source1 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(30).challengeId(UUID.randomUUID()).createdAt(week10).build();
+                .userId(userId).pointsEarned(30).challengeId(UUID.randomUUID()).createdAt(WEEK_10_MONDAY).build();
         UserScoreDocument source2 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(60).challengeId(UUID.randomUUID()).createdAt(week10b).build();
+                .userId(userId).pointsEarned(60).challengeId(UUID.randomUUID()).createdAt(WEEK_10_TUESDAY).build();
 
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
                 .thenReturn(Flux.just(source1, source2));
@@ -238,6 +230,24 @@ class UserScoreServiceImplTest {
                 .expectNextMatches(response ->
                         response.getHistory().size() == 1 &&
                                 response.getHistory().getFirst().getPointsEarned() == 90)
+                .verifyComplete();
+    }
+
+    @Test
+    void givenScoresOnSundayAndNextMonday_whenGetUserScoresHistoryChart_thenBelongToDifferentWeeks() {
+        UserScoreDocument sundayScore = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(50).challengeId(UUID.randomUUID()).createdAt(WEEK_10_SUNDAY).build();
+        UserScoreDocument mondayScore = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(75).challengeId(UUID.randomUUID()).createdAt(WEEK_11_MONDAY).build();
+
+        when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
+                .thenReturn(Flux.just(sundayScore, mondayScore));
+
+        StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
+                .expectNextMatches(response ->
+                        response.getHistory().size() == 2 &&
+                                response.getHistory().get(0).getPeriod().equals("2024-W10") &&
+                                response.getHistory().get(1).getPeriod().equals("2024-W11"))
                 .verifyComplete();
     }
 }

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/UserScoreServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/UserScoreServiceImplTest.java
@@ -220,7 +220,7 @@ class UserScoreServiceImplTest {
                 .verifyComplete();
     }
 
-    @SuppressWarnings("java:S2699") // to be extended with source_type when #275/#276 are merged
+    @SuppressWarnings("java:S2699") // to be extended with activityType when #275/#276 are merged
     @Test
     void givenMixedSourcesInSameWeek_whenGetUserScoresHistoryChart_thenAllPointsAreSummedTogether() {
         LocalDateTime week10 = LocalDateTime.of(2024, 3, 4, 10, 0);

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/UserScoreServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/UserScoreServiceImplTest.java
@@ -31,13 +31,22 @@ class UserScoreServiceImplTest {
     private static final LocalDateTime WEEK_10_SUNDAY    = LocalDateTime.of(2024, 3, 10, 23, 59);
     private static final LocalDateTime WEEK_11_MONDAY    = LocalDateTime.of(2024, 3, 11, 0, 1);
 
+    private UserScoreDocument scoreDoc(int points, LocalDateTime date) {
+        return UserScoreDocument.builder()
+                .userId(userId)
+                .pointsEarned(points)
+                .challengeId(UUID.randomUUID())
+                .createdAt(date)
+                .build();
+    }
+
     @Test
     void givenMultipleScores_whenGetUserPointsHistory_thenTotalPointsIsCorrectlySummed() {
         LocalDateTime now = LocalDateTime.now();
 
-        UserScoreDocument score1 = UserScoreDocument.builder().pointsEarned(10).challengeId(UUID.randomUUID()).createdAt(now).build();
-        UserScoreDocument score2 = UserScoreDocument.builder().pointsEarned(5).challengeId(UUID.randomUUID()).createdAt(now.minusDays(3)).build();
-        UserScoreDocument score3 = UserScoreDocument.builder().pointsEarned(20).challengeId(UUID.randomUUID()).createdAt(now.minusDays(1)).build();
+        UserScoreDocument score1 = UserScoreDocument.builder().userId(userId).pointsEarned(10).challengeId(UUID.randomUUID()).createdAt(now).build();
+        UserScoreDocument score2 = UserScoreDocument.builder().userId(userId).pointsEarned(5).challengeId(UUID.randomUUID()).createdAt(now.minusDays(3)).build();
+        UserScoreDocument score3 = UserScoreDocument.builder().userId(userId).pointsEarned(20).challengeId(UUID.randomUUID()).createdAt(now.minusDays(1)).build();
 
         when(userScoreRepository.findByUserIdOrderByCreatedAtDesc(userId)).thenReturn(Flux.just(score1, score2, score3));
 
@@ -54,10 +63,12 @@ class UserScoreServiceImplTest {
         LocalDateTime now = LocalDateTime.now();
 
         UserScoreDocument latest = UserScoreDocument.builder()
+                .userId(userId)
                 .pointsEarned(10)
                 .createdAt(now)
                 .build();
         UserScoreDocument older = UserScoreDocument.builder()
+                .userId(userId)
                 .pointsEarned(5)
                 .createdAt(now.minusDays(3))
                 .build();
@@ -80,6 +91,7 @@ class UserScoreServiceImplTest {
         String expectedDate = fixedDate.toString();
 
         UserScoreDocument score = UserScoreDocument.builder()
+                .userId(userId)
                 .pointsEarned(10)
                 .challengeId(UUID.randomUUID())
                 .createdAt(fixedDate)
@@ -116,11 +128,13 @@ class UserScoreServiceImplTest {
         LocalDateTime now = LocalDateTime.now();
 
         UserScoreDocument validScore = UserScoreDocument.builder()
+                .userId(userId)
                 .challengeId(UUID.randomUUID())
                 .pointsEarned(10)
                 .createdAt(now)
                 .build();
         UserScoreDocument invalidScore = UserScoreDocument.builder()
+                .userId(userId)
                 .challengeId(UUID.randomUUID())
                 .pointsEarned(null)
                 .createdAt(now.minusDays(3))
@@ -138,14 +152,10 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScoresInSameWeek_whenGetUserScoresHistoryChart_thenWeeklyPointsEarnedIsCorrect() {
-
-        UserScoreDocument score1 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(50).challengeId(UUID.randomUUID()).createdAt(WEEK_10_MONDAY).build();
-        UserScoreDocument score2 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(100).challengeId(UUID.randomUUID()).createdAt(WEEK_10_WEDNESDAY).build();
-
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
-                .thenReturn(Flux.just(score1, score2));
+                .thenReturn(Flux.just(
+                        scoreDoc(50, WEEK_10_MONDAY),
+                        scoreDoc(100, WEEK_10_WEDNESDAY)));
 
         StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
                 .expectNextMatches(response ->
@@ -156,13 +166,11 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScoresAcrossMultipleWeeks_whenGetUserScoresHistoryChart_thenAccumulatedAtEndIsProgressiveSum() {
-        UserScoreDocument score1 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(150).challengeId(UUID.randomUUID()).createdAt(WEEK_10_MONDAY).build();
-        UserScoreDocument score2 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(75).challengeId(UUID.randomUUID()).createdAt(WEEK_11_MONDAY).build();
-
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
-                .thenReturn(Flux.just(score1, score2));
+                .thenReturn(Flux.just(
+                        scoreDoc(150, WEEK_10_MONDAY),
+                        scoreDoc(75, WEEK_11_MONDAY)
+                ));
 
         StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
                 .expectNextMatches(response ->
@@ -173,11 +181,8 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScores_whenGetUserScoresHistoryChart_thenPeriodFormatIsIsoWeek() {
-        UserScoreDocument score = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(50).challengeId(UUID.randomUUID()).createdAt(WEEK_10_MONDAY).build();
-
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
-                .thenReturn(Flux.just(score));
+                .thenReturn(Flux.just(scoreDoc(50, WEEK_10_MONDAY)));
 
         StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
                 .expectNextMatches(response ->
@@ -187,13 +192,11 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScoresAcrossMultipleWeeks_whenGetUserScoresHistoryChart_thenTotalPointsEqualsLastAccumulatedAtEnd() {
-        UserScoreDocument score1 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(150).challengeId(UUID.randomUUID()).createdAt(WEEK_10_MONDAY).build();
-        UserScoreDocument score2 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(75).challengeId(UUID.randomUUID()).createdAt(WEEK_11_MONDAY).build();
-
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
-                .thenReturn(Flux.just(score1, score2));
+                .thenReturn(Flux.just(
+                        scoreDoc(150, WEEK_10_MONDAY),
+                        scoreDoc(75, WEEK_11_MONDAY)
+                ));
 
         StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
                 .expectNextMatches(response ->
@@ -204,7 +207,6 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenNoScores_whenGetUserScoresHistoryChart_thenReturnsTotalPointsZeroAndEmptyHistory() {
-
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
                 .thenReturn(Flux.empty());
 
@@ -218,13 +220,9 @@ class UserScoreServiceImplTest {
     @SuppressWarnings("java:S2699") // to be extended with activityType when #275/#276 are merged
     @Test
     void givenMixedSourcesInSameWeek_whenGetUserScoresHistoryChart_thenAllPointsAreSummedTogether() {
-        UserScoreDocument source1 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(30).challengeId(UUID.randomUUID()).createdAt(WEEK_10_MONDAY).build();
-        UserScoreDocument source2 = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(60).challengeId(UUID.randomUUID()).createdAt(WEEK_10_TUESDAY).build();
-
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
-                .thenReturn(Flux.just(source1, source2));
+                .thenReturn(Flux.just(scoreDoc(30, WEEK_10_MONDAY),
+                        scoreDoc(60, WEEK_10_TUESDAY)));
 
         StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
                 .expectNextMatches(response ->
@@ -235,13 +233,10 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScoresOnSundayAndNextMonday_whenGetUserScoresHistoryChart_thenBelongToDifferentWeeks() {
-        UserScoreDocument sundayScore = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(50).challengeId(UUID.randomUUID()).createdAt(WEEK_10_SUNDAY).build();
-        UserScoreDocument mondayScore = UserScoreDocument.builder()
-                .userId(userId).pointsEarned(75).challengeId(UUID.randomUUID()).createdAt(WEEK_11_MONDAY).build();
-
         when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
-                .thenReturn(Flux.just(sundayScore, mondayScore));
+                .thenReturn(Flux.just(
+                        scoreDoc(50, WEEK_10_SUNDAY),
+                        scoreDoc(75, WEEK_11_MONDAY)));
 
         StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
                 .expectNextMatches(response ->

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/UserScoreServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/UserScoreServiceImplTest.java
@@ -24,9 +24,10 @@ class UserScoreServiceImplTest {
     @InjectMocks
     private UserScoreServiceImpl userScoreService;
 
+    private final UUID userId = UUID.randomUUID();
+
     @Test
     void givenMultipleScores_whenGetUserPointsHistory_thenTotalPointsIsCorrectlySummed() {
-        UUID userId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
 
         UserScoreDocument score1 = UserScoreDocument.builder().pointsEarned(10).challengeId(UUID.randomUUID()).createdAt(now).build();
@@ -45,7 +46,6 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenDescendingRepoData_whenGetUserPointsHistory_thenReturnsAscendingForFrontend() {
-        UUID userId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
 
         UserScoreDocument latest = UserScoreDocument.builder()
@@ -71,7 +71,6 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScoreDocument_whenGetUserPointsHistory_thenDateIsCorrectlyMapped() {
-        UUID userId = UUID.randomUUID();
         LocalDateTime fixedDate = LocalDateTime.of(2015, 3, 26, 7, 33, 21);
         String expectedDate = fixedDate.toString();
 
@@ -95,7 +94,6 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenNoScores_whenGetUserPointsHistory_thenReturnsEmptyHistoryAndZeroPoints() {
-        UUID userId = UUID.randomUUID();
 
         when(userScoreRepository.findByUserIdOrderByCreatedAtDesc(userId)).thenReturn(Flux.empty());
 
@@ -110,7 +108,6 @@ class UserScoreServiceImplTest {
 
     @Test
     void givenScoresWithNullPoints_whenGetUserPointsHistory_thenTotalPointsIgnoresNullValues() {
-        UUID userId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
 
         UserScoreDocument validScore = UserScoreDocument.builder()
@@ -131,6 +128,116 @@ class UserScoreServiceImplTest {
 
         StepVerifier.create(result)
                 .expectNextMatches(response -> response.getTotalPoints() == 10)
+                .verifyComplete();
+    }
+
+    @Test
+    void givenScoresInSameWeek_whenGetUserScoresHistoryChart_thenWeeklyPointsEarnedIsCorrect() {
+        LocalDateTime week1Day1 = LocalDateTime.of(2024, 3, 4, 10, 0);
+        LocalDateTime week1Day2 = LocalDateTime.of(2024, 3, 6, 10, 0);
+
+        UserScoreDocument score1 = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(50).challengeId(UUID.randomUUID()).createdAt(week1Day1).build();
+        UserScoreDocument score2 = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(100).challengeId(UUID.randomUUID()).createdAt(week1Day2).build();
+
+        when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
+                .thenReturn(Flux.just(score1, score2));
+
+        StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
+                .expectNextMatches(response ->
+                        response.getHistory().size() == 1 &&
+                                response.getHistory().getFirst().getPointsEarned() == 150)
+                .verifyComplete();
+    }
+
+    @Test
+    void givenScoresAcrossMultipleWeeks_whenGetUserScoresHistoryChart_thenAccumulatedAtEndIsProgressiveSum() {
+        LocalDateTime week10 = LocalDateTime.of(2024, 3, 4, 10, 0);
+        LocalDateTime week11 = LocalDateTime.of(2024, 3, 11, 10, 0);
+
+        UserScoreDocument score1 = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(150).challengeId(UUID.randomUUID()).createdAt(week10).build();
+        UserScoreDocument score2 = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(75).challengeId(UUID.randomUUID()).createdAt(week11).build();
+
+        when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
+                .thenReturn(Flux.just(score1, score2));
+
+        StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
+                .expectNextMatches(response ->
+                        response.getHistory().get(0).getAccumulatedAtEnd() == 150 &&
+                                response.getHistory().get(1).getAccumulatedAtEnd() == 225)
+                .verifyComplete();
+    }
+
+    @Test
+    void givenScores_whenGetUserScoresHistoryChart_thenPeriodFormatIsIsoWeek() {
+        LocalDateTime week10 = LocalDateTime.of(2024, 3, 4, 10, 0);
+
+        UserScoreDocument score = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(50).challengeId(UUID.randomUUID()).createdAt(week10).build();
+
+        when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
+                .thenReturn(Flux.just(score));
+
+        StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
+                .expectNextMatches(response ->
+                        response.getHistory().getFirst().getPeriod().matches("\\d{4}-W\\d{2}"))
+                .verifyComplete();
+    }
+
+    @Test
+    void givenScoresAcrossMultipleWeeks_whenGetUserScoresHistoryChart_thenTotalPointsEqualsLastAccumulatedAtEnd() {
+        LocalDateTime week10 = LocalDateTime.of(2024, 3, 4, 10, 0);
+        LocalDateTime week11 = LocalDateTime.of(2024, 3, 11, 10, 0);
+
+        UserScoreDocument score1 = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(150).challengeId(UUID.randomUUID()).createdAt(week10).build();
+        UserScoreDocument score2 = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(75).challengeId(UUID.randomUUID()).createdAt(week11).build();
+
+        when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
+                .thenReturn(Flux.just(score1, score2));
+
+        StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
+                .expectNextMatches(response ->
+                        response.getTotalPoints() == response.getHistory()
+                                .get(response.getHistory().size() - 1).getAccumulatedAtEnd())
+                .verifyComplete();
+    }
+
+    @Test
+    void givenNoScores_whenGetUserScoresHistoryChart_thenReturnsTotalPointsZeroAndEmptyHistory() {
+
+        when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
+                .thenReturn(Flux.empty());
+
+        StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
+                .expectNextMatches(response ->
+                        response.getTotalPoints() == 0 &&
+                                response.getHistory().isEmpty())
+                .verifyComplete();
+    }
+
+    @SuppressWarnings("java:S2699") // to be extended with source_type when #275/#276 are merged
+    @Test
+    void givenMixedSourcesInSameWeek_whenGetUserScoresHistoryChart_thenAllPointsAreSummedTogether() {
+        LocalDateTime week10 = LocalDateTime.of(2024, 3, 4, 10, 0);
+        LocalDateTime week10b = LocalDateTime.of(2024, 3, 5, 10, 0);
+
+        UserScoreDocument source1 = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(30).challengeId(UUID.randomUUID()).createdAt(week10).build();
+        UserScoreDocument source2 = UserScoreDocument.builder()
+                .userId(userId).pointsEarned(60).challengeId(UUID.randomUUID()).createdAt(week10b).build();
+
+        when(userScoreRepository.findByUserIdOrderByCreatedAtAsc(userId))
+                .thenReturn(Flux.just(source1, source2));
+
+        StepVerifier.create(userScoreService.getUserScoresHistoryChart(userId))
+                .expectNextMatches(response ->
+                        response.getHistory().size() == 1 &&
+                                response.getHistory().getFirst().getPointsEarned() == 90)
                 .verifyComplete();
     }
 }


### PR DESCRIPTION
⚠️ Do not merge until PR 1/3 (#294) is merged first. This PR depends on `findByUserIdOrderByCreatedAtAsc` introduced there.

## Description

PR 2/3 of parent issue #281. Implements weekly aggregation logic in `UserScoreServiceImpl` and introduces the new `ScoresHistoryResponseDto` and `WeeklyPointsDto` to support the score history chart.

## Analysis of existing behavior

`UserScoreServiceImpl` previously returned a flat list of score entries via `getUserPointsHistory()` using `findByUserIdOrderByCreatedAtDesc`. No aggregation or accumulated total was calculated.

## What this PR adds

- `ScoresHistoryResponseDto` and `WeeklyPointsDto` — new DTOs for the weekly chart response
- `getUserScoresHistoryChart()` in `UserScoreService` and `UserScoreServiceImpl`
- Weekly aggregation logic grouped by ISO week (yyyy-Www)
- Progressive accumulated total per week (`accumulatedAtEnd`)
- `aggregationType` fixed to `"WEEKLY"`
- Defined behavior for empty history (`totalPoints: 0`, `history: []`)
- Unit tests for all aggregation scenarios (all passing, see screenshot below)

<img width="1286" height="557" alt="test-results-service-chart-aggregation-pr2" src="https://github.com/user-attachments/assets/a08c3b77-a611-4533-9b77-bcd2cf650066" />

## Out of scope

- Filtering history by `activityType` — tracked in #311
- Configurable `aggregationType` (daily, monthly) — tracked in #310
- Controller changes — covered in PR 3/3

## Known limitations

`givenMixedSourcesInSameWeek_whenGetUserScoresHistoryChart_thenAllPointsAreSummedTogether` currently simulates multiple point sources using distinct `challengeId` values, as `activityType` is not yet available in `UserScoreDocument`. `@SuppressWarnings("java:S2699")` added temporarily. This test must be extended once #275 and #276 are merged.

## Technical debt

- `aggregationType` hardcoded to `"WEEKLY"` — tracked in #310
- `activityType` filtering not yet supported — tracked in #311

## Changes after initial review

- Renamed `ScoresHistoryChartDto` to `ScoresHistoryResponseDto` to decouple the DTO name from a specific use case

## Self-checklist

- [x] I tested my changes locally and verified they work as expected
- [x] The PR has a clear and focused purpose (only one feature, fix or refactor)
- [x] Title, description, and changelog (if needed) are filled in correctly
- [x] There are no leftover merge conflicts or unrelated changes from previous branches
- [x] All automated checks (like SonarCloud) have passed
- [x] I responded to all previous review comments and only resolved those I truly addressed
- [x] I ran SonarLint locally on the modified files and confirmed there are no warnings or errors