### PR TITLE
PR 2 - refactor(user): update bookmark controller (#279)

### DIFF
--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/UserController.java
@@ -3,7 +3,6 @@ package com.itachallenge.user.controller;
 import com.itachallenge.user.annotations.ValidGithubUsername;
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.service.UserService;
-import com.itachallenge.userinteraction.service.bookmark.BookmarkService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -12,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -28,11 +26,9 @@ public class UserController {
     public static final String X_GITHUB_USERNAME ="X-Github-Username";
 
     private final UserService userService;
-    private final BookmarkService bookmarkService;
 
-    public UserController(UserService userService, BookmarkService bookmarkService) {
+    public UserController(UserService userService) {
         this.userService = userService;
-        this.bookmarkService = bookmarkService;
     }
 
     @GetMapping(value = "/test")
@@ -86,120 +82,4 @@ public class UserController {
                             .body(user);
                 });
     }
-
-
-    @Operation(
-            summary = "Add Challenge to User Bookmark Challenges",
-            description = "Adds challenge to user Bookmarks",
-            parameters = {
-                    @Parameter(
-                            name = "userId",
-                            description = "User ID",
-                            required = true,
-                            in = ParameterIn.PATH
-                    ),
-                    @Parameter(
-                            name = "challengeId",
-                            description = "Challenge ID",
-                            required = true,
-                            in = ParameterIn.PATH
-                    )
-            },
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "Challenge is already in bookmarks",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "201",
-                            description = "Challenge added to bookmarks",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "Bad Request. The provided IDs have a bad format",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "Not found. No user is found with the provided user id.",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "Internal server error. An unexpected error occurred.",
-                            content = @Content(mediaType = "application/json")
-                    )
-            }
-    )
-
-    @PostMapping("/users/{userId}/bookmarks/{challengeId}")
-    public Mono<ResponseEntity<Boolean>> addChallengeToBookmarks(@PathVariable String userId, @PathVariable String challengeId) {
-        return bookmarkService.addChallengeToBookmarks(userId, challengeId)
-                .map(added -> {
-                    if (Boolean.TRUE.equals(added)) {
-                        log.info("Challenge '{}' added to user '{}' bookmarks", challengeId, userId);
-                        return ResponseEntity.status(HttpStatus.CREATED).body(true);
-                    } else {
-                        log.info("User's '{}' bookmarks already contain Challenge '{}'", userId, challengeId);
-                        return ResponseEntity.ok().body(false);
-                    }
-                });
-    }
-
-    @Operation(
-            summary = "Delete Challenge from User Bookmark Challenges",
-            description = "Deletes challenge from user bookmarks",
-            parameters = {
-                    @Parameter(
-                            name = "userId",
-                            description = "User ID",
-                            required = true,
-                            in = ParameterIn.PATH
-                    ),
-                    @Parameter(
-                            name = "challengeId",
-                            description = "Challenge ID",
-                            required = true,
-                            in = ParameterIn.PATH
-                    )
-            },
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "Challenge deleted from bookmarks or was not in bookmarks",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "Bad Request. The provided IDs have a bad format",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "Not found. No user is found with the provided user id.",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "Internal server error. An unexpected error occurred.",
-                            content = @Content(mediaType = "application/json")
-                    )
-            }
-    )
-    @DeleteMapping("/users/{userId}/bookmarks/{challengeId}")
-    public Mono<ResponseEntity<Boolean>> deleteChallengeFromBookmarks(@PathVariable String userId, @PathVariable String challengeId) {
-        return bookmarkService.deleteChallengeFromBookmarks(userId, challengeId)
-                .map(deleted -> {
-                    if (Boolean.TRUE.equals(deleted)) {
-                        log.info("Challenge '{}' deleted from user '{}' bookmarks", challengeId, userId);
-                        return ResponseEntity.ok().body(true);
-                    } else {
-                        log.info("No change, User's '{}' bookmarks doesn't contain Challenge '{}'", userId, challengeId);
-                        return ResponseEntity.ok().body(false);
-                    }
-                });
-    }
-
 }

