### PR TITLE
feat(gamification): implement read-only endpoint for available activity types (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [itachallenge-challenge-3.5.0-RELEASE] - 2026-04-09
+
+[Gamification]
+
+### Added
+
+#### Activity Types API
+- Added `ActivityType` enum as the shared source of truth for available point-generating activity types.
+- Added `GET /itachallenge/api/v1/activity-types` endpoint to expose available activity types for frontend consumption.
+- Added service, DTO, and controller support for activity type retrieval, along with unit and controller tests.
+
 ## [itachallenge-challenge-3.4.0 - RELEASED] 2026-03-23
 
 [Gamification]

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/gamification/ActivityTypeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/gamification/ActivityTypeController.java
@@ -29,7 +29,7 @@ public class ActivityTypeController {
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "OK - empty array if none.",
+                            description = "OK - returns an object with an empty activityTypes list if none.",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = ActivityTypeResponseDto.class)

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/gamification/ActivityTypeController.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/controller/gamification/ActivityTypeController.java
@@ -1,0 +1,49 @@
+package com.itachallenge.challenge.controller.gamification;
+
+import com.itachallenge.challenge.dto.MessageDto;
+import com.itachallenge.challenge.dto.gamification.ActivityTypeResponseDto;
+import com.itachallenge.gamification.service.ActivityTypeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/itachallenge/api/v1/activity-types")
+public class ActivityTypeController {
+
+    private final ActivityTypeService activityTypeService;
+
+    @GetMapping
+    @Operation(
+            summary = "Get available activity types.",
+            description = "Returns the list of available activity types that generate points in the system.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "OK - empty array if none.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ActivityTypeResponseDto.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "Internal Server Error",
+                            content = @Content(schema = @Schema(implementation = MessageDto.class))
+                    )
+            }
+    )
+    public Mono<ActivityTypeResponseDto> getAvailableActivityTypes() {
+        log.info("Requesting available activity types");
+        return activityTypeService.getAvailableActivityTypes();
+    }
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/gamification/ActivityTypeResponseDto.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/challenge/dto/gamification/ActivityTypeResponseDto.java
@@ -1,0 +1,16 @@
+package com.itachallenge.challenge.dto.gamification;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ActivityTypeResponseDto {
+    private List<String> activityTypes;
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/ActivityTypeService.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/ActivityTypeService.java
@@ -1,0 +1,9 @@
+package com.itachallenge.gamification.service;
+
+import com.itachallenge.challenge.dto.gamification.ActivityTypeResponseDto;
+import reactor.core.publisher.Mono;
+
+public interface ActivityTypeService {
+
+    Mono<ActivityTypeResponseDto> getAvailableActivityTypes();
+}

--- a/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/ActivityTypeServiceImpl.java
+++ b/itachallenge-challenge/src/main/java/com/itachallenge/gamification/service/ActivityTypeServiceImpl.java
@@ -1,0 +1,23 @@
+package com.itachallenge.gamification.service;
+
+import com.itachallenge.challenge.dto.gamification.ActivityTypeResponseDto;
+import com.itachallenge.gamification.enums.ActivityType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityTypeServiceImpl implements ActivityTypeService {
+
+    @Override
+    public Mono<ActivityTypeResponseDto> getAvailableActivityTypes() {
+        return Mono.just(ActivityTypeResponseDto.builder()
+                .activityTypes(Arrays.stream(ActivityType.values())
+                        .map(Enum::name)
+                        .toList())
+                .build());
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/gamification/ActivityTypeControllerTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/challenge/controller/gamification/ActivityTypeControllerTest.java
@@ -1,0 +1,86 @@
+package com.itachallenge.challenge.controller.gamification;
+
+import com.itachallenge.challenge.dto.gamification.ActivityTypeResponseDto;
+import com.itachallenge.challenge.exception.InternalServerErrorException;
+import com.itachallenge.gamification.service.ActivityTypeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebFluxTest(ActivityTypeController.class)
+class ActivityTypeControllerTest {
+
+    private static final String URL = "/itachallenge/api/v1/activity-types";
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private ActivityTypeService activityTypeService;
+
+    @Test
+    void getAvailableActivityTypes_returnsOkAndActivityTypes() {
+        ActivityTypeResponseDto responseDto = ActivityTypeResponseDto.builder()
+                .activityTypes(List.of("CODE_REVIEW", "PRESENTATION", "CHALLENGE_COMPLETED"))
+                .build();
+
+        when(activityTypeService.getAvailableActivityTypes()).thenReturn(Mono.just(responseDto));
+
+        webTestClient.get()
+                .uri(URL)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.activityTypes.length()").isEqualTo(3)
+                .jsonPath("$.activityTypes[0]").isEqualTo("CODE_REVIEW")
+                .jsonPath("$.activityTypes[1]").isEqualTo("PRESENTATION")
+                .jsonPath("$.activityTypes[2]").isEqualTo("CHALLENGE_COMPLETED");
+
+        verify(activityTypeService).getAvailableActivityTypes();
+    }
+
+    @Test
+    void getAvailableActivityTypes_whenEmpty_returnsOkAndEmptyList() {
+        ActivityTypeResponseDto emptyResponse = ActivityTypeResponseDto.builder()
+                .activityTypes(Collections.emptyList())
+                .build();
+
+        when(activityTypeService.getAvailableActivityTypes()).thenReturn(Mono.just(emptyResponse));
+
+        webTestClient.get()
+                .uri(URL)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .jsonPath("$.activityTypes").isEmpty();
+
+        verify(activityTypeService).getAvailableActivityTypes();
+    }
+
+    @Test
+    void getAvailableActivityTypes_whenServiceError_returns500Error() {
+        when(activityTypeService.getAvailableActivityTypes())
+                .thenReturn(Mono.error(new InternalServerErrorException("Unexpected error")));
+
+        webTestClient.get()
+                .uri(URL)
+                .exchange()
+                .expectStatus().is5xxServerError();
+
+        verify(activityTypeService).getAvailableActivityTypes();
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/ActivityTypeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/ActivityTypeServiceImplTest.java
@@ -1,0 +1,19 @@
+package com.itachallenge.gamification.service;
+
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActivityTypeServiceImplTest {
+
+    private final ActivityTypeServiceImpl activityTypeService = new ActivityTypeServiceImpl();
+
+    @Test
+    void getAvailableActivityTypes_returnsAllEnumNames() {
+        StepVerifier.create(activityTypeService.getAvailableActivityTypes())
+                .assertNext(response -> assertThat(response.getActivityTypes())
+                        .containsExactly("CODE_REVIEW", "PRESENTATION", "CHALLENGE_COMPLETED"))
+                .verifyComplete();
+    }
+}

--- a/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/ActivityTypeServiceImplTest.java
+++ b/itachallenge-challenge/src/test/java/com/itachallenge/gamification/service/ActivityTypeServiceImplTest.java
@@ -1,7 +1,10 @@
 package com.itachallenge.gamification.service;
 
+import com.itachallenge.gamification.enums.ActivityType;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
+
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,7 +16,9 @@ class ActivityTypeServiceImplTest {
     void getAvailableActivityTypes_returnsAllEnumNames() {
         StepVerifier.create(activityTypeService.getAvailableActivityTypes())
                 .assertNext(response -> assertThat(response.getActivityTypes())
-                        .containsExactly("CODE_REVIEW", "PRESENTATION", "CHALLENGE_COMPLETED"))
+                        .containsExactly(Arrays.stream(ActivityType.values())
+                                .map(Enum::name)
+                                .toArray(String[]::new)))
                 .verifyComplete();
     }
 }

--- a/postman/ITA-Challenges.postman_collection.json
+++ b/postman/ITA-Challenges.postman_collection.json
@@ -581,6 +581,27 @@
           "response": []
         },
         {
+          "name": "Get Activity Types",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "http://{{ip}}:{{challenge_port}}/itachallenge/api/v1/activity-types",
+              "protocol": "http",
+              "host": ["{{ip}}"],
+              "port": "{{challenge_port}}",
+              "path": ["itachallenge", "api", "v1", "activity-types"]
+            },
+            "description": "Returns the list of available activity types."
+          },
+          "response": []
+        },
+        {
           "name": "Get Leaderboard",
           "request": {
             "method": "GET",


### PR DESCRIPTION
Closes #305

## Description

This PR implements a read-only endpoint to expose the available activity types defined in `ActivityType`, so the frontend can consume them dynamically without hardcoding values.

The new endpoint added is:

- `GET /itachallenge/api/v1/activity-types`

It returns the list of available activity types currently defined in the system:
- `CODE_REVIEW`
- `PRESENTATION`
- `CHALLENGE_COMPLETED`

## Changes

- Added `ActivityTypeController` to expose the new read-only endpoint
- Added `ActivityTypeService` and `ActivityTypeServiceImpl`
- Added `ActivityTypeResponseDto` for the endpoint response
- Updated `CHANGELOG.md`
- Updated `postman/ITA-Challenges.postman_collection.json`

## Scope

Included:
- Read-only retrieval of available activity types
- Swagger/OpenAPI exposure for the new endpoint
- Unit and controller tests
- Postman collection update

Not included:
- Point registration logic
- Score persistence changes
- Ranking or history changes

## Validation

- Local service test passed
- Local controller tests passed
- Endpoint verified manually in Swagger with expected response

<img width="1733" height="1155" alt="TestPR2Service" src="https://github.com/user-attachments/assets/542f90dc-63bf-4ba4-87d7-6ed7b86372c6" />
<img width="1728" height="1302" alt="TestPR2Controller" src="https://github.com/user-attachments/assets/52deeb27-8449-45e6-9aab-ca4ff2cd485b" />
<img width="1243" height="1168" alt="SwaggerENDPOINT" src="https://github.com/user-attachments/assets/878d93fb-da11-450b-bab4-3f8fa89dd23b" />