--- a/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkController.java
+++ b/itachallenge-user/src/main/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkController.java
@@ -4,9 +4,11 @@ import com.itachallenge.userinteraction.service.bookmark.BookmarkService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -15,7 +17,6 @@ import java.util.Set;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/itachallenge/api/v1/users/{userId}/bookmarks")
 public class BookmarkController {
 
     private static final Logger log = LoggerFactory.getLogger(BookmarkController.class);
@@ -45,12 +46,125 @@ public class BookmarkController {
             }
     )
 
-    @GetMapping
+    @GetMapping("/itachallenge/api/v1/users/{userId}/bookmarks")
     public Mono<ResponseEntity<Set<UUID>>> getUserBookmarks(@PathVariable String userId) {
         return bookmarkService.getUserBookmarks(userId)
                 .map(bookmarks -> {
                     log.info("Retrieved {} bookmark challenges for user {}", bookmarks.size(), userId);
                     return ResponseEntity.ok(bookmarks);
+                });
+    }
+
+    @Operation(
+            summary = "Add Challenge to User Bookmark Challenges",
+            description = "Adds challenge to user Bookmarks",
+            parameters = {
+                    @Parameter(
+                            name = "userId",
+                            description = "User ID",
+                            required = true,
+                            in = ParameterIn.PATH
+                    ),
+                    @Parameter(
+                            name = "challengeId",
+                            description = "Challenge ID",
+                            required = true,
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Challenge is already in bookmarks",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "Challenge added to bookmarks",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Bad Request. The provided IDs have a bad format",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Not found. No user is found with the provided user id.",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "Internal server error. An unexpected error occurred.",
+                            content = @Content(mediaType = "application/json")
+                    )
+            }
+    )
+    @PostMapping("/itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}")
+    public Mono<ResponseEntity<Boolean>> addChallengeToBookmarks(@PathVariable String userId, @PathVariable String challengeId) {
+        return bookmarkService.addChallengeToBookmarks(userId, challengeId)
+                .map(added -> {
+                    if (Boolean.TRUE.equals(added)) {
+                        log.info("Challenge '{}' added to user '{}' bookmarks", challengeId, userId);
+                        return ResponseEntity.status(HttpStatus.CREATED).body(true);
+                    } else {
+                        log.info("User's '{}' bookmarks already contain Challenge '{}'", userId, challengeId);
+                        return ResponseEntity.ok().body(false);
+                    }
+                });
+    }
+
+    @Operation(
+            summary = "Delete Challenge from User Bookmark Challenges",
+            description = "Deletes challenge from user bookmarks",
+            parameters = {
+                    @Parameter(
+                            name = "userId",
+                            description = "User ID",
+                            required = true,
+                            in = ParameterIn.PATH
+                    ),
+                    @Parameter(
+                            name = "challengeId",
+                            description = "Challenge ID",
+                            required = true,
+                            in = ParameterIn.PATH
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Challenge deleted from bookmarks or was not in bookmarks",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Bad Request. The provided IDs have a bad format",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Not found. No user is found with the provided user id.",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "Internal server error. An unexpected error occurred.",
+                            content = @Content(mediaType = "application/json")
+                    )
+            }
+    )
+    @DeleteMapping("/itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}")
+    public Mono<ResponseEntity<Boolean>> deleteChallengeFromBookmarks(@PathVariable String userId, @PathVariable String challengeId) {
+        return bookmarkService.deleteChallengeFromBookmarks(userId, challengeId)
+                .map(deleted -> {
+                    if (Boolean.TRUE.equals(deleted)) {
+                        log.info("Challenge '{}' deleted from user '{}' bookmarks", challengeId, userId);
+                        return ResponseEntity.ok().body(true);
+                    } else {
+                        log.info("No change, User's '{}' bookmarks doesn't contain Challenge '{}'", userId, challengeId);
+                        return ResponseEntity.ok().body(false);
+                    }
                 });
     }
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/UserControllerTest.java
@@ -2,11 +2,9 @@ package com.itachallenge.user.controller;
 
 import com.itachallenge.user.document.UserDocument;
 import com.itachallenge.user.document.enums.Role;
-import com.itachallenge.common.exception.BadUUIDException;
 import com.itachallenge.common.exception.NotFoundException;
 import com.itachallenge.common.exception.UserGlobalExceptionHandler;
 import com.itachallenge.user.service.UserService;
-import com.itachallenge.userinteraction.service.bookmark.BookmarkService;
 import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -23,9 +21,6 @@ class UserControllerTest {
 
     @Mock
     private UserService userService;
-
-    @Mock
-    private BookmarkService bookmarkService;
 
     @InjectMocks
     private UserController userController;
@@ -103,165 +98,4 @@ class UserControllerTest {
 
         verify(userService, times(1)).getUser(githubUsername);
     }
-
-    @Test
-    void addToBookmarks_WhenAdded_Returns201() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(bookmarkService.addChallengeToBookmarks(userId, challengeId))
-                .thenReturn(Mono.just(true));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.CREATED)
-                .expectBody(Boolean.class).isEqualTo(true);
-
-        verify(bookmarkService, times(1)).addChallengeToBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void addToBookmarks_WhenAlreadyInBookmarks_Returns200() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(bookmarkService.addChallengeToBookmarks(userId, challengeId))
-                .thenReturn(Mono.just(false));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(Boolean.class).isEqualTo(false);
-
-        verify(bookmarkService, times(1)).addChallengeToBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void addToBookmarks_WhenUserNotExists_Returns404() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(bookmarkService.addChallengeToBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new NotFoundException("User not found")));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
-
-        verify(bookmarkService, times(1)).addChallengeToBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void addToBookmarks_WhenBadFormattedId_Returns400() {
-        String userId = "invalidUuid";
-        String challengeId = "invalidUUid";
-        when(bookmarkService.addChallengeToBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
-
-        verify(bookmarkService, times(1)).addChallengeToBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void addToBookmarks_WhenUnexpectedError_Returns500() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(bookmarkService.addChallengeToBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new Exception()));
-
-        webTestClient.post()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
-
-        verify(bookmarkService, times(1)).addChallengeToBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void deleteFromBookmarks_WhenDeleted_Returns200() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(bookmarkService.deleteChallengeFromBookmarks(userId, challengeId))
-                .thenReturn(Mono.just(true));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.OK)
-                .expectBody(Boolean.class).isEqualTo(true);
-
-        verify(bookmarkService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void deleteFromBookmarks_WhenNotInBookmarks_Returns200() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(bookmarkService.deleteChallengeFromBookmarks(userId, challengeId))
-                .thenReturn(Mono.just(false));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(Boolean.class).isEqualTo(false);
-
-        verify(bookmarkService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void deleteFromBookmarks_WhenUserNotExists_Returns404() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(bookmarkService.deleteChallengeFromBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new NotFoundException("User not found")));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
-                .expectBody(String.class).isEqualTo("User not found");
-
-        verify(bookmarkService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void deleteFromBookmarks_WhenBadFormattedId_Returns404() {
-        String userId = "invalidUuid";
-        String challengeId = "invalidUUid";
-        when(bookmarkService.deleteChallengeFromBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new BadUUIDException("Error message")));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
-                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
-
-        verify(bookmarkService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
-    }
-
-    @Test
-    void deleteFromBookmarks_WhenUnexpectedError_Returns500() {
-        String userId = UUID.randomUUID().toString();
-        String challengeId = UUID.randomUUID().toString();
-        when(bookmarkService.deleteChallengeFromBookmarks(userId, challengeId))
-                .thenReturn(Mono.error(new Exception()));
-
-        webTestClient.delete()
-                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-                .expectBody(String.class).isEqualTo("Unexpected error happened.");
-
-        verify(bookmarkService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
-    }
-
 }

--- a/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
+++ b/itachallenge-user/src/test/java/com/itachallenge/user/controller/userinteraction/bookmark/BookmarkControllerTest.java
@@ -108,4 +108,165 @@ class BookmarkControllerTest {
 
         verify(bookmarkService, times(1)).getUserBookmarks(userId.toString());
     }
+
+
+    @Test
+    void addToBookmarks_WhenAdded_Returns201() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(bookmarkService.addChallengeToBookmarks(userId, challengeId))
+                .thenReturn(Mono.just(true));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.CREATED)
+                .expectBody(Boolean.class).isEqualTo(true);
+
+        verify(bookmarkService, times(1)).addChallengeToBookmarks(userId, challengeId);
+    }
+
+    @Test
+    void addToBookmarks_WhenAlreadyInBookmarks_Returns200() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(bookmarkService.addChallengeToBookmarks(userId, challengeId))
+                .thenReturn(Mono.just(false));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(Boolean.class).isEqualTo(false);
+
+        verify(bookmarkService, times(1)).addChallengeToBookmarks(userId, challengeId);
+    }
+
+    @Test
+    void addToBookmarks_WhenUserNotExists_Returns404() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(bookmarkService.addChallengeToBookmarks(userId, challengeId))
+                .thenReturn(Mono.error(new NotFoundException("User not found")));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
+                .expectBody(String.class).isEqualTo("User not found");
+
+        verify(bookmarkService, times(1)).addChallengeToBookmarks(userId, challengeId);
+    }
+
+    @Test
+    void addToBookmarks_WhenBadFormattedId_Returns400() {
+        String userId = "invalidUuid";
+        String challengeId = "invalidUUid";
+        when(bookmarkService.addChallengeToBookmarks(userId, challengeId))
+                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+
+        verify(bookmarkService, times(1)).addChallengeToBookmarks(userId, challengeId);
+    }
+
+    @Test
+    void addToBookmarks_WhenUnexpectedError_Returns500() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(bookmarkService.addChallengeToBookmarks(userId, challengeId))
+                .thenReturn(Mono.error(new Exception()));
+
+        webTestClient.post()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+
+        verify(bookmarkService, times(1)).addChallengeToBookmarks(userId, challengeId);
+    }
+
+    @Test
+    void deleteFromBookmarks_WhenDeleted_Returns200() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(bookmarkService.deleteChallengeFromBookmarks(userId, challengeId))
+                .thenReturn(Mono.just(true));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.OK)
+                .expectBody(Boolean.class).isEqualTo(true);
+
+        verify(bookmarkService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
+    }
+
+    @Test
+    void deleteFromBookmarks_WhenNotInBookmarks_Returns200() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(bookmarkService.deleteChallengeFromBookmarks(userId, challengeId))
+                .thenReturn(Mono.just(false));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(Boolean.class).isEqualTo(false);
+
+        verify(bookmarkService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
+    }
+
+    @Test
+    void deleteFromBookmarks_WhenUserNotExists_Returns404() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(bookmarkService.deleteChallengeFromBookmarks(userId, challengeId))
+                .thenReturn(Mono.error(new NotFoundException("User not found")));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
+                .expectBody(String.class).isEqualTo("User not found");
+
+        verify(bookmarkService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
+    }
+
+    @Test
+    void deleteFromBookmarks_WhenBadFormattedId_Returns404() {
+        String userId = "invalidUuid";
+        String challengeId = "invalidUUid";
+        when(bookmarkService.deleteChallengeFromBookmarks(userId, challengeId))
+                .thenReturn(Mono.error(new BadUUIDException("Error message")));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+                .expectBody(String.class).isEqualTo("The provided IDs are not valid.");
+
+        verify(bookmarkService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
+    }
+
+    @Test
+    void deleteFromBookmarks_WhenUnexpectedError_Returns500() {
+        String userId = UUID.randomUUID().toString();
+        String challengeId = UUID.randomUUID().toString();
+        when(bookmarkService.deleteChallengeFromBookmarks(userId, challengeId))
+                .thenReturn(Mono.error(new Exception()));
+
+        webTestClient.delete()
+                .uri("/itachallenge/api/v1/user/users/" + userId + "/bookmarks/" + challengeId)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                .expectBody(String.class).isEqualTo("Unexpected error happened.");
+
+        verify(bookmarkService, times(1)).deleteChallengeFromBookmarks(userId, challengeId);
+    }
 }


### PR DESCRIPTION
## ⚠️ Prerequisites
Merge PR #1147: `refactor(user): move bookmark logic from UserService to BookmarkService (#297)` first.

---

## Description

This PR completes the bookmark refactoring by moving the add/delete bookmark endpoints from `UserController` to `BookmarkController`. 

Previously, bookmark endpoints lived in `UserController`, mixing user and bookmark responsibilities. This PR establishes `BookmarkController` as the sole owner of all bookmark operations while maintaining backward compatibility with the micro-challenge integration.

Modified documents: 
- `UserController`
- `BookmarkController`
- `UserControllerTest`
- `BookmarkControllerTest`

**Related Issue:** #279

---

## Changes

### Modified Components
- **UserController**: Removed all bookmark-related endpoints (POST/DELETE)
- **BookmarkController**: Now owns all bookmark endpoints (GET/POST/DELETE)
- **Tests**: Updated `UserControllerTest` and `BookmarkControllerTest` to reflect the new endpoint ownership

### Endpoint Structure
The bookmark endpoints are now consolidated in `BookmarkController`:
✅ GET    /itachallenge/api/v1/users/{userId}/bookmarks                      (existing, used by frontend)
✅ POST   /itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}   (consumed by micro-challenge)
✅ DELETE /itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}   (consumed by micro-challenge)

**Note:** The path inconsistency (`/users/...` vs `/user/users/...`) exists to maintain backward compatibility. See **Known Technical Debt** section below.

---

## Scope

**In scope:**
- Move bookmark endpoints from `UserController` to `BookmarkController`
- Maintain compatibility with micro-challenge integration
- Update all related tests
- Ensure no breaking changes to public APIs

**Out of scope:**
- Unifying endpoint paths (requires frontend coordination - see Technical Debt)
- Changing micro-challenge configuration
- Frontend changes

---

## Definition of Done ✅

- [x] `UserController` no longer contains bookmark endpoints
- [x] `BookmarkController` owns all add/delete/get bookmark endpoints
- [x] Bookmark logic is in dedicated `BookmarkService`
- [x] `UserServiceImpl` no longer manages bookmarks
- [x] Micro-challenge continues to call user correctly (verified endpoint paths match config)
- [x] Public endpoints of micro-challenge remain unchanged
- [x] All tests are green ✅
- [x] Manual validation with Postman:
  - [x] Add bookmark works
  - [x] Delete bookmark works
  - [x] Get bookmarks works

---

## Known Technical Debt

The bookmark endpoints currently have **inconsistent paths**:
- `GET /users/{userId}/bookmarks` (existing, used by frontend)
- `POST/DELETE /user/users/{userId}/bookmarks/{challengeId}` (consumed by micro-challenge)

This inconsistency exists because:
1. The GET endpoint predates this refactor and is consumed by the frontend
2. The POST/DELETE endpoints must match the path configured in micro-challenge (`user.endpoints.bookmarks`)
3. Changing either would require coordinated updates across multiple services and frontend

**Recommendation:** Create a follow-up issue to unify all bookmark endpoints under a single consistent path after coordinating with:
- Frontend team (update GET endpoint consumers)
- Backend team (update micro-challenge config if needed)

**Tracked in:** [create issue after this PR is merged]

---

## Testing

<img width="1917" height="1029" alt="image" src="https://github.com/user-attachments/assets/c42fa46b-2261-40f2-bb99-5e8319a40b53" />

### Manual Testing 
**Postman Collection:** [link to updated collection]

1. **Get user bookmarks:**
GET /itachallenge/api/v1/users/{userId}/bookmarks
Expected: 200 OK with bookmark list

2. **Add bookmark (via micro-challenge path):**
POST /itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}
Expected: 201 Created (if new) or 200 OK (if already exists)

3. **Delete bookmark (via micro-challenge path):**
DELETE /itachallenge/api/v1/user/users/{userId}/bookmarks/{challengeId}
Expected: 200 OK with true/false response